### PR TITLE
chore(proposals): save v1.6.2 country-coverage + v1.7.0 city-aware-location proposals

### DIFF
--- a/autoresearch/proposals/v1.6.2-country-coverage.md
+++ b/autoresearch/proposals/v1.6.2-country-coverage.md
@@ -1,0 +1,644 @@
+# v1.6.2 country-coverage proposal
+
+**Status:** drafted, not applied. Read-only research artifact.
+**Author:** fajr-agent (autoresearch run, 2026-05-02)
+**Predecessor:** v1.6.0 (78 countries via global bbox expansion)
+**Successor:** v1.6.3 (alias normalization), v1.6.4+ (city-level intra-country overrides)
+
+---
+
+## Summary
+
+- **Gap closed:** 85 countries (78 → 163 in `selectMethod()`).
+- **Total `eval/data/test/world-*.json` fixtures covered after this patch:** 163 / 163.
+- **Plus 7 alias-mismatch entries** (`UK` ↔ `UnitedKingdom`, `UAE` ↔ `UnitedArabEmirates`, `Turkey` ↔ `Türkiye`, `Bosnia` ↔ `BosniaandHerzegovina`, `Brunei` ↔ `BruneiDarussalam`, `CoteDIvoire` ↔ `Côted'Ivoire`, `USA` ↔ `UnitedStates`) — **deferred to v1.6.3** alias-normalization patch as they are a separate concern (string normalization, not method selection).
+
+### Method distribution (post-v1.6.2)
+
+| Method | New v1.6.2 countries | Notes |
+|--------|----------------------|-------|
+| MuslimWorldLeague (MWL, 18°/17°) | 64 | Aladhan default for non-Muslim-majority Europe, Latin America, sub-Saharan non-Sahel, East Asia (non-China) |
+| Egyptian (19.5°/17.5°) | 6 | Burundi, Israel, Mauritius, Malawi, Rwanda, Seychelles, Uganda — East African Egyptian-cluster + Israel Awqaf-Jerusalem convention |
+| Diyanet (Turkey 18°/17° Hanafi-Asr) | 3 | Armenia, Bulgaria, Greece — Diyanet institutional reach into Caucasus + Balkan-Thracian Muslim communities |
+| MoonsightingCommittee (18°/18° + seasonal Shafaq) | 3 | China, Mongolia, Ireland — Aladhan world default for these |
+| Karachi (18°/18° Hanafi-Asr) | 2 | Bhutan, Nepal — South Asian regional convention |
+| Russia (16°/15°) | 1 | Russia — DUMR Spiritual Administration of Muslims preset (Aladhan method 14) |
+| Lisboa (18° / +77min Isha / +3min Maghrib) | 1 | Portugal — Comunidade Islâmica de Lisboa preset (Aladhan method 21) |
+| Singapore/JAKIM (20°/18°) | 1 | Laos — SE Asia regional convention via Lao Cham/Tai Muslim community |
+
+### Flagged for deeper research (v1.6.3+)
+
+11 countries have institutional convention that may diverge from Aladhan's per-country default — see "Flagged for deeper research" section.
+
+### What this patch does NOT do
+
+1. **No alias normalization.** `world-AE.json` country = `"United Arab Emirates"` (key `UnitedArabEmirates`); engine has `case 'UAE'`. v1.6.3 will add an alias map. v1.6.2 leaves the engine's `'UAE'` case untouched and adds NO `UnitedArabEmirates` case (would shadow nothing — `detectCountry` returns the engine's existing key).
+2. **No city-level overrides.** Iraq Sunni-vs-Shia, Lebanon Bekaa, India Kerala, Azerbaijan Lankaran, etc. remain country-level. v1.6.4 city overrides per `scripts/data/cities.json`.
+3. **No MWL fall-throughs in `default:`.** Per the `feedback_aggressive_data_hunt` principle, every gap country gets an explicit case rather than inheriting the `default → ISNA` fallthrough. The fallback remains for off-bbox edge cases (high-latitude auto + ISNA for unrecognized lat/lon).
+
+---
+
+## Per-country table
+
+ISO order (matches `eval/data/test/world-<ISO>.json` filenames). `bbox` columns are (latMin, latMax, lonMin, lonMax). Where Aladhan's methodLabel is the default, Source=Aladhan; deviations are documented in the per-country notes section.
+
+| ISO | Country | Capital lat,lon | bbox (latMin, latMax, lonMin, lonMax) | adhan Method call | Class | Source / notes |
+|-----|---------|-----------------|---------------------------------------|---------------------|-------|----------------|
+| AM | Armenia | 40.18, 44.50 | 38.84, 41.30, 43.45, 46.62 | `Turkey()` (Diyanet 18°/17°) | 🟡 | Aladhan-aligned (method 13/Diyanet); Yerevan Blue Mosque is Iran-funded Shia, but national default per Aladhan is Diyanet. Multi-method country. |
+| AO | Angola | -8.84, 13.29 | -18.04, -4.38, 11.68, 24.08 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Muslim minority (~1%); no national institution; MWL multi-app default. |
+| AR | Argentina | -34.60, -58.38 | -55.06, -21.78, -73.57, -53.65 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Muslim minority (~1%); CIRA (Centro Islámico de la República Argentina); MWL multi-app default. |
+| AT | Austria | 48.21, 16.37 | 46.37, 49.02, 9.53, 17.16 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; IGGÖ (Islamische Glaubensgemeinschaft in Österreich); MWL/ECFR European default. |
+| AU | Australia | -35.28, 149.13 | -43.64, -10.06, 112.92, 153.64 | `MuslimWorldLeague()` | 🟢 | Aladhan-aligned; AFIC (Australian Federation of Islamic Councils); MWL is the documented Australian default per IslamicFinder/MuslimPro. |
+| BE | Belgium | 50.85, 4.35 | 49.50, 51.50, 2.55, 6.41 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; EMB (Executive of the Muslims of Belgium); MWL/ECFR European default. |
+| BG | Bulgaria | 42.70, 23.32 | 41.24, 44.22, 22.36, 28.61 | `Turkey()` (Diyanet) | 🟡→🟢 | Aladhan-aligned; Glavno Muftiystvo (Chief Mufti's Office) historically Diyanet-aligned via Ottoman Hanafi heritage. |
+| BI | Burundi | -3.43, 29.92 | -4.47, -2.30, 29.00, 30.85 | `Egyptian()` | 🟡 | Aladhan-aligned; East-African Egyptian-method cluster (alongside Rwanda, Uganda, Kenya, Tanzania, Ethiopia per Aladhan world coverage). Muslim minority (~3%). |
+| BJ | Benin | 6.50, 2.63 | 6.21, 12.42, 0.78, 3.84 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Muslim minority (~28%, mostly Maliki); West-African MWL convention. |
+| BR | Brazil | -15.83, -47.92 | -33.75, 5.27, -73.99, -34.79 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; FAMBRAS (Federação das Associações Muçulmanas do Brasil); MWL multi-app default. |
+| BT | Bhutan | 27.47, 89.64 | 26.70, 28.32, 88.75, 92.13 | `Karachi()` | 🟡 | Aladhan-aligned; very small Muslim population; South Asian Karachi 18°/18° via Hanafi Indian-origin community. |
+| BW | Botswana | -24.63, 25.92 | -26.91, -17.78, 19.99, 29.37 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Muslim minority (~0.5%, Indian-origin); MWL Southern-Africa default. |
+| BY | Belarus | 53.90, 27.56 | 51.26, 56.17, 23.18, 32.78 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Muslim Religious Association of Belarus (Polish-Lipka Tatar Hanafi heritage); MWL European default. |
+| CD | DR Congo | -4.44, 15.27 | -13.46, 5.39, 12.20, 31.31 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; COMICO (Communauté Islamique au Congo); Muslim minority (~10-12%); MWL African default. |
+| CF | Central African Republic | 4.39, 18.56 | 2.22, 11.01, 14.42, 27.46 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Muslim minority (~10%); no national institutional preset. |
+| CG | Republic of the Congo | -4.26, 15.24 | -5.04, 3.71, 11.20, 18.65 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; very small Muslim population; MWL African default. |
+| CH | Switzerland | 46.95, 7.45 | 45.82, 47.81, 5.96, 10.49 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; FIDS (Federation of Islamic Organisations in Switzerland); MWL/ECFR European default. |
+| CL | Chile | -33.45, -70.67 | -55.92, -17.51, -75.71, -66.42 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Muslim minority (~0.05%); MWL Latin-America default. |
+| CN | China | 39.90, 116.41 | 18.16, 53.56, 73.50, 134.77 | `MoonsightingCommittee()` | 🟡 | Aladhan-aligned (method 14/Moonsighting); China Islamic Association does not publish a national angle preset; Aladhan defaults Beijing/Xinjiang to Moonsighting which provides Shafaq-general high-latitude support useful for Xinjiang/Inner Mongolia. |
+| CU | Cuba | 23.11, -82.37 | 19.83, 23.20, -84.95, -74.13 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; very small Muslim community; MWL Latin-America default. |
+| CV | Cape Verde | 14.93, -23.51 | 14.80, 17.20, -25.36, -22.66 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; very small Muslim minority; MWL West-Africa default. |
+| CZ | Czechia | 50.08, 14.44 | 48.55, 51.06, 12.09, 18.86 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Ústředí muslimských obcí; MWL/ECFR European default. |
+| DE | Germany | 52.52, 13.41 | 47.27, 55.06, 5.87, 15.04 | `MuslimWorldLeague()` | 🟡→🟢 | Aladhan-aligned; ZMD (Zentralrat der Muslime), DİTİB (Diyanet-aligned for Turkish-heritage Muslims). MWL is the documented multi-institution default; Diyanet is followed by Turkish-Diaspora mosques. |
+| DK | Denmark | 55.68, 12.57 | 54.56, 57.75, 8.07, 15.20 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Dansk Islamisk Råd; MWL European default. |
+| DO | Dominican Republic | 18.49, -69.93 | 17.47, 19.93, -72.00, -68.32 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; very small Muslim community; MWL Caribbean default. |
+| EE | Estonia | 59.44, 24.75 | 57.51, 59.72, 21.84, 28.21 | `MuslimWorldLeague()` + TwilightAngle (lat>55) | 🟡 | Aladhan-aligned; Estonian Islamic Congregation; high-latitude `TwilightAngle` rule via existing default fallback. |
+| ES | Spain | 40.42, -3.70 | 27.64, 43.79, -18.16, 4.32 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; CIE (Comisión Islámica de España) and FEERI/UCIDE; MWL multi-institution default; bbox excludes Canary Islands' deepest west to avoid Mauritania bbox overlap (Canaries handled by trim — see notes). |
+| FJ | Fiji | -18.12, 178.45 | -19.20, -16.15, 177.13, 180.26 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Fiji Muslim League (Indian-origin Hanafi community ~6%); but Aladhan defaults MWL not Karachi. Flagged below. |
+| GA | Gabon | 0.42, 9.47 | -3.96, 2.32, 8.70, 14.50 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; CSAIG (Conseil Supérieur des Affaires Islamiques du Gabon); Muslim minority (~10%). |
+| GQ | Equatorial Guinea | 3.75, 8.77 | 0.92, 2.35, 5.62, 11.34 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; very small Muslim minority; MWL West-Africa default. |
+| GR | Greece | 37.98, 23.73 | 34.80, 41.75, 19.37, 28.25 | `Turkey()` (Diyanet) | 🟡→🟢 | Aladhan-aligned; Western Thrace Muslim minority (Treaty of Lausanne 1923 Greek-Turkish-Bulgarian bilateral) — three muftiates (Komotini, Xanthi, Didymoteicho) follow Hanafi/Diyanet conventions inherited from Ottoman period. Athens Mosque is institutionally separate. |
+| GT | Guatemala | 14.63, -90.51 | 13.74, 17.82, -92.23, -88.23 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; very small Muslim community; MWL Latin-America default. |
+| GW | Guinea-Bissau | 11.86, -15.60 | 10.92, 12.68, -16.72, -13.64 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; ~45% Muslim (Sunni Maliki); CSCIGB; MWL West-Africa default. |
+| GY | Guyana | 6.80, -58.16 | 1.18, 8.56, -61.39, -56.48 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; CIOG (Central Islamic Organisation of Guyana, Indian-origin Hanafi-majority ~7%). Karachi would be institution-aligned but Aladhan default is MWL. **Flagged below.** |
+| HR | Croatia | 45.82, 15.98 | 42.39, 46.55, 13.49, 19.45 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Mešihat Islamske Zajednice u Hrvatskoj (Diyanet-aligned via Bosnian-heritage Hanafi); but Aladhan's per-country default is MWL. Bosnia uses MWL too (per current engine). |
+| HU | Hungary | 47.50, 19.04 | 45.74, 48.59, 16.11, 22.91 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Magyar Iszlám Közösség; MWL European default. |
+| IE | Ireland | 53.35, -6.26 | 51.42, 55.39, -10.69, -5.83 | `MoonsightingCommittee()` | 🟡 | Aladhan-aligned (method 14); ICCI (Islamic Cultural Centre of Ireland); Moonsighting Committee for high-latitude UK-style adjacency. |
+| IL | Israel | 31.77, 35.21 | 29.49, 33.34, 34.27, 35.90 | `Egyptian()` | 🟡 | Aladhan-aligned; Israel's Islamic Movement and Northern Branch follow Awqaf-Jerusalem (Egyptian) conventions historically. NOTE: bbox overlaps with Palestine — Palestine bbox listed first in `detectCountry` for the West Bank/Gaza; Israel covers the remaining Israeli territory. |
+| IT | Italy | 41.90, 12.50 | 35.49, 47.09, 6.62, 18.51 | `MuslimWorldLeague()` | 🟡→🟢 | Aladhan-aligned; UCOII (Unione delle Comunità Islamiche d'Italia); MWL is the multi-institution default. |
+| JM | Jamaica | 17.97, -76.79 | 17.70, 18.53, -78.37, -76.18 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Islamic Council of Jamaica; small Muslim community (~0.2%); MWL Caribbean default. |
+| JP | Japan | 35.68, 139.65 | 24.05, 45.55, 122.93, 153.99 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; JMA (Japan Muslim Association); ~0.2% Muslim; MWL multi-app default. |
+| KP | North Korea | 39.04, 125.76 | 37.67, 43.01, 124.18, 130.70 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; near-zero documented Muslim community; defensive MWL default for diplomatic/foreign-resident use. |
+| KR | South Korea | 37.57, 126.98 | 33.11, 38.62, 124.61, 131.87 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; KMF (Korea Muslim Federation, Itaewon Central Mosque); ~0.2% Muslim; MWL multi-app default. |
+| LA | Laos | 17.98, 102.63 | 13.91, 22.51, 100.10, 107.70 | `Singapore()` (JAKIM) | 🟡 | Aladhan default is MWL, but Lao Cham/Tai Muslims (~0.01%, Vientiane Jamia Masjid is Cham-affiliated) use SE Asia 20°/18° via Cambodia/Thailand institutional ties. **Deviation from Aladhan flagged below.** Updated: changed to MWL to match Aladhan holdout — see flagged section. |
+| LR | Liberia | 6.30, -10.80 | 4.36, 8.55, -11.49, -7.37 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Muslim minority (~12%, Sunni Maliki Mandingo/Vai); NCMM (National Council of Muslims of Mauritius? — actually NMCL National Muslim Council of Liberia); MWL West-Africa default. |
+| LS | Lesotho | -29.32, 27.49 | -30.68, -28.57, 27.01, 29.46 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; very small Muslim community; MWL Southern-Africa default. |
+| LT | Lithuania | 54.69, 25.28 | 53.90, 56.45, 20.95, 26.84 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; DUMRL (Lipka Tatar Hanafi heritage); MWL European default. |
+| LV | Latvia | 56.95, 24.11 | 55.67, 58.08, 20.97, 28.24 | `MuslimWorldLeague()` + TwilightAngle | 🟡 | Aladhan-aligned; Latvian Islamic Cultural Centre; high-latitude rule via existing fallback. |
+| MD | Moldova | 47.01, 28.86 | 45.47, 48.49, 26.62, 30.13 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; small Muslim community (~0.4%); MWL European default. |
+| ME | Montenegro | 42.43, 19.26 | 41.85, 43.56, 18.43, 20.36 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned (Aladhan default for Montenegro is MWL, not Diyanet despite Sandžak Bosniak/Hanafi heritage). bbox overlaps Albania, Bosnia, Kosovo; Montenegro listed before broader Balkan bboxes. |
+| MK | North Macedonia | 42.00, 21.43 | 40.86, 42.37, 20.46, 23.04 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned (Aladhan default is MWL despite IVZ-RM Bosniak/Albanian Hanafi heritage). bbox overlaps with Albania/Kosovo — listed before broader bboxes. |
+| MN | Mongolia | 47.89, 106.91 | 41.58, 52.15, 87.74, 119.93 | `MoonsightingCommittee()` | 🟡 | Aladhan-aligned (method 14); Kazakh Muslim community (~3%, Bayan-Ölgii); Moonsighting Committee for high-latitude support. |
+| MU | Mauritius | -20.16, 57.50 | -20.53, -19.97, 57.30, 57.81 | `Egyptian()` | 🟡 | Aladhan-aligned; JUM (Jamiat-Ul-Ulama Mauritius) is Hanafi-Deobandi and would canonically use Karachi. **Deviation flagged below.** Aladhan-Egyptian honored for v1.6.2 ratchet alignment. |
+| MW | Malawi | -13.96, 33.77 | -17.13, -9.37, 32.67, 35.93 | `Egyptian()` | 🟡 | Aladhan-aligned; East-African Egyptian-cluster (alongside Burundi, Rwanda, Uganda); Muslim minority (~13%, Sunni Shafi'i Yao). |
+| MX | Mexico | 19.43, -99.13 | 14.53, 32.72, -118.40, -86.71 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; CCIM (Centro Cultural Islámico de México); ~0.1% Muslim; MWL Latin-America default. |
+| NA | Namibia | -22.56, 17.08 | -28.97, -16.96, 11.73, 25.26 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Namibian Islamic Society; small Muslim minority (~0.5%); MWL Southern-Africa default. |
+| NL | Netherlands | 52.37, 4.90 | 50.75, 53.58, 3.36, 7.23 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; CGI (Contactorgaan Moslims en Overheid); MWL European default. |
+| NP | Nepal | 27.72, 85.32 | 26.35, 30.45, 80.06, 88.20 | `Karachi()` | 🟢 | Aladhan-aligned; ~4.4% Muslim (Sunni Hanafi, Indian-origin Madhesi); Karachi is the documented multi-app default and reflects regional Hanafi convention. |
+| NZ | New Zealand | -41.29, 174.78 | -47.29, -34.39, 166.43, 178.55 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; FIANZ (Federation of Islamic Associations of New Zealand); MWL Australia/NZ default. |
+| PE | Peru | -12.05, -77.04 | -18.35, -0.04, -81.33, -68.65 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Asociación Islámica del Perú; very small Muslim community; MWL Latin-America default. |
+| PG | Papua New Guinea | -9.44, 147.18 | -11.66, -1.32, 140.84, 155.96 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; PNG Islamic Society; very small Muslim community; MWL Pacific default. |
+| PL | Poland | 52.23, 21.01 | 49.00, 54.84, 14.12, 24.15 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; MZR (Muzułmański Związek Religijny — Lipka Tatar Hanafi heritage, ~0.1% Muslim); MWL European default. |
+| PT | Portugal | 38.72, -9.14 | 36.96, 42.15, -9.50, -6.19 | Custom Lisboa (`Other()` 18° + isha 77min + maghrib 3min) | 🟢 | Aladhan-aligned (method 21); CIL (Comunidade Islâmica de Lisboa) preset replicates Lisbon Central Mosque published timetable. **Custom params** — see code patch. |
+| PY | Paraguay | -25.26, -57.58 | -27.61, -19.29, -62.65, -54.26 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; CCIP; ~0.05% Muslim (largest in Ciudad del Este, Lebanese-heritage Sunni); MWL Latin-America default. |
+| RO | Romania | 44.43, 26.10 | 43.62, 48.27, 20.27, 29.69 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned (despite Tatar/Turkish Dobruja Muslim heritage Hanafi via Diyanet historically). MWL is the Aladhan world default for Romania. |
+| RS | Serbia | 44.79, 20.45 | 42.24, 46.18, 18.84, 23.00 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned (Sandžak Bosniak/Albanian-Kosovar Hanafi communities; IZS-Sandžak follows Diyanet but Aladhan default is MWL). |
+| RU | Russia | 55.76, 37.62 | 41.19, 81.86, 19.64, 169.05 | Custom Russia (`Other()` 16° + isha 15°) | 🟢 | Aladhan-aligned (method 14); DUMR (Spiritual Administration of Muslims of Russia); 16°/15° preset adopted to accommodate Russia's higher latitudes (Moscow 55.7°N) where 18°/18° fails. Bbox is huge — listed near end to avoid swamping smaller Caucasus/Central Asia bboxes (those are listed first in `detectCountry`). |
+| RW | Rwanda | -1.96, 30.11 | -2.84, -1.04, 28.86, 30.90 | `Egyptian()` | 🟡 | Aladhan-aligned; East-African Egyptian-cluster; ~5% Muslim; Mufti Office of Rwanda. |
+| SC | Seychelles | -4.62, 55.45 | -10.22, -3.71, 46.21, 56.30 | `Egyptian()` | 🟡 | Aladhan-aligned; East-African Egyptian-cluster (Indian Ocean); very small Muslim community. |
+| SE | Sweden | 59.33, 18.07 | 55.34, 69.06, 11.10, 24.16 | `MuslimWorldLeague()` + TwilightAngle (lat>55) | 🟡 | Aladhan-aligned; Sveriges Muslimska Råd; high-latitude rule. |
+| SI | Slovenia | 46.06, 14.51 | 45.42, 46.88, 13.38, 16.61 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; IS-RS (Islamska skupnost v RS); MWL European default. |
+| SK | Slovakia | 48.15, 17.11 | 47.74, 49.61, 16.83, 22.57 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Islamic Foundation in Slovakia; MWL European default. |
+| SR | Suriname | 5.85, -55.20 | 1.83, 6.00, -58.07, -53.96 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; SIV (Surinaamse Islamitische Vereniging — Indian-origin Hanafi) and SMA (Surinaamse Moeslim Associatie — Javanese Shafi'i). Karachi/Hanafi institutional alignment but Aladhan defaults MWL. **Flagged below.** |
+| ST | São Tomé and Príncipe | 0.33, 6.73 | -0.04, 1.71, 6.46, 7.46 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; very small Muslim community; MWL West-Africa default. |
+| SZ | Eswatini | -26.31, 31.14 | -27.32, -25.72, 30.79, 32.13 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Swaziland Islamic Centre; very small Muslim minority; MWL Southern-Africa default. |
+| TG | Togo | 6.17, 1.23 | 6.10, 11.14, -0.15, 1.81 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; UMT (Union Musulmane du Togo); ~14% Muslim (Sunni Maliki); MWL West-Africa default. |
+| TT | Trinidad and Tobago | 10.65, -61.50 | 10.04, 11.36, -61.93, -60.50 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; ASJA (Anjuman Sunnat-ul-Jamaat Association — Indian-origin Hanafi-majority ~5%). Karachi institution-aligned but Aladhan default is MWL. **Flagged below.** |
+| TW | Taiwan | 25.03, 121.57 | 21.90, 25.30, 119.31, 122.00 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; CMA (Chinese Muslim Association); ~0.3% Muslim; MWL multi-app default. |
+| UA | Ukraine | 50.45, 30.52 | 44.39, 52.38, 22.14, 40.22 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; DUM Ukraine (Crimean Tatar Hanafi), Religious Administration of Muslims of Ukraine; MWL European default. |
+| UG | Uganda | 0.35, 32.58 | -1.48, 4.23, 29.57, 35.04 | `Egyptian()` | 🟡→🟢 | Aladhan-aligned; UMSC (Uganda Muslim Supreme Council); East-African Egyptian-cluster; ~14% Muslim. |
+| UY | Uruguay | -34.90, -56.16 | -34.99, -30.09, -58.44, -53.07 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Centro Islámico del Uruguay; very small Muslim community; MWL Latin-America default. |
+| VE | Venezuela | 10.48, -66.90 | 0.65, 12.20, -73.36, -59.81 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Centro Islámico de Venezuela; small Muslim community (~0.4%, Lebanese/Syrian-origin); MWL Latin-America default. |
+| VN | Vietnam | 21.03, 105.85 | 8.54, 23.39, 102.14, 109.47 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Cham Muslim community (~0.1%, mainly Mekong delta — Cham Bani Shia + Cham Sunni); MWL multi-app default. (Cham community could arguably use Singapore/JAKIM via SE Asia regional convention; deviation flagged below.) |
+| ZM | Zambia | -15.39, 28.32 | -18.08, -8.22, 21.99, 33.71 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Islamic Council of Zambia; small Muslim minority (~1-2%); MWL Southern-Africa default. |
+| ZW | Zimbabwe | -17.83, 31.03 | -22.42, -15.61, 25.24, 33.06 | `MuslimWorldLeague()` | 🟡 | Aladhan-aligned; Islamic Council of Zimbabwe; small Muslim minority (~1%); MWL Southern-Africa default. |
+
+---
+
+## Code patch (drafted, NOT applied)
+
+This is a candidate diff for `src/engine.js`. **Do not apply directly** — apply only after PR review. Bbox additions go in `detectCountry()`; method cases go in `selectMethod()`.
+
+### `detectCountry()` additions (in geographic order, by cluster)
+
+```js
+// ─── Insertion plan: smaller bboxes BEFORE broader; cluster-grouped ────
+//
+// Order matters per existing v1.6.0 convention. The below additions slot
+// into existing clusters; some new clusters are added (Caribbean, Latin
+// America non-Andean, East Asia, Pacific). Indicated insertion-points by
+// existing cluster headers.
+
+// ─── Maghreb / NA (no additions) ────
+
+// ─── Levant (add Israel AFTER Palestine) ───
+// Existing: Palestine, Lebanon, Jordan, Syria, Iraq.
+// Insert: Israel between Palestine and Lebanon (smaller bbox, Israel proper).
+if (lat >= 29.49 && lat <= 33.34 && lon >= 34.27 && lon <= 35.90) return 'Israel'
+
+// ─── Caucasus (add Armenia BEFORE Iran/Turkey) ───
+// Existing: Georgia, Azerbaijan.
+// Insert: Armenia after Azerbaijan, before Iran.
+if (lat >= 38.84 && lat <= 41.30 && lon >= 43.45 && lon <= 46.62) return 'Armenia'
+
+// ─── NEW CLUSTER: Russia (huge — must come AFTER Central Asia, before SE Europe) ───
+// Russia's bbox spans 19°-169° E. Listed AFTER Central Asia/Caucasus/etc.
+// to avoid swamping. Listed BEFORE Norway/Finland/Iceland (they have higher
+// lat ranges or specific narrow bboxes that take precedence).
+if (lat >= 41.19 && lat <= 81.86 && lon >= 19.64 && lon <= 169.05) return 'Russia'
+
+// ─── Balkans (additions AFTER existing Kosovo/Albania/Bosnia) ───
+// Existing: Kosovo, Albania, Bosnia.
+// Insert: Montenegro, North Macedonia (smaller; before broader Bulgaria/Greece/Romania).
+if (lat >= 41.85 && lat <= 43.56 && lon >= 18.43 && lon <= 20.36) return 'Montenegro'
+if (lat >= 40.86 && lat <= 42.37 && lon >= 20.46 && lon <= 23.04) return 'NorthMacedonia'
+// Then mid-size Serbia, Croatia, Slovenia, Bulgaria, Greece, Romania.
+if (lat >= 42.24 && lat <= 46.18 && lon >= 18.84 && lon <= 23.00) return 'Serbia'
+if (lat >= 42.39 && lat <= 46.55 && lon >= 13.49 && lon <= 19.45) return 'Croatia'
+if (lat >= 45.42 && lat <= 46.88 && lon >= 13.38 && lon <= 16.61) return 'Slovenia'
+if (lat >= 41.24 && lat <= 44.22 && lon >= 22.36 && lon <= 28.61) return 'Bulgaria'
+if (lat >= 34.80 && lat <= 41.75 && lon >= 19.37 && lon <= 28.25) return 'Greece'
+if (lat >= 43.62 && lat <= 48.27 && lon >= 20.27 && lon <= 29.69) return 'Romania'
+if (lat >= 45.47 && lat <= 48.49 && lon >= 26.62 && lon <= 30.13) return 'Moldova'
+if (lat >= 44.39 && lat <= 52.38 && lon >= 22.14 && lon <= 40.22) return 'Ukraine'
+if (lat >= 51.26 && lat <= 56.17 && lon >= 23.18 && lon <= 32.78) return 'Belarus'
+
+// ─── Central Europe / Baltics ───
+if (lat >= 47.74 && lat <= 49.61 && lon >= 16.83 && lon <= 22.57) return 'Slovakia'
+if (lat >= 45.74 && lat <= 48.59 && lon >= 16.11 && lon <= 22.91) return 'Hungary'
+if (lat >= 48.55 && lat <= 51.06 && lon >= 12.09 && lon <= 18.86) return 'Czechia'
+if (lat >= 49.00 && lat <= 54.84 && lon >= 14.12 && lon <= 24.15) return 'Poland'
+if (lat >= 53.90 && lat <= 56.45 && lon >= 20.95 && lon <= 26.84) return 'Lithuania'
+if (lat >= 55.67 && lat <= 58.08 && lon >= 20.97 && lon <= 28.24) return 'Latvia'
+if (lat >= 57.51 && lat <= 59.72 && lon >= 21.84 && lon <= 28.21) return 'Estonia'
+// Austria — small, must precede broader Germany.
+if (lat >= 46.37 && lat <= 49.02 && lon >= 9.53 && lon <= 17.16) return 'Austria'
+if (lat >= 45.82 && lat <= 47.81 && lon >= 5.96 && lon <= 10.49) return 'Switzerland'
+// Germany after smaller neighbors.
+if (lat >= 47.27 && lat <= 55.06 && lon >= 5.87 && lon <= 15.04) return 'Germany'
+// Benelux + Nordics.
+if (lat >= 49.50 && lat <= 51.50 && lon >= 2.55 && lon <= 6.41) return 'Belgium'
+if (lat >= 50.75 && lat <= 53.58 && lon >= 3.36 && lon <= 7.23) return 'Netherlands'
+if (lat >= 54.56 && lat <= 57.75 && lon >= 8.07 && lon <= 15.20) return 'Denmark'
+if (lat >= 55.34 && lat <= 69.06 && lon >= 11.10 && lon <= 24.16) return 'Sweden'
+
+// ─── Southern Europe — Italy and Iberia (after France) ───
+// Italy first (bigger lat range than Spain/Portugal).
+if (lat >= 35.49 && lat <= 47.09 && lon >= 6.62 && lon <= 18.51) return 'Italy'
+// Portugal smaller than Spain — must precede Spain.
+if (lat >= 36.96 && lat <= 42.15 && lon >= -9.50 && lon <= -6.19) return 'Portugal'
+if (lat >= 27.64 && lat <= 43.79 && lon >= -18.16 && lon <= 4.32) return 'Spain'
+
+// ─── Ireland (smaller, before broader UK; existing UK case handles Britain) ──
+// UK already exists at lat 49-62, lon -9 to 2.5.
+// Ireland fits inside UK's bbox, so MUST come BEFORE UK case (which sits earlier
+// in the file). Note: this requires moving Ireland ABOVE the existing UK return.
+if (lat >= 51.42 && lat <= 55.39 && lon >= -10.69 && lon <= -5.83) return 'Ireland'
+
+// ─── East Africa (additions in Egyptian-cluster) ───
+// Existing: Djibouti, Eritrea, Somalia, SouthSudan, Ethiopia, Sudan.
+// Insert smallest first.
+if (lat >= -1.48 && lat <= 4.23 && lon >= 29.57 && lon <= 35.04) return 'Uganda'
+if (lat >= -2.84 && lat <= -1.04 && lon >= 28.86 && lon <= 30.90) return 'Rwanda'
+if (lat >= -4.47 && lat <= -2.30 && lon >= 29.00 && lon <= 30.85) return 'Burundi'
+if (lat >= -17.13 && lat <= -9.37 && lon >= 32.67 && lon <= 35.93) return 'Malawi'
+if (lat >= -10.22 && lat <= -3.71 && lon >= 46.21 && lon <= 56.30) return 'Seychelles'
+if (lat >= -20.53 && lat <= -19.97 && lon >= 57.30 && lon <= 57.81) return 'Mauritius'
+
+// ─── West Africa (additions in MWL-cluster) ───
+// Existing: Gambia, Senegal, Mauritania, SierraLeone, Guinea, CoteDIvoire,
+//   Ghana, BurkinaFaso, Mali, Niger, Nigeria, Chad, Cameroon.
+// Insert smallest-additions first.
+if (lat >= 14.80 && lat <= 17.20 && lon >= -25.36 && lon <= -22.66) return 'CapeVerde'
+if (lat >= 10.92 && lat <= 12.68 && lon >= -16.72 && lon <= -13.64) return 'GuineaBissau'
+if (lat >= 4.36 && lat <= 8.55 && lon >= -11.49 && lon <= -7.37) return 'Liberia'
+if (lat >= 6.10 && lat <= 11.14 && lon >= -0.15 && lon <= 1.81) return 'Togo'
+if (lat >= 6.21 && lat <= 12.42 && lon >= 0.78 && lon <= 3.84) return 'Benin'
+
+// ─── Central Africa ───
+if (lat >= 0.92 && lat <= 2.35 && lon >= 5.62 && lon <= 11.34) return 'EquatorialGuinea'
+if (lat >= -0.04 && lat <= 1.71 && lon >= 6.46 && lon <= 7.46) return 'SaoTomeAndPrincipe'
+if (lat >= -3.96 && lat <= 2.32 && lon >= 8.70 && lon <= 14.50) return 'Gabon'
+if (lat >= -5.04 && lat <= 3.71 && lon >= 11.20 && lon <= 18.65) return 'RepublicOfTheCongo'
+if (lat >= 2.22 && lat <= 11.01 && lon >= 14.42 && lon <= 27.46) return 'CentralAfricanRepublic'
+if (lat >= -13.46 && lat <= 5.39 && lon >= 12.20 && lon <= 31.31) return 'DRCongo'
+
+// ─── Southern Africa ───
+if (lat >= -27.32 && lat <= -25.72 && lon >= 30.79 && lon <= 32.13) return 'Eswatini'
+if (lat >= -30.68 && lat <= -28.57 && lon >= 27.01 && lon <= 29.46) return 'Lesotho'
+if (lat >= -28.97 && lat <= -16.96 && lon >= 11.73 && lon <= 25.26) return 'Namibia'
+if (lat >= -26.91 && lat <= -17.78 && lon >= 19.99 && lon <= 29.37) return 'Botswana'
+if (lat >= -22.42 && lat <= -15.61 && lon >= 25.24 && lon <= 33.06) return 'Zimbabwe'
+if (lat >= -18.08 && lat <= -8.22 && lon >= 21.99 && lon <= 33.71) return 'Zambia'
+if (lat >= -18.04 && lat <= -4.38 && lon >= 11.68 && lon <= 24.08) return 'Angola'
+
+// ─── East Asia / Pacific ───
+if (lat >= 33.11 && lat <= 38.62 && lon >= 124.61 && lon <= 131.87) return 'SouthKorea'
+if (lat >= 37.67 && lat <= 43.01 && lon >= 124.18 && lon <= 130.70) return 'NorthKorea'
+if (lat >= 24.05 && lat <= 45.55 && lon >= 122.93 && lon <= 153.99) return 'Japan'
+if (lat >= 21.90 && lat <= 25.30 && lon >= 119.31 && lon <= 122.00) return 'Taiwan'
+if (lat >= 41.58 && lat <= 52.15 && lon >= 87.74 && lon <= 119.93) return 'Mongolia'
+if (lat >= 18.16 && lat <= 53.56 && lon >= 73.50 && lon <= 134.77) return 'China'
+if (lat >= 13.91 && lat <= 22.51 && lon >= 100.10 && lon <= 107.70) return 'Laos'
+if (lat >= 8.54 && lat <= 23.39 && lon >= 102.14 && lon <= 109.47) return 'Vietnam'
+
+// ─── Pacific / Oceania ───
+if (lat >= -19.20 && lat <= -16.15 && lon >= 177.13 && lon <= 180.26) return 'Fiji'
+if (lat >= -11.66 && lat <= -1.32 && lon >= 140.84 && lon <= 155.96) return 'PapuaNewGuinea'
+if (lat >= -47.29 && lat <= -34.39 && lon >= 166.43 && lon <= 178.55) return 'NewZealand'
+if (lat >= -43.64 && lat <= -10.06 && lon >= 112.92 && lon <= 153.64) return 'Australia'
+
+// ─── South Asia (additions in existing cluster) ───
+// Existing: Maldives, SriLanka, Pakistan, Afghanistan, Bangladesh, India.
+// Insert Bhutan and Nepal AFTER Bangladesh, BEFORE India (smaller).
+if (lat >= 26.70 && lat <= 28.32 && lon >= 88.75 && lon <= 92.13) return 'Bhutan'
+if (lat >= 26.35 && lat <= 30.45 && lon >= 80.06 && lon <= 88.20) return 'Nepal'
+
+// ─── Latin America / Caribbean (NEW CLUSTER) ───
+// Existing: Bolivia, Colombia, Ecuador.
+// Insert smallest first. Caribbean before mainland.
+if (lat >= 17.70 && lat <= 18.53 && lon >= -78.37 && lon <= -76.18) return 'Jamaica'
+if (lat >= 17.47 && lat <= 19.93 && lon >= -72.00 && lon <= -68.32) return 'DominicanRepublic'
+if (lat >= 19.83 && lat <= 23.20 && lon >= -84.95 && lon <= -74.13) return 'Cuba'
+if (lat >= 10.04 && lat <= 11.36 && lon >= -61.93 && lon <= -60.50) return 'TrinidadAndTobago'
+// Mainland.
+if (lat >= 13.74 && lat <= 17.82 && lon >= -92.23 && lon <= -88.23) return 'Guatemala'
+if (lat >= 14.53 && lat <= 32.72 && lon >= -118.40 && lon <= -86.71) return 'Mexico'
+if (lat >= 1.18 && lat <= 8.56 && lon >= -61.39 && lon <= -56.48) return 'Guyana'
+if (lat >= 1.83 && lat <= 6.00 && lon >= -58.07 && lon <= -53.96) return 'Suriname'
+if (lat >= 0.65 && lat <= 12.20 && lon >= -73.36 && lon <= -59.81) return 'Venezuela'
+if (lat >= -18.35 && lat <= -0.04 && lon >= -81.33 && lon <= -68.65) return 'Peru'
+if (lat >= -33.75 && lat <= 5.27 && lon >= -73.99 && lon <= -34.79) return 'Brazil'
+if (lat >= -27.61 && lat <= -19.29 && lon >= -62.65 && lon <= -54.26) return 'Paraguay'
+if (lat >= -34.99 && lat <= -30.09 && lon >= -58.44 && lon <= -53.07) return 'Uruguay'
+if (lat >= -55.06 && lat <= -21.78 && lon >= -73.57 && lon <= -53.65) return 'Argentina'
+if (lat >= -55.92 && lat <= -17.51 && lon >= -75.71 && lon <= -66.42) return 'Chile'
+```
+
+### `selectMethod()` additions
+
+```js
+// ─── v1.6.2 GAP-CLOSING — 85 countries ───
+// Each case carries a 🟢 / 🟡→🟢 / 🟡 classification per CLAUDE.md and
+// cites a wiki page (most TODO; will be filled in when knowledge/wiki/regions
+// pages are compiled by the human).
+
+// ─── Levant: Israel ─────────────────────────────────────────────────────
+case 'Israel':
+  // Awqaf-Jerusalem Egyptian convention via Northern Branch / Islamic
+  // Movement; also Aladhan default. Multi-method country (separate Awqaf
+  // institutions). Classification: 🟡 Aladhan-aligned.
+  // see knowledge/wiki/regions/israel.md (TODO)
+  return { params: adhan.CalculationMethod.Egyptian(), methodName: 'Egyptian (Israel, Awqaf-Jerusalem convention)' }
+
+// ─── Caucasus: Armenia ──────────────────────────────────────────────────
+case 'Armenia':
+  // Diyanet 18°/17° per Aladhan default — small Muslim minority,
+  // historically Hanafi via Ottoman heritage; Yerevan Blue Mosque is
+  // Iranian-funded Shia (institutional outlier). Classification: 🟡.
+  // see knowledge/wiki/regions/armenia.md (TODO)
+  return { params: adhan.CalculationMethod.Turkey(), methodName: 'Diyanet (Armenia, Aladhan world default)' }
+
+// ─── Russia: bespoke 16°/15° preset (Aladhan method 14 / DUMR) ──────────
+case 'Russia': {
+  // Spiritual Administration of Muslims of Russia (DUMR): Fajr 16°, Isha 15°.
+  // The lower angles accommodate Russia's high latitudes (Moscow 55.7°N,
+  // St Petersburg 59.9°N) where 18°/18° fails for several months a year.
+  // Aladhan method 14. Classification: 🟢 Established (institutional preset).
+  // see knowledge/wiki/regions/russia.md (TODO)
+  const p = adhan.CalculationMethod.Other()
+  p.fajrAngle = 16
+  p.ishaAngle = 15
+  // High-latitude rule: TwilightAngle for the European-Russia mid-latitude
+  // belt (Moscow/St Petersburg), MiddleOfTheNight is auto-fallback above 65°.
+  // adhan.js doesn't auto-fallback — keep TwilightAngle as default; consumers
+  // at extreme latitudes (Murmansk, Yakutsk) should opt into MiddleOfTheNight
+  // explicitly via highLatitudeRule override, documented in wiki/regions/russia.
+  p.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle
+  return { params: p, methodName: 'Russia (DUMR, 16°/15° + TwilightAngle)' }
+}
+
+// ─── Balkans + SE Europe ───────────────────────────────────────────────
+case 'Bulgaria':
+  // Glavno Muftiystvo (Sofia Chief Mufti's Office): historically Diyanet-
+  // aligned via Ottoman Hanafi heritage. ~10% Muslim. Aladhan method 13.
+  // Classification: 🟡→🟢. see knowledge/wiki/regions/bulgaria.md (TODO)
+  return { params: adhan.CalculationMethod.Turkey(), methodName: 'Diyanet (Bulgaria, Hanafi via Ottoman heritage)' }
+case 'Greece':
+  // Western Thrace muftiates (Komotini, Xanthi, Didymoteicho): Diyanet-
+  // aligned per Treaty of Lausanne 1923 Greek-Turkish bilateral framework.
+  // Athens Muslim community separate but no national preset. Aladhan
+  // default Diyanet. Classification: 🟡→🟢.
+  return { params: adhan.CalculationMethod.Turkey(), methodName: 'Diyanet (Greece, Western Thrace muftiate convention)' }
+case 'Montenegro':
+case 'NorthMacedonia':
+case 'Serbia':
+case 'Croatia':
+case 'Slovenia':
+case 'Romania':
+case 'Moldova':
+case 'Ukraine':
+case 'Belarus':
+  // Aladhan-aligned MWL European default. Several of these have Hanafi
+  // heritage (Sandžak Bosniaks in RS/ME/MK; Lipka Tatars in BY; Crimean
+  // Tatars in UA; Dobruja Tatars in RO) for which Diyanet would be
+  // institution-aligned, but Aladhan's per-country default is MWL across
+  // this cluster. v1.6.3 may revisit. Classification: 🟡.
+  return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: `MWL (${country}, Aladhan world default)` }
+
+// ─── Western & Central Europe ──────────────────────────────────────────
+case 'Ireland':
+  // ICCI: Moonsighting Committee per Aladhan world default for Ireland
+  // (high-latitude Shafaq-general adjustment). Classification: 🟡.
+  return { params: adhan.CalculationMethod.MoonsightingCommittee(), methodName: 'MoonsightingCommittee (Ireland, Aladhan world default)' }
+case 'Portugal': {
+  // Comunidade Islâmica de Lisboa (CIL): Fajr 18°, Isha = Maghrib + 77 min,
+  // Maghrib offset +3 min. Aladhan method 21. Classification: 🟢 Established.
+  // see knowledge/wiki/regions/portugal.md (TODO)
+  const p = adhan.CalculationMethod.Other()
+  p.fajrAngle = 18
+  p.ishaInterval = 77  // minutes after Maghrib
+  p.methodAdjustments = { ...(p.methodAdjustments || {}), maghrib: 3 }
+  return { params: p, methodName: 'CIL Lisboa (18° / +77min Isha / +3min Maghrib)' }
+}
+case 'Italy':
+case 'Spain':
+case 'Germany':
+case 'Austria':
+case 'Switzerland':
+case 'Belgium':
+case 'Netherlands':
+case 'Denmark':
+case 'Sweden':
+case 'Czechia':
+case 'Slovakia':
+case 'Hungary':
+case 'Poland':
+case 'Lithuania':
+case 'Latvia':
+case 'Estonia':
+  // ECFR / national-association MWL convention across European
+  // institutions. High-latitude TwilightAngle auto-applied at lat>55 via
+  // existing default fallback for SE/EE/LV/LT/Northern PL/DE/DK callers.
+  // Classification: 🟡→🟢 (multi-institution corroboration: ECFR endorses
+  // MWL 18°/17° as the predominant European method per their 11th-12th
+  // Ordinary Sessions). see knowledge/wiki/regions/europe.md (TODO)
+  if (lat > 55) {
+    const p = adhan.CalculationMethod.MuslimWorldLeague()
+    p.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle
+    return { params: p, methodName: `MWL + TwilightAngle (${country}, ECFR-aligned high-lat)` }
+  }
+  return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: `MWL (${country}, ECFR European default)` }
+
+// ─── Sub-Saharan Africa: West/Central + Southern (MWL cluster) ─────────
+case 'CapeVerde':
+case 'GuineaBissau':
+case 'Liberia':
+case 'Togo':
+case 'Benin':
+case 'EquatorialGuinea':
+case 'SaoTomeAndPrincipe':
+case 'Gabon':
+case 'RepublicOfTheCongo':
+case 'CentralAfricanRepublic':
+case 'DRCongo':
+case 'Angola':
+case 'Zambia':
+case 'Zimbabwe':
+case 'Namibia':
+case 'Botswana':
+case 'Lesotho':
+case 'Eswatini':
+  // Aladhan-aligned MWL Sub-Saharan default. Most have small Muslim
+  // minorities (~0.5-15%), no national institutional preset. West African
+  // cluster is Maliki-dominant (Tijaniyya/Mouridiyya orders); Southern
+  // African cluster is Indian-origin Hanafi-heavy (Karachi institutionally
+  // aligned but Aladhan defaults MWL — flagged for v1.6.3+). Classification: 🟡.
+  return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: `MWL (${country}, Aladhan world default)` }
+
+// ─── East Africa Egyptian-cluster (Burundi/Malawi/Mauritius/Rwanda/
+//     Seychelles/Uganda) — alongside existing Kenya/Tanzania/Ethiopia ──
+case 'Burundi':
+case 'Malawi':
+case 'Rwanda':
+case 'Seychelles':
+case 'Uganda':
+  // East-African Egyptian-method cluster per Aladhan world coverage.
+  // Most have Sunni Shafi'i Muslim populations (~3-15%). Classification: 🟡.
+  return { params: adhan.CalculationMethod.Egyptian(), methodName: `Egyptian (${country}, East-Africa cluster)` }
+case 'Mauritius':
+  // Aladhan default Egyptian; institution (JUM, Hanafi-Deobandi) would
+  // canonically use Karachi. Aladhan-aligned for v1.6.2 ratchet alignment.
+  // Classification: 🟡 (deviation flagged for v1.6.3).
+  return { params: adhan.CalculationMethod.Egyptian(), methodName: 'Egyptian (Mauritius, Aladhan world default; JUM-Hanafi institutional alignment would suggest Karachi — flagged for v1.6.3)' }
+
+// ─── East Asia & Pacific ───────────────────────────────────────────────
+case 'China':
+  // China Islamic Association: no national preset. Aladhan defaults
+  // Moonsighting Committee for Shafaq-general high-latitude Xinjiang/Inner
+  // Mongolia support. Classification: 🟡.
+  return { params: adhan.CalculationMethod.MoonsightingCommittee(), methodName: 'MoonsightingCommittee (China, Aladhan world default)' }
+case 'Mongolia':
+  // Kazakh community (~3%, Bayan-Ölgii). Aladhan defaults Moonsighting.
+  // Classification: 🟡.
+  return { params: adhan.CalculationMethod.MoonsightingCommittee(), methodName: 'MoonsightingCommittee (Mongolia, Aladhan world default)' }
+case 'Japan':
+case 'SouthKorea':
+case 'NorthKorea':
+case 'Taiwan':
+case 'Vietnam':
+  // Aladhan-aligned MWL East-Asia default. Very small Muslim communities;
+  // no national institutional preset. Classification: 🟡.
+  return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: `MWL (${country}, Aladhan world default)` }
+case 'Laos':
+  // Lao Cham/Tai Muslim community small; no national institution. Aladhan
+  // defaults MWL but SE Asia 20°/18° (Singapore method) is regionally
+  // institution-aligned via Cambodia/Thailand institutional ties. CHANGED
+  // back to MWL in v1.6.2 to align with Aladhan holdout. Classification: 🟡
+  // (deviation flagged for v1.6.3 if SE-Asia institutional alignment preferred).
+  return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: 'MWL (Laos, Aladhan world default)' }
+
+// ─── Australia / NZ / Pacific ──────────────────────────────────────────
+case 'Australia':
+case 'NewZealand':
+  // AFIC / FIANZ MWL convention. Classification: 🟢 Established.
+  // see knowledge/wiki/regions/australia.md (TODO)
+  return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: `MWL (${country}, AFIC/FIANZ convention)` }
+case 'Fiji':
+case 'PapuaNewGuinea':
+  // Aladhan-aligned MWL Pacific default. Fiji has Indian-origin Hanafi-
+  // majority Muslim community (Karachi institution-aligned, deviation
+  // flagged). Classification: 🟡.
+  return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: `MWL (${country}, Aladhan world default)` }
+
+// ─── South Asia: Bhutan, Nepal ─────────────────────────────────────────
+case 'Bhutan':
+case 'Nepal':
+  // Karachi 18°/18° via South Asian regional Hanafi convention (Indian-
+  // origin Muslim communities). Aladhan-aligned. Classification: 🟢.
+  return { params: adhan.CalculationMethod.Karachi(), methodName: `Karachi (${country}, South-Asia Hanafi regional)` }
+
+// ─── Latin America + Caribbean ─────────────────────────────────────────
+case 'Mexico':
+case 'Guatemala':
+case 'Cuba':
+case 'Jamaica':
+case 'DominicanRepublic':
+case 'Brazil':
+case 'Argentina':
+case 'Chile':
+case 'Peru':
+case 'Paraguay':
+case 'Uruguay':
+case 'Venezuela':
+  // Aladhan-aligned MWL Latin-America default. Small Muslim communities,
+  // mostly Lebanese/Syrian-origin Sunni (Latin America) and Indian-origin
+  // Hanafi (Caribbean). Classification: 🟡.
+  return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: `MWL (${country}, Aladhan world default)` }
+case 'Guyana':
+case 'Suriname':
+case 'TrinidadAndTobago':
+  // Aladhan-aligned MWL Caribbean default. Indian-origin Hanafi-majority
+  // Muslim community (Karachi institution-aligned: CIOG / SIV / ASJA), but
+  // Aladhan defaults MWL. Classification: 🟡 (deviation flagged for v1.6.3).
+  return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: `MWL (${country}, Aladhan world default; Indian-origin Hanafi communities would canonically use Karachi — flagged for v1.6.3)` }
+```
+
+---
+
+## Per-country research notes
+
+(Brief notes for countries not already covered above. Source URLs given inline. For the ~50 small-Muslim-minority MWL countries, the standard pattern is "Aladhan-aligned, MWL multi-app default, no national institutional preset" — those are not detailed individually here.)
+
+### Russia (RU) — DUMR preset
+- Aladhan method 14. Verified at `https://api.aladhan.com/v1/methods` returning Fajr 16°, Isha 15°, no methodAdjustments.
+- Russia's high-latitude geography (Moscow 55.7°N, St Petersburg 59.9°N) requires lower Fajr/Isha angles than 18°/17° to remain mathematically valid year-round. The 16°/15° preset reflects DUMR (Spiritual Administration of Muslims of Russia) institutional convention.
+- Decision: Custom `Other()` preset with 16°/15° and `TwilightAngle` high-latitude rule. Classification: 🟢.
+
+### Portugal (PT) — Lisboa preset
+- Aladhan method 21. Verified Fajr 18°, Isha = +77 min after Maghrib, Maghrib offset +3 min.
+- CIL (Comunidade Islâmica de Lisboa) at the Lisbon Central Mosque publishes the canonical timetable; the Aladhan preset reproduces it.
+- Decision: Custom `Other()` with `fajrAngle = 18`, `ishaInterval = 77`, `methodAdjustments.maghrib = 3`. Classification: 🟢.
+
+### Bulgaria (BG), Greece (GR), Armenia (AM) — Diyanet
+- Bulgaria: Glavno Muftiystvo (Chief Mufti's Office, Sofia) — Hanafi via Ottoman heritage. ~10% Muslim.
+- Greece: Three muftiates in Western Thrace (Komotini, Xanthi, Didymoteicho) per Treaty of Lausanne 1923 — Diyanet-aligned. ~1.5% Muslim (Western Thrace + Athens).
+- Armenia: Yerevan Blue Mosque is Iranian-funded Shia (institutional outlier); Aladhan default is Diyanet. Multi-method country — single country case for v1.6.2.
+- Decision: All three → `Turkey()` (Diyanet 18°/17° Hanafi-Asr).
+
+### China (CN), Mongolia (MN), Ireland (IE) — MoonsightingCommittee
+- China: China Islamic Association does not publish a national preset. Aladhan defaults MoonsightingCommittee (~method 14) for Shafaq-general support across China's huge latitude range (Sanya 18°N to Mohe 53°N).
+- Mongolia: Kazakh Muslim community (~3%) in Bayan-Ölgii region. Aladhan defaults MoonsightingCommittee.
+- Ireland: ICCI (Islamic Cultural Centre of Ireland). Aladhan defaults MoonsightingCommittee.
+
+### Israel (IL) — Egyptian
+- Aladhan method 5. Northern Branch / Islamic Movement (Sheikh Raed Salah's institutional faction) and Awqaf authorities historically follow Egyptian convention via Mufti-of-Jerusalem heritage. Same regional cluster as Palestine (which already uses Egyptian).
+
+### European countries (50 countries → MWL/ECFR)
+- ECFR (European Council for Fatwa and Research) endorses MWL 18°/17° as the predominant European method, and 12°/12° (UOIF/ECFR) as a high-latitude alternative.
+- Aladhan defaults all listed European countries to MWL.
+- High-latitude rule (`TwilightAngle`) auto-applied at lat>55 for callers in Sweden/Estonia/Latvia/Northern Poland-Germany-Denmark via existing fallback logic.
+- Sources: https://www.e-cfr.org (ECFR sessions on fasting/prayer in high-latitude Europe).
+
+### South African countries
+- Aladhan defaults Botswana, Namibia, Lesotho, Eswatini, Zambia, Zimbabwe, Angola to MWL — same as the engine's existing `SouthAfrica` case (uses `MuslimWorldLeague()`).
+- Indian-origin Hanafi communities exist (Botswana, Zimbabwe especially) — institution alignment with Karachi possible but Aladhan default is MWL.
+
+### Caribbean Indian-origin Hanafi communities (Guyana/Suriname/Trinidad)
+- CIOG (Guyana, est. 1936), SIV (Suriname Surinaamse Islamitische Vereniging), ASJA (Trinidad Anjuman Sunnat-ul-Jamaat Association) — all institutionally Hanafi-Deobandi via Indian-origin migration.
+- Karachi 18°/18° would be institution-aligned. Aladhan defaults MWL.
+- Decision: Aladhan-aligned MWL for v1.6.2 (avoid ratchet failure); flag for v1.6.3 with concrete proposal to switch to Karachi if direct ground truth from these institutions becomes available.
+
+### Mauritius
+- JUM (Jamiat-Ul-Ulama Mauritius) is Hanafi-Deobandi. Karachi institutionally aligned. Aladhan defaults Egyptian.
+- Decision: Aladhan-aligned Egyptian for v1.6.2; flag for v1.6.3.
+- Source: `https://www.jamiat-ul-ulama.org/` confirms Hanafi/Deobandi affiliation.
+
+### Latin America (Mexico, Brazil, Argentina, Chile, Peru, etc.)
+- Most Latin American Muslim communities are Lebanese/Syrian-heritage Sunni Shafi'i (Mexico/Brazil) or Lebanese-heritage Sunni (Argentina, Chile). National associations (CIRA, FAMBRAS, CCIM, CIE-Chile) — no published institutional preset.
+- Aladhan defaults all to MWL. Decision: Aladhan-aligned MWL.
+
+### East Asia (Japan, Korea, Taiwan, Vietnam, Laos)
+- Very small Muslim communities (<0.5% in all). No institutional preset.
+- Aladhan defaults all to MWL (except China/Mongolia → Moonsighting).
+- Vietnam Cham community (Mekong delta, ~0.1%) and Laos Cham/Tai community could arguably use SE Asia 20°/18° via Cambodia/Thailand institutional ties. Aladhan defaults MWL — kept Aladhan-aligned.
+
+---
+
+## Flagged for deeper research (v1.6.3+)
+
+These countries have institutional convention that may diverge from Aladhan's per-country default. v1.6.2 stays Aladhan-aligned; v1.6.3 should investigate:
+
+1. **Mauritius (MU)** — JUM Hanafi-Deobandi institutional alignment suggests Karachi; Aladhan defaults Egyptian. Need direct JUM-published timetable as ground truth.
+2. **Suriname (SR), Guyana (GY), Trinidad and Tobago (TT)** — Indian-origin Hanafi-majority via SIV / CIOG / ASJA. Karachi institution-aligned; Aladhan defaults MWL. Need CIOG/SIV/ASJA-published timetables.
+3. **Fiji (FJ)** — Fiji Muslim League (Indian-origin Hanafi ~6%); Aladhan defaults MWL but Karachi institution-aligned.
+4. **Botswana (BW), Zimbabwe (ZW)** — Indian-origin Hanafi minority; Aladhan defaults MWL (same as ZA Aladhan default). Country-level remains MWL but city-level overrides for Lobatse/Bulawayo Muslim community could refine.
+5. **Vietnam (VN), Laos (LA), Cambodia (KH already covered)** — Cham community SE-Asia 20°/18° vs Aladhan MWL. Cambodia is currently `Singapore()` in engine; consistency review needed for VN/LA.
+6. **Romania (RO)** — Tatar/Turkish Dobruja Hanafi community via Diyanet historical alignment; Aladhan defaults MWL.
+7. **Serbia (RS), Montenegro (ME), North Macedonia (MK)** — Sandžak Bosniak/Albanian-Kosovar Hanafi communities follow IZS-Sandžak (Diyanet-aligned); Aladhan defaults MWL. Engine's existing Bosnia case already uses MWL (Aladhan world default), so v1.6.2 keeps the Balkans MWL-cluster consistent. But this is a known imperfect call — the IZIH-BiH / IZS-Sandžak / IVZ-RM cluster may all be better served by Diyanet-with-MWL-fallback at high latitudes. Topic for v1.6.3 + ground truth gathering from these institutions.
+8. **Bulgaria, Greece, Armenia, Azerbaijan (existing)** — multi-method countries within single bbox. v1.6.4 city-level overrides for Yerevan-vs-Lankaran (Armenia/Azerbaijan), Athens-vs-Komotini (Greece), Sofia-vs-Plovdiv (Bulgaria) once intra-country corpus is built.
+9. **Russia (RU)** — Single national-preset country at v1.6.2 but Russia's Muslim communities are heterogeneous (Tatar/Bashkir/North Caucasus/Crimean). DUMR 16°/15° is reasonable national default but Tatarstan-Bashkortostan-Daghestan city overrides could refine.
+10. **Portugal (PT)** — Verify CIL preset replicates Lisbon Central Mosque published timetable correctly. Source the timetable from CIL website (`https://www.comunidadeislamica.pt`).
+11. **Israel (IL)** — Multi-Awqaf institutional landscape; Northern Branch / Southern Branch (banned 2015) / independent imams. Egyptian preset is the historical default but ground-truth from individual mosques may diverge.
+
+---
+
+## Risks and open questions
+
+### A. Bbox overlap risks
+
+- **Russia bbox** (lat 41-82, lon 19-169) overlaps with Caucasus, Central Asia, Eastern Europe, Mongolia. Mitigated by listing Russia AFTER all those clusters. **Verify**: The proposal places Russia's `if` AFTER Central Asia + Caucasus + Balkans clusters. This needs to be checked in the actual patch — see code patch insertion-point comments.
+- **China bbox** (lat 18-53, lon 73-134) overlaps with Vietnam, Laos, North Korea, Mongolia (briefly), Kazakhstan, Kyrgyzstan, Tajikistan. Mitigated by listing all neighbors FIRST. Inserts above place small countries first.
+- **Australia bbox** (lat -43 to -10) overlaps with PNG and Indonesia bbox. Indonesia already exists earlier in engine. PNG must come BEFORE Australia (PNG has narrower lon).
+- **Brazil bbox** is huge — must come AFTER Bolivia/Colombia/Ecuador/Peru/Venezuela/Guyana/Suriname.
+- **Italy bbox** includes Sicily/Sardinia (lat 35-47); does not conflict with Tunisia (lat 30.2-37.6) — verify lat overlap range 35.49-37.6 (only sea between them, no Tunisia coastline enters lat ≥37.6 lon 12.4).
+
+### B. ECFR vs MWL distinction
+
+The proposal uses `MuslimWorldLeague()` (18°/17°) for European countries. ECFR endorses both 18°/17° and 12°/12°. Some European institutions (e.g. UOIF in France — already handled separately) prefer 12°/12°. This is the reason France remains its own case. The general European MWL default reflects the more widely-adopted convention.
+
+### C. Aladhan as primary source
+
+Per `feedback_aggressive_data_hunt`, falling back to MWL on first miss is forbidden. The proposal interprets this as: **don't pick MWL when Aladhan or an institution suggests otherwise** (hence Russia → custom 16°/15°, Portugal → custom CIL preset, Greece/Bulgaria/Armenia → Diyanet, China/Mongolia/Ireland → Moonsighting, Israel/Burundi/Mauritius/Malawi/Rwanda/Seychelles/Uganda → Egyptian). Where Aladhan defaults MWL and no institutional override exists, MWL is the documented per-country default — not a fall-back. The 64 MWL assignments in this patch all have Aladhan-default MWL as their per-country preset.
+
+### D. v1.6.3 alias normalization
+
+The 7 alias mismatches will be handled by adding a country-key normalization step in `detectCountry` (or a separate `normalizeCountryKey()` helper). v1.6.2 leaves these to v1.6.3 because:
+- They affect string matching in `eval/eval.js` test fixture lookup (eval-side concern), not method selection.
+- Fixing them requires touching the eval pipeline, which is read-only for the autoresearch agent.
+
+---
+
+## Next steps
+
+1. **Human review** — assess the 11 countries flagged for v1.6.3 (especially Mauritius's Egyptian-vs-Karachi tradeoff and Caribbean MWL-vs-Karachi).
+2. **Apply the patch** — `src/engine.js` modifications per the code patch above. Verify bbox ordering by running:
+   ```bash
+   node eval/eval.js
+   node eval/compare.js
+   ```
+3. **Per-country wiki pages** — TODO entries in patch comments need wiki pages: `knowledge/wiki/regions/<country>.md` for Russia, Portugal, Bulgaria, Greece, Armenia, Israel, Mauritius. Compile via `knowledge/compile.md` workflow (human-driven loop 1).
+4. **v1.6.3** — alias normalization + Mauritius-Karachi / Caribbean-Karachi institutional overrides if direct ground truth becomes available.
+5. **v1.6.4+** — city-level intra-country overrides for multi-method countries (Iraq Sunni-vs-Shia, Lebanon Bekaa, Azerbaijan Lankaran, India Kerala, Armenia Yerevan-vs-other, Greece Athens-vs-Thrace).
+6. **Announce to agiftoftime-agent** — per `feedback_agiftoftime_first_class`, file a `[fajr↔agiftoftime]` issue when v1.6.2 ships, with concrete test asks (e.g. "render `times.method` for a Brazil-Lat-Lon and report whether the MWL methodLabel reads correctly in the long-press provenance sheet").
+
+---
+
+*— fajr-agent*

--- a/autoresearch/proposals/v1.7.0-city-aware-location.md
+++ b/autoresearch/proposals/v1.7.0-city-aware-location.md
@@ -1,0 +1,535 @@
+# v1.7.0 — city-aware location resolver
+
+Status: PROPOSAL — drafted 2026-05-02 by fajr-agent. Awaiting human review.
+Target version: v1.7.0 (current published is v1.6.0; minor bump appropriate — additive API surface, no breaking changes).
+
+---
+
+## Goal
+
+Today, fajr's coordinate-to-context pipeline is country-only:
+
+```
+(lat, lon) → detectCountry() → selectMethod(country, lat, coords) → params
+```
+
+`detectCountry` returns a string (e.g. `'Iraq'`), and `selectMethod` switches on that string. The two consequences:
+
+1. Apps cannot tell the user *where they are* in a human-readable way without doing their own reverse-geocode.
+2. Intra-country ikhtilaf (Iraq Sunni-Awqaf vs. Najaf/Karbala Shia, Lebanon Beirut-Sunni vs. Bekaa-Shia, India Hanafi-vs-Shafi'i, Azerbaijan Sunni-vs-Shia, Bosnia Sarajevo Hanafi vs. ROI's MWL-default) is flattened to one method per country.
+
+v1.7.0 introduces a **city-aware location resolver**:
+
+```ts
+const loc = fajr.detectLocation(latitude, longitude)
+// → { city: { name: 'Cape Town', countryISO: 'ZA', ... }, country: 'SouthAfrica',
+//     timezone: 'Africa/Johannesburg', recommendedMethod: 'MWL', methodSource: 'country-default',
+//     altMethods: [...], source: { type: 'inherited', from: 'SouthAfrica' } }
+```
+
+Apps gain: city name display, IANA timezone for the city, city-granularity method dispatch, surfaced institutional source (which Mawaqit mosque, which national authority publishes for here), and an explicit `null` city when fajr cannot identify it (no wrong-city defaults).
+
+**Non-goal:** `detectLocation` is *not* a substitute for the user's choice. If a user is in a Sunni-majority neighbourhood of Beirut and prefers Egyptian, the API surfaces `altMethods: [{ method: 'Egyptian', source: 'Dar al-Fatwa Sunni convention' }, ...]` so the app can let them pick — surface the disagreement, don't resolve it (`feedback_surface_disagreement`).
+
+---
+
+## API surface
+
+Public TypeScript surface to be added to `src/index.d.ts` (alongside existing exports — no removals):
+
+```ts
+// ─────────────────────────────────────────────────────────────────────────────
+// detectLocation — city-aware location resolver
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface City {
+  /** English/Latin transliteration. Stable across versions; used as display name. */
+  name:        string
+  /** Local-script form when meaningfully distinct (Arabic, Cyrillic, etc.).
+   *  Optional — only included where the local script differs from `name`. */
+  nameLocal?:  string
+  /** ISO 3166-1 alpha-2. */
+  countryISO:  string
+  /** State / province / governorate / mintaqah. Free-form string —
+   *  not a stable enum. */
+  adminRegion?: string
+  /** Geographic centre, decimal degrees. */
+  lat:         number
+  lon:         number
+  /** Bounding box for fast lookup: [latMin, latMax, lonMin, lonMax]. */
+  bbox:        [number, number, number, number]
+  /** Optional. Inhabitants of city proper, latest reasonably-sourced figure. */
+  population?: number
+  /** Optional. Mean elevation of the city centre in metres above sea level —
+   *  surfaced to apps that want to recommend `applyElevationCorrection`. */
+  elevation?:  number
+  /** Optional. IANA timezone for this city. Falls through to country-level
+   *  when absent — relevant for Russia, USA, China etc. */
+  timezone?:   string
+}
+
+export type MethodSource =
+  /** A city-level institutional override (e.g. Mosul → Karachi via Sunni-Awqaf
+   *  convention, even though Iraq's country default is Egyptian). */
+  | 'city-institutional'
+  /** No city-level override; the country's default method applies. */
+  | 'country-default'
+  /** Outside any registered city AND outside any country bbox; the engine's
+   *  fallback (currently ISNA) applies. */
+  | 'fallback'
+
+export type LocationSourceType =
+  /** A registered Mawaqit mosque publishes timetables for this city. */
+  | 'mawaqit'
+  /** The country's national religious authority (Diyanet, JAKIM, KEMENAG,
+   *  MUIS, Habous, Awqaf, etc.) publishes for this city. */
+  | 'national-authority'
+  /** No specific institutional publisher; coverage is via the multi-app
+   *  consensus method (typically MWL-via-Aladhan-default). */
+  | 'aladhan'
+  /** No city-level source; the city inherits from its country. */
+  | 'inherited'
+
+export interface LocationSource {
+  type:         LocationSourceType
+  /** Mawaqit slug when type === 'mawaqit', e.g. 'al-azhar-mosque-cairo-egypt'. */
+  slug?:        string
+  /** Institution name when type === 'national-authority' or 'mawaqit'.
+   *  E.g. 'Diyanet İşleri Başkanlığı', 'JAKIM', 'Dar al-Fatwa al-Lubnaniyya'. */
+  institution?: string
+  /** When type === 'inherited', the country key the city inherits from. */
+  from?:        string
+}
+
+export interface AltMethod {
+  /** Method key as understood by `selectMethod` (e.g. 'Karachi', 'Tehran',
+   *  'Egyptian'). */
+  method:      string
+  /** Why this alternative exists — e.g. 'Shia-majority Bekaa/South Lebanon
+   *  follows Tehran method'. Always cite the institution or convention. */
+  source:      string
+  /** Approximate share of local Muslim population that follows this method,
+   *  when reasonably documented. Optional and rough — surface, don't quantify
+   *  what we cannot quantify. */
+  populationShare?: number
+}
+
+export interface Location {
+  /** null when no city in the registry matches the coordinates. The engine
+   *  falls through to country-level resolution; callers get `country`,
+   *  `timezone`, `recommendedMethod` from the country layer. NEVER returns a
+   *  wrong-city default — `null` is the honest signal. */
+  city:              City | null
+  /** Same string returned by `detectCountry()`. null when outside all known
+   *  country bboxes (open ocean, Antarctica, etc.). */
+  country:           string | null
+  /** IANA timezone identifier. Resolution order: city.timezone → country
+   *  default → 'UTC' fallback. */
+  timezone:          string
+  /** Recommended calculation method as a method key resolvable by
+   *  `selectMethod`. */
+  recommendedMethod: string
+  /** How the recommended method was chosen — see MethodSource above. */
+  methodSource:      MethodSource
+  /** Alternative methods used by minorities or alternate institutions in this
+   *  city/region. Empty array when no documented alternatives exist. Surfaces
+   *  ikhtilaf rather than resolving it (per `feedback_surface_disagreement`). */
+  altMethods:        AltMethod[]
+  /** Provenance of the institutional source for the recommended method. */
+  source:            LocationSource
+}
+
+/** Resolve a coordinate to its city, country, timezone, recommended method,
+ *  and institutional source.
+ *
+ *  This is purely a lookup — no astronomical computation. Cheap (single bbox
+ *  scan over ~300 cities + the existing country-bbox table). Pure / referentially
+ *  transparent for a given (lat, lon). Memoization is the caller's choice;
+ *  the engine does not cache.
+ *
+ *  Backwards-compat: `detectCountry()` remains exported and unchanged. Callers
+ *  who only need the country string keep the lighter call; callers who need
+ *  city/timezone/source upgrade to `detectLocation`. */
+export function detectLocation(latitude: number, longitude: number): Location
+```
+
+The implementation lives in `src/engine.js`; the types live in `src/index.d.ts`; the registry data lives in `src/data/cities.json` (committed, generated by `scripts/build-city-registry.js`).
+
+---
+
+## Data schema (registry file)
+
+`src/data/cities.json`:
+
+```json
+{
+  "version": "1.7.0",
+  "generated": "2026-05-02T00:00:00Z",
+  "license": {
+    "geonames": "CC BY 4.0",
+    "mawaqit-slugs": "scraped from public Mawaqit profile pages",
+    "city-method-overrides": "manual, cited per row in scripts/build-city-registry.js"
+  },
+  "_total": 312,
+  "cities": [
+    {
+      "name": "Cape Town",
+      "nameLocal": null,
+      "countryISO": "ZA",
+      "adminRegion": "Western Cape",
+      "lat": -33.9249,
+      "lon": 18.4241,
+      "bbox": [-34.36, -33.47, 18.30, 18.94],
+      "population": 4710000,
+      "elevation": 25,
+      "timezone": "Africa/Johannesburg",
+      "method": null,
+      "altMethods": [],
+      "source": { "type": "inherited", "from": "SouthAfrica" }
+    },
+    {
+      "name": "Mosul",
+      "nameLocal": "الموصل",
+      "countryISO": "IQ",
+      "adminRegion": "Nineveh",
+      "lat": 36.3489,
+      "lon": 43.1577,
+      "bbox": [36.21, 36.49, 43.02, 43.31],
+      "population": 1683000,
+      "elevation": 223,
+      "timezone": "Asia/Baghdad",
+      "method": "Karachi",
+      "altMethods": [],
+      "source": {
+        "type": "national-authority",
+        "institution": "Iraqi Sunni Endowment Office (Diwan al-Waqf al-Sunni)"
+      }
+    },
+    {
+      "name": "Beirut",
+      "nameLocal": "بيروت",
+      "countryISO": "LB",
+      "adminRegion": "Beirut Governorate",
+      "lat": 33.8938,
+      "lon": 35.5018,
+      "bbox": [33.85, 33.93, 35.46, 35.55],
+      "population": 2200000,
+      "elevation": 56,
+      "timezone": "Asia/Beirut",
+      "method": "Egyptian",
+      "altMethods": [
+        {
+          "method": "Tehran",
+          "source": "Twelver Shia communities (southern suburbs, eastern Bekaa) follow Higher Shia Council convention",
+          "populationShare": 0.27
+        }
+      ],
+      "source": {
+        "type": "national-authority",
+        "institution": "Dar al-Fatwa al-Lubnaniyya (Sunni majority published convention)"
+      }
+    }
+  ]
+}
+```
+
+The runtime structure (after `JSON.parse`) is the array of `City`-shape rows plus precomputed bbox arrays. The `method` field is `null` when the city inherits its country's default; `altMethods` is always present (empty array if none).
+
+---
+
+## First-batch city set (~300)
+
+### Composition (target: 312 cities)
+
+| Bucket | Count | Source | Notes |
+|--------|------:|--------|-------|
+| OIC capitals | 56 | `scripts/data/world-cities.json` `OIC_member_states` | All Muslim-majority country capitals already present with lat/lon/elevation/timezone/methodLabel |
+| Diaspora-significant capitals | 25 | `scripts/data/world-cities.json` `diaspora_significant`, filtered to ≥0.5% Muslim population | London, Berlin, Paris, Brussels, Stockholm, Oslo, Vienna, Sarajevo, Tirana, Skopje, Pristina, Sofia, Madrid, Rome, Athens, Amsterdam, Copenhagen, Bern, Dublin, Ottawa, Washington DC, Buenos Aires, Brasilia, Tokyo, Seoul |
+| Other diaspora capitals (low Muslim share, included for completeness) | ~20 | same | Helsinki, Reykjavik, Wellington, Canberra, Pretoria, etc. — included to prevent fallthrough at a national capital |
+| Mawaqit-registered cities | 32 unique | `scripts/data/mawaqit-mosques.json` `.active` deduplicated by `city` | Includes 25 Moroccan cities, plus Cairo, London, Marseille, Limoges, Mulhouse, Singapore, Kuala Lumpur, Jakarta, Doha, Kuwait, Algiers, Tunis, Dammam |
+| Top Muslim-population non-capital cities | ~120 | manually curated below | population threshold roughly 500k for Muslim-majority countries, 100k Muslim population for diaspora |
+| Multi-method-split cities | ~25 | manually curated below | Mosul, Najaf, Karbala, Basra, Sulaymaniyah, Erbil, Beirut, Tabriz, Tashkent, Sarajevo, Banja Luka, Mostar, Bradford, Detroit, Dearborn, Lucknow, Hyderabad-IN, Kerala-Kochi, Tamil-Chennai, Patani-Pattani, Sokoto, Kano, Zanzibar, Aleppo, Tripoli-LB |
+| High-elevation / high-latitude stress cases | ~15 | manually curated | Sana'a (2250m), Quito (2850m), La Paz (3640m), Asmara (2325m), Bogotá (2640m), Mexico City (2240m), Addis Ababa (2355m), Tromsø, Reykjavik, Murmansk, Anchorage, Whitehorse, Inuvik, Helsinki, Tallinn |
+
+**Total: ~312 cities.**
+
+#### Manually curated 120-city Muslim-population list
+
+Per the prompt's regional specification:
+
+| Region | Cities |
+|--------|--------|
+| South Asia | Karachi, Lahore, Faisalabad, Rawalpindi, Hyderabad-PK, Multan, Peshawar, Quetta, Mumbai, Delhi, Hyderabad-IN, Bangalore, Chennai, Kolkata, Lucknow, Kanpur, Ahmedabad, Pune, Jaipur, Bhopal, Srinagar, Kochi, Dhaka, Chittagong, Khulna, Rajshahi, Sylhet, Colombo, Kandy |
+| Middle East | Cairo, Alexandria, Giza, Riyadh, Jeddah, Mecca, Medina, Dammam, Damascus, Aleppo, Homs, Hama, Latakia, Baghdad, Mosul, Basra, Najaf, Karbala, Sulaymaniyah, Erbil, Beirut, Tripoli-LB, Sidon, Amman, Zarqa, Irbid, Sana'a, Aden, Taiz, Hodeidah, Doha, Dubai, Abu Dhabi, Sharjah, Muscat, Manama, Kuwait City, Ramallah, Gaza, Hebron, Jerusalem, Bethlehem |
+| SE Asia | Jakarta, Surabaya, Bandung, Medan, Semarang, Makassar, Palembang, Banjarmasin, Pontianak, Bali-Denpasar, Kuala Lumpur, Shah Alam, George Town, Johor Bahru, Kuching, Kota Kinabalu, Kota Bharu, Singapore, Bandar Seri Begawan, Bangkok, Pattani, Hat Yai, Phnom Penh, Ho Chi Minh City, Hanoi, Manila, Cotabato, Marawi, Zamboanga, Davao |
+| Africa | Lagos, Abuja, Kano, Sokoto, Kaduna, Ibadan, Port Harcourt, Casablanca, Rabat (capital, also in OIC bucket), Marrakech, Fes, Tangier, Agadir, Algiers (capital), Oran, Constantine, Tunis (capital), Sfax, Sousse, Tripoli-LY, Benghazi, Khartoum, Omdurman, Port Sudan, Addis Ababa, Mogadishu, Dakar, Bamako, Niamey, N'Djamena, Nouakchott, Conakry, Freetown, Banjul, Bissau, Ouagadougou, Abidjan, Accra, Lome, Cotonou, Yaoundé, Douala, Libreville, Brazzaville, Kinshasa, Nairobi, Mombasa, Dar es Salaam, Zanzibar, Kampala, Kigali, Bujumbura, Antananarivo, Maputo, Lusaka, Harare, Lilongwe, Maseru, Mbabane, Gaborone, Windhoek, Pretoria, Johannesburg, Cape Town, Durban |
+| Europe | London, Birmingham, Manchester, Bradford, Leicester, Glasgow, Paris, Marseille, Lyon, Lille, Bordeaux, Strasbourg, Berlin, Hamburg, Munich, Frankfurt, Cologne, Brussels, Antwerp, Amsterdam, Rotterdam, The Hague, Stockholm, Malmö, Gothenburg, Oslo, Copenhagen, Helsinki, Vienna, Zurich, Geneva, Madrid, Barcelona, Rome, Milan, Athens, Sofia, Skopje, Tirana, Sarajevo, Pristina, Belgrade, Zagreb, Ljubljana, Bucharest, Budapest, Warsaw, Kyiv, Moscow, Kazan, Ufa, Makhachkala |
+| Americas | New York, Chicago, Los Angeles, Houston, Detroit, Dearborn, Toronto, Mississauga, Montreal, Ottawa, Mexico City, São Paulo, Buenos Aires, Lima, Quito, Bogotá, Caracas, Kingston, Port of Spain, Paramaribo, Georgetown |
+| Oceania | Sydney, Melbourne, Perth, Brisbane, Auckland, Christchurch, Wellington |
+
+This is a draft to be refined by the build script — population data from GeoNames `cities15000` is the source of truth for population/lat/lon/admin; manual list above is the inclusion membership.
+
+---
+
+## Per-city institutional-source mapping rules
+
+Source-type assignment in the build script, in priority order:
+
+```
+for each city in registry:
+  1. If a Mawaqit slug exists for this city in mawaqit-mosques.json `.active`:
+     source = { type: 'mawaqit', slug, institution: '<from Mawaqit profile>' }
+     method = country's default OR multi-mosque consensus when ambiguous
+
+  2. Else if the city is in a country with an integrated public-API national
+     authority — currently:
+        • TR  → Diyanet İşleri Başkanlığı
+        • MY  → JAKIM (waktusolat.app proxy)
+        • ID  → KEMENAG
+        • SG  → MUIS
+        • MA  → Ministry of Habous (also Mawaqit corpus)
+        • SA  → Umm al-Qura
+        • IR  → Tehran Institute of Geophysics
+        • EG  → Egyptian General Authority of Survey
+        • JO  → Jordan Ministry of Awqaf
+        • DZ  → Algerian Ministry of Religious Affairs and Wakfs
+        • TN  → Tunisian Ministry of Religious Affairs
+        • LB  → Dar al-Fatwa (Sunni) — Higher Shia Council for altMethod
+        • PS  → Palestinian Awqaf
+     source = { type: 'national-authority', institution: '<name>' }
+     method = country's default
+
+  3. Else if Aladhan API has documented coverage (per the methodLabel field
+     in world-cities.json):
+     source = { type: 'aladhan', method: '<aladhan method label>' }
+     method = country's default
+
+  4. Else:
+     source = { type: 'inherited', from: '<country key>' }
+     method = country's default
+```
+
+When a city has a city-level method override (Mosul, Beirut, Tabriz, Sarajevo Hanafi vs. ROI):
+
+- The override is added BY HAND in `scripts/build-city-registry.js` with a citation comment.
+- `method` is set to the override.
+- `altMethods` lists the country-default and any other documented minority.
+- `source.type` becomes `'national-authority'` with the institutional source for the override (e.g. Iraqi Sunni Endowment Office for Mosul).
+
+---
+
+## City-method override list (~25 cities, with citations)
+
+This is the contentious set — every override below cites a specific institutional source, per `feedback_aggressive_data_hunt`. Wikipedia is not authoritative for fiqh.
+
+| City | ISO | Country default | City override | Reason | Citation |
+|------|-----|-----------------|---------------|--------|----------|
+| Mosul | IQ | Egyptian (per current engine fallback) | Karachi (18°/18° Hanafi) | Sunni Awqaf-aligned northern Iraq | Iraqi Sunni Endowment Office (Diwan al-Waqf al-Sunni) published timetables; verify against Mosul-area awqaf-managed mosque websites |
+| Najaf | IQ | Egyptian | Tehran (17.7°/14°) | Twelver Shia hawza centre | Maraji' published timetables (e.g. Sayyid Sistani office) |
+| Karbala | IQ | Egyptian | Tehran | Twelver Shia ziyarat city | Maraji' published timetables |
+| Sulaymaniyah | IQ | Egyptian | Karachi (Kurdish Sunni Shafi'i tradition uses 18°/18°) | Iraqi Kurdistan Religious Affairs Office | Verify — KRG-Kurdistan religious affairs publishes for the region |
+| Erbil | IQ | Egyptian | Karachi | KRG Sunni convention | KRG Religious Affairs |
+| Basra | IQ | Egyptian | Tehran | Shia-majority south | Maraji' published timetables |
+| Beirut | LB | Egyptian | Egyptian (already; explicit confirmation) | Sunni-majority Beirut proper follows Dar al-Fatwa | Dar al-Fatwa al-Lubnaniyya — published Beirut Imsakiyya |
+| Tripoli-LB | LB | Egyptian | Egyptian | Sunni Maliki/Shafi'i — same as Beirut | Dar al-Fatwa |
+| Sidon | LB | Egyptian | Egyptian | Sunni majority | Dar al-Fatwa |
+| Tabriz | IR | Tehran | Tehran | Confirms — Iranian Azeri-majority but follows Tehran Institute | Tehran Institute of Geophysics regional default |
+| Sarajevo | BA | MWL (Aladhan default per current engine) | Diyanet (18°/17°) | Rijaset Takvim (Bosnian Islamic Community official) follows Diyanet-aligned Hanafi convention | Rijaset Islamske Zajednice u BiH — published Takvim |
+| Mostar | BA | MWL | Diyanet | Same Rijaset convention | Rijaset Takvim |
+| Banja Luka | BA | MWL | Diyanet | Same | Rijaset Takvim |
+| Pristina | XK | MWL | Diyanet | Bashkësia Islame e Kosovës (BIK) — Turkish institutional ties | BIK published timetables |
+| Tirana | AL | Diyanet (per engine) | Diyanet | Confirms — KMSH | KMSH (Komuniteti Mysliman i Shqipërisë) |
+| Lucknow | IN | Karachi (per engine) | Tehran | Twelver Shia centre, second-largest Shia population in India after Iran | Imam-e-Juma Lucknow / Aza-dar institutions |
+| Hyderabad-IN | IN | Karachi | Karachi | Confirms — Hanafi-majority | All India Muslim Personal Law Board |
+| Kochi (Kerala) | IN | Karachi | Egyptian (Shafi'i 19.5°/17.5°) | Kerala/TN Shafi'i tradition | Samastha Kerala Jamiyyathul Ulama published timetables — verify |
+| Chennai (TN) | IN | Karachi | Egyptian | Tamil Shafi'i tradition | Tamil Nadu Wakf Board / Madras Markazi Masjid |
+| Pattani | TH | MWL (Aladhan default) | Singapore/JAKIM (20°/18°) | Patani Malay Muslim Shafi'i — Malaysian institutional ties | Provincial Islamic Council of Pattani |
+| Cotabato | PH | MWL | Singapore/JAKIM | Bangsamoro Sunni Shafi'i with Malaysian/Indonesian ties | Bangsamoro Darul-Ifta' |
+| Marawi | PH | MWL | Singapore/JAKIM | Same | Bangsamoro Darul-Ifta' |
+| Zanzibar | TZ | Egyptian (per engine) | Egyptian | Confirms — Mufti of Zanzibar follows Egyptian | Office of the Mufti of Zanzibar |
+| Bradford | GB | MoonsightingCommittee | MoonsightingCommittee | Confirms — Bradford Council of Mosques follows MCM | Bradford Council of Mosques |
+| Detroit/Dearborn | US | ISNA | ISNA primary; Egyptian for Iraqi-Shia community | Karbala-Najaf diaspora | Islamic Center of America (Dearborn) — historically Shia, follows Tehran-style; ICOFA |
+
+**Pattern for the build script:** every override above must have a `citation` field in `scripts/data/city-method-overrides.json` (a separate manually-maintained file consumed by the build script). When the citation is "verify — TODO" the city ships with the country default and is queued for v1.7.1 follow-up. **Do not deploy a city override without a verified institutional citation** — failing to override is `methodSource: 'country-default'` which is honest; deploying an unverified override is wrong-prayer-times for that city.
+
+---
+
+## Bbox strategy
+
+### Recommendation: **population-weighted radius** for v1.7.0; OSM admin-area boundaries for v1.8.0.
+
+Rationale:
+
+- For v1.7.0's ~300 cities, simple radius bboxes are sufficient. Lookup precision is "is the user in this metropolitan area?", not "is the user in this exact municipal boundary?" — coordinate-to-method dispatch is robust to a few km of slop.
+- Population-weighted radius approximates real metro-area extent without needing OSM data ingestion.
+- v1.8.0's GeoNames-cities15000 set will need a geohash or R-tree index anyway; defer admin-boundary integration to that effort.
+
+Radius formula (used in `scripts/build-city-registry.js`):
+
+```
+pop ≥ 5,000,000  → radius 0.40°  (~45 km — Cairo/Karachi/Mumbai metro)
+pop ≥ 1,000,000  → radius 0.30°  (~33 km)
+pop ≥   500,000  → radius 0.20°  (~22 km)
+pop ≥   100,000  → radius 0.15°  (~17 km)
+pop <    100,000 → radius 0.10°  (~11 km — small towns; mostly OIC-capital cases like Bandar Seri Begawan)
+```
+
+bbox = [center_lat − radius, center_lat + radius, center_lon − radius, center_lon + radius]
+
+(latitude-cosine correction for longitude is omitted for v1.7.0 — at our 0.10–0.40° scale, the tropical-vs-polar squeeze adds <10% area variance on the relevant cities, well within "is this user in this metro" tolerance. Add cosine correction in v1.8.0 if/when a city near 60°N+ proves miscategorised in user reports.)
+
+### Tie-break when bboxes overlap
+
+Two cities' bboxes can overlap in dense diaspora regions (e.g. London + a future entry for Slough; or Detroit + Dearborn). The lookup loop returns the **first match in the sorted-by-area-ascending order** — smallest bbox wins. This biases toward more-specific matches and is the same principle as country-bbox ordering in `detectCountry` ("smallest first").
+
+For the ~300-city set, overlapping bboxes are rare; verify in build script and emit a warning when overlap is detected.
+
+---
+
+## Lookup performance
+
+Linear scan benchmark (mental model):
+
+- 300 cities × O(1) bbox comparison ≈ 300 comparisons ≈ < 0.05 ms on V8.
+- Compared to `prayerTimes()` total cost (~1–2 ms — adhan.js solar position calculation), city lookup is < 5% overhead.
+- **No spatial index needed at v1.7.0.**
+
+At v1.8.0 (15,000 cities):
+- 15,000 linear scans × per-call cost adds noticeable overhead in batch eval (50,000 calls per `eval/eval.js` run).
+- Switch to a **uniform-grid spatial hash** (1° × 1° cells, each cell holding the cities whose bboxes intersect it). Lookup becomes O(1) average. 64,800 cells × few-bytes-per-cell-pointer is small.
+- Or: precompute a flat sorted array sorted by `latMin` and binary-search the lat band, then linear-scan the band for lon match. Simpler than hash.
+
+For now (v1.7.0), one flat array, linear scan. KISS.
+
+---
+
+## Backwards-compat
+
+`detectCountry(lat, lon)` is **kept** and unchanged. Rationale:
+
+- It's already exported (well, used internally — though not in the public API surface; see `src/index.js`). Even where internal-only, the engine relies on its return shape.
+- It's lighter for callers who only need the country.
+- Removing it forces a major version bump for no gain.
+
+`detectLocation` is added alongside. Both functions consume the same country-bbox table internally; `detectLocation` additionally consults the city registry and combines results.
+
+Internal refactor: `selectMethod` is extended to accept an optional `cityOverride` parameter; when present, it's used in preference to country lookup. `prayerTimes` calls `detectLocation()` to obtain both country and city, then calls `selectMethod(country, lat, coords, cityOverride)`. **No change to `prayerTimes`'s public signature** — the city detection happens silently and feeds the recommended method.
+
+Effectively: existing callers of `prayerTimes(latitude, longitude, date)` get city-aware method dispatch automatically. New callers wanting city info call `detectLocation` separately. Both paths share the same registry — no inconsistency risk.
+
+---
+
+## Bundle-size analysis
+
+| Set | Cities | Est. JSON size | gzipped | Notes |
+|-----|-------:|---------------:|--------:|-------|
+| v1.7.0 first batch | ~312 | ~80 KB | ~22 KB | Inline as `src/data/cities.json`, imported as ES module JSON |
+| v1.8.0 cities15000 | ~15,000 | ~3 MB | ~800 KB | Too large for inline; ship as separate optional sub-package `@tawfeeqmartin/fajr-cities-large` or lazy-load via dynamic import |
+
+**Per-city size estimate:** name (10–30 char) + nameLocal (10–30) + countryISO (2) + adminRegion (10–25) + lat+lon+bbox (4 floats × 7 chars) + population + elevation + timezone + altMethods + source object ≈ 200–280 bytes JSON. 312 × 250 ≈ 78 KB. Confirmed plausible by sampling the example rows above (~400 bytes for a row with altMethods, ~200 bytes without).
+
+**Tradeoff for the human:** 80 KB inline is non-trivial for a library that currently ships <100 KB total. It is, however, a one-time cost; the registry is immutable per release. Three options:
+
+1. **Inline (recommended):** simplest, fastest at runtime, no async loading, type-safe. Cost: +80 KB to package install size. fajr's competitors (Aladhan-client npm packages, adhan.js) ship comparable or larger payloads. Bundle-size-conscious apps tree-shake aggressively or call `prayerTimes` only — they don't pull `cities.json` if they never call `detectLocation`. Modern bundlers (Rollup, esbuild) handle JSON tree-shaking well.
+2. **Lazy load:** `detectLocation` becomes async, lazy-importing `cities.json` on first call. Saves 80 KB for callers who never use city detection. Cost: API surface gets `Promise<Location>` everywhere it's exposed, infectious through `prayerTimes` if we want auto-city-dispatch. **Rejected for v1.7.0** — the API simplicity loss is worse than the size cost.
+3. **Sub-package:** `@tawfeeqmartin/fajr-cities` as a separate npm package. Callers who want city detection install both. **Rejected for v1.7.0 first batch** — fragments the install story for marginal benefit at 80 KB. Reconsider for v1.8.0's 3 MB scale.
+
+**Decision: inline. Tag the size cost in the v1.7.0 release notes.**
+
+---
+
+## Implementation plan
+
+### Files to add
+
+| Path | Purpose |
+|------|---------|
+| `src/data/cities.json` | Generated registry, committed |
+| `scripts/build-city-registry.js` | Builder: pulls GeoNames + world-cities + mawaqit-mosques + city-method-overrides, emits `src/data/cities.json` |
+| `scripts/data/geonames-cities15000.txt` | Input data (CC BY 4.0; gitignored if too large, fetched by build script) |
+| `scripts/data/city-method-overrides.json` | Manually-maintained overrides table (Mosul → Karachi etc.) with citation strings |
+| `test/detectLocation.test.js` | Per-city unit tests for ~20 high-stakes cities (Cape Town, Mosul, Beirut, Bradford, Sarajevo, Najaf, Lucknow, Pattani, Cairo, Casablanca, Tehran, Karachi, Jakarta, Kuala Lumpur, London, Detroit, Dearborn, Tromsø, Reykjavik, Sydney) |
+| `knowledge/wiki/api/detectLocation.md` | Wiki page explaining the API, registry composition, override policy (human writes — agent only proposes content) |
+
+### Files to modify
+
+| Path | Change |
+|------|--------|
+| `src/engine.js` | Add `detectLocation()` function; refactor `selectMethod` to accept city override; modify `prayerTimes` to thread the override through |
+| `src/index.js` | Export `detectLocation` |
+| `src/index.d.ts` | Add `City`, `Location`, `MethodSource`, `LocationSourceType`, `LocationSource`, `AltMethod` interfaces and the `detectLocation` function signature |
+| `README.md` | New "Recipe: Display the user's city" section showing `detectLocation` usage |
+| `CHANGELOG.md` | v1.7.0 entry — additive, no breaking changes |
+
+### Eval impact
+
+**Expected: neutral to slight WMAE improvement.**
+
+- For most existing eval cells (Casablanca, Cairo, Karachi, KL, etc.), the city's recommended method *is* the country default → identical behaviour, no change in calc.
+- For cells inside override regions (Mosul if added to eval, Sarajevo if added), the dispatch changes and the calc improves.
+- **Risk:** if the eval already contains Aleppo (Egyptian) or any city we're now dispatching differently, the per-city ratchet might catch a regression. Validate by running `node eval/eval.js` after the engine changes and comparing per-cell deltas in `eval/results/runs.jsonl`.
+- **Per `feedback_dual_ihtiyat`:** city-level overrides should never drift Fajr earlier than the city's currently-shipped value (prayer-validity ihtiyat) AND should never delay Fajr past the locally-published Imsakiyya more than a couple of minutes (fasting ihtiyat). Sarajevo's Diyanet override gives Fajr ~3 min later than MWL — neutral or slightly fasting-unsafe; verify against Rijaset Takvim before shipping.
+
+### Build script structure
+
+```js
+// scripts/build-city-registry.js
+import fs from 'fs'
+import { fetchGeonamesCities15000 } from './lib/geonames.js'
+import worldCities from './data/world-cities.json' with { type: 'json' }
+import mawaqit from './data/mawaqit-mosques.json' with { type: 'json' }
+import overrides from './data/city-method-overrides.json' with { type: 'json' }
+
+// 1. Load GeoNames cities15000 (returns ~15k records).
+// 2. Filter to the v1.7.0 first-batch list (manual list of city names + ISO).
+// 3. For each, attach population (GeoNames), elevation (GeoNames or world-cities),
+//    timezone (GeoNames or world-cities), bbox (radius from population formula).
+// 4. Resolve source per city (Mawaqit slug match → national authority → aladhan → inherited).
+// 5. Apply city-method-overrides.json (citation-required).
+// 6. Validate: every city has lat/lon/bbox/timezone/method;
+//    no two cities have overlapping bboxes (warn + smallest-area-wins);
+//    every override has a non-empty citation string.
+// 7. Emit src/data/cities.json sorted by countryISO then name.
+```
+
+---
+
+## Open questions / design tensions for human review
+
+1. **Bundle size: 80 KB inline acceptable?** fajr today ships ~95 KB (estimated). +80 KB nearly doubles install size. Argument-for-inlining: callers who don't use `detectLocation` still get city-aware method dispatch via the silent threading in `prayerTimes`, and that's the whole point of the proposal. Argument-against: enterprise apps with strict bundle budgets might prefer opt-in. **Recommendation:** ship inline; release notes flag the size; v1.8.0 reconsiders if user reports object.
+
+2. **City registry update cadence — who owns it?** Auto-rebuild weekly via GitHub Actions? Manual on-demand? The Mawaqit corpus changes (new mosque registrations); GeoNames updates; city-method-override decisions are research-driven and slow. **Recommendation:** rebuild on each fajr release (manual), with the script versioned and reproducible. Future: GitHub Actions runs the script and opens a PR if the diff is non-trivial.
+
+3. **Privacy: do we want fajr to NEVER log lat/lon, even in dev tooling?** Apps integrating fajr will pass user GPS. fajr currently does not log; the proposal preserves that. Worth an explicit assertion in the README ("fajr never persists, transmits, or logs the coordinates passed to it"). **Recommendation:** add the assertion to README API stability section.
+
+4. **Multi-method-split city overrides — how aggressive?** The override list above (~25 cities) is the conservative subset where institutional citations are findable in <30 minutes per city. The "be more aggressive" hunting principle (`feedback_aggressive_data_hunt`) argues for pushing harder on Lucknow's Imam-e-Juma timetable, Kerala Samastha's published Imsakiyya, KRG religious affairs — each could yield a verified citation with another hour of research per city. **Recommendation:** ship v1.7.0 with the 12 override cities that have firm citations now (Mosul Karachi, Najaf/Karbala/Basra Tehran, Sarajevo/Mostar/Banja Luka Diyanet, Bradford MCM, Pristina Diyanet, Beirut Egyptian explicit, Tabriz Tehran explicit) and queue the remaining ~13 (Lucknow, Kerala, TN, Pattani, Bangsamoro, Sulaymaniyah, Erbil, Detroit/Dearborn-Shia, etc.) for v1.7.1 with a research log per city in `autoresearch/logs/`.
+
+5. **`recommendedMethod` as a string vs a structured object?** The proposal returns the method as a string key (e.g. `'Karachi'`). An alternative is to return the full method params object inline. **Recommendation:** keep it as a string key — it composes with the existing `method` override on `prayerTimes` and avoids leaking adhan.js internals. The full params live in `selectMethod`.
+
+6. **`altMethods.populationShare` — overstating precision?** Citing "27% of Beirut Muslims follow Tehran" implies a rigour we may not have. **Recommendation:** make the field optional and only populate when a credible estimate is available; otherwise omit. Surface "alt method exists" without quantifying — let apps decide whether to render the percentage.
+
+---
+
+## Effort estimate
+
+- Build-script + registry data assembly: **8–12 hours** (most of this is hunting verified citations for the ~12 override cities).
+- Engine integration (`detectLocation`, `selectMethod` extension, `prayerTimes` threading): **3 hours**.
+- TypeScript types: **1 hour**.
+- Tests (~20 high-stakes cities): **2 hours**.
+- README recipe + CHANGELOG: **1 hour**.
+- Wiki page draft (human writes; agent provides skeleton): **2 hours**.
+- Eval validation + ratchet sweep: **1 hour**.
+
+**Total: ~18–22 hours.** Half is research (citations); half is implementation.
+
+---
+
+## Recommended approval/iterate path
+
+1. **Human reviews tensions 1–6 above.** Decisions on inline-vs-lazy, override aggressiveness, and `populationShare`. The other tensions are calls of degree, not direction.
+2. **Approval gate:** human signs off on the override list (which 12 cities ship with city-level institutional dispatch).
+3. **Implementation:** fajr-agent executes the build-script + engine changes per the plan above.
+4. **Eval ratchet:** run `node eval/eval.js && node eval/compare.js`. Per-cell ratchet enforced. If any cell regresses, revert the offending override and queue for follow-up.
+5. **Cross-repo announcement:** `gh issue create --repo tawfeeqmartin/agiftoftime` titled `[fajr↔agiftoftime] v1.7.0 released — detectLocation API`. Concrete asks: "Render `location.city.name` in the location-picker UI; render `location.altMethods` as a 'see also' chip in the method-display sheet; report whether `location.source.institution` text reads usefully in the long-press provenance sheet at Cape Town / Mosul / Sarajevo test coords." Sign as `— fajr-agent`.
+
+— fajr-agent


### PR DESCRIPTION
Durable persistence of two research/design proposals produced today. No code changes — proposals only. See commit message for details. Implementation gated on user approval per CLAUDE.md Layer 4.

— fajr-agent