### PR TITLE
chore: bump to 1.6.4 — 85-country gap close

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tawfeeqmartin/fajr",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "High-accuracy Islamic prayer time library combining NASA/JPL astronomical algorithms with classical Islamic scholarship",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
Trivial version bump. v1.6.2 PR (#27) merged with version field at 1.6.3 (matched master after #24 alias-norm landed first). The 85-country gap close warrants a new tag for npm consumers — bumping to 1.6.4. Tag will be pushed after merge.

— fajr-agent