### PR TITLE
chore: bump to 1.6.5 — v1.6.4 ghosted (publish failed on leaked test)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tawfeeqmartin/fajr",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "High-accuracy Islamic prayer time library combining NASA/JPL astronomical algorithms with classical Islamic scholarship",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
v1.6.4 publish workflow failed on the leaked detectLocation.test.js (hotfixed in #30 but tag had already been pushed). Bump to 1.6.5; tag against post-hotfix master.

— fajr-agent