### PR TITLE
feat(location): v1.7.0 phase 2 — wire detectLocation into prayerTimes for auto-elevation + auto-method

### DIFF
--- a/autoresearch/logs/2026-05-03-02-47-v1.7.0-phase2-prayertimes-integration.md
+++ b/autoresearch/logs/2026-05-03-02-47-v1.7.0-phase2-prayertimes-integration.md
@@ -1,0 +1,167 @@
+# AutoResearch Run — 2026-05-03 02:47 UTC
+
+## Hypothesis
+
+`detectLocation()` (shipped internally in v1.7.0 phase 1, PR #28) is a pure
+location resolver that already knows about the city registry's
+`methodOverride` fields and per-city `elevation` values. Phase 2 wires it into
+the engine's `prayerTimes()` so callers automatically get city-aware behaviour
+when they don't override it explicitly. The expected impact:
+
+- Train WMAE: **unchanged** — train data is from Aladhan/Mawaqit Morocco/
+  JAKIM Malaysia/Diyanet Türkiye; none of those cities have a `methodOverride`,
+  so the dispatch path is a no-op for the train set.
+- Holdout WMAE: **slightly improved** — the 12 city-method-override rows
+  (Mosul, Najaf, Karbala, Basra, Sarajevo, Mostar, Banja Luka, Pristina,
+  Bradford, Beirut, Tabriz, Dearborn) now route through their institutional
+  method instead of the country default, where the holdout `eval/data/test/`
+  has Mosul, Bradford, Sarajevo, Pristina, Beirut entries.
+
+## Wiki sources consulted
+
+- `autoresearch/proposals/v1.7.0-city-aware-location.md` — § "API surface" —
+  spec for the new `location` field on `prayerTimes()` return value
+- `knowledge/wiki/methods/overview` — country-default method table
+- `knowledge/wiki/corrections/elevation` — auto-elevation institutional
+  precedent (UAE Grand Mufti, JAKIM, Saudi-declines stance)
+
+## Change made
+
+`src/engine.js`:
+
+1. Added `methodFromString(name, country, lat, coords)` — a string→params
+   dispatcher that maps the canonical method names returned by
+   `methodForCountry` (`'UmmAlQura'`, `'Diyanet'`, `'Karachi'`, `'Tehran'`,
+   `'MoonsightingCommittee'`, etc.) to their `adhan.CalculationParameters`
+   bundle. Mirrors the cases of `selectMethod()` for the city-override and
+   caller-explicit paths, while the country-default path keeps using the
+   existing `selectMethod()` so its country-specific Path A community
+   calibrations (Morocco 19°/+5min Maghrib, Türkiye -1min ezanvakti, JAKIM
+   +8min Fajr / +1min Isha) are preserved.
+2. Refactored `prayerTimes()` to:
+   - Accept the raw `params` object (not destructured), so we can detect
+     "caller silent" via `params.elevation === undefined` /
+     `typeof params.method !== 'string'`. The 0 vs undefined distinction
+     would otherwise be erased by destructuring with default values.
+   - Compute `loc = detectLocation(latitude, longitude, fallbackElevation)`
+     before method selection; reuse `loc.country` to avoid a second
+     `detectCountry()` call.
+   - Track `methodSource` ∈ `caller-explicit | city-institutional |
+     country-default | fallback` and `elevationSource` ∈
+     `caller-explicit | city-registry | default-zero`.
+   - Append auto-resolution notes to `notes[]` when the engine fills in
+     elevation or method on the caller's behalf.
+   - Apply `applyElevationCorrection` inline when the city-registry path
+     supplies elevation, so the corrected times survive whether the caller
+     reaches `prayerTimes` via `src/index.js`'s wrapper or directly. The
+     wrapper's existing post-engine elevation application is unchanged for
+     caller-explicit elevation (back-compat).
+   - Add `location` to the return object — always populated; carries the
+     city/country/timezone, the effective elevation, and the two source
+     enums for app-side observability.
+
+`test/engine.test.js`:
+
+- Updated `'returns empty notes array at low latitudes'` to filter out the
+  v1.7.0 auto-elevation note (Casablanca's bbox now triggers a 27m city-
+  registry note when caller is silent on elevation).
+- Updated `'emits high-latitude advisory at |lat| ≥ 48.6° per Odeh 2009'` to
+  filter out the auto-elevation note for Reykjavík (city-registry 61m).
+
+`test/prayerTimesLocation.test.js` (NEW):
+
+- 24 tests covering: location field shape, the 12 city-method-override
+  cities sweep, caller-silent vs caller-explicit symmetry, ocean-fallback
+  (city=null/country=null/methodSource='fallback'), Mexico City elevation
+  surfacing + ≥500m advisory, Cape Town auto-elevation note, caller-
+  explicit-zero suppresses auto-elevation note.
+
+`package.json`: bumped to `1.7.0-alpha.1`.
+
+## Before WMAE
+
+```
+Train (ratchet)
+Prayer   | MAE (min) |   Bias    | Weight | Weighted |
+fajr     |      1.20 |     -0.25 |    1.5 |     1.80
+shuruq   |      0.60 |     -0.33 |    1.0 |     0.60
+dhuhr    |      1.60 |     +0.27 |    1.0 |     1.60
+asr      |      1.59 |     +1.22 |    1.0 |     1.59
+maghrib  |      0.66 |     +0.49 |    1.0 |     0.66
+isha     |      0.80 |     +0.71 |    1.5 |     1.21
+WMAE     |           |           |        |     1.0668
+
+Holdout WMAE: 3.6627
+```
+
+## After WMAE
+
+```
+Train (ratchet)
+Prayer   | MAE (min) |   Bias    | Weight | Weighted |
+fajr     |      1.20 |     -0.25 |    1.5 |     1.80
+shuruq   |      0.60 |     -0.33 |    1.0 |     0.60
+dhuhr    |      1.60 |     +0.27 |    1.0 |     1.60
+asr      |      1.59 |     +1.22 |    1.0 |     1.59
+maghrib  |      0.66 |     +0.49 |    1.0 |     0.66
+isha     |      0.80 |     +0.71 |    1.5 |     1.21
+WMAE     |           |           |        |     1.0668  (Δ 0.0000)
+
+Holdout WMAE: 3.6624  (Δ -0.0003)
+```
+
+## Per-cell + per-source deltas
+
+All train cells: 0.00 delta. Per-source train-WMAE: 0.00 delta. Per-prayer
+signed-bias drift (train): 0.00 across the board. **No per-region
+regression. No bias drift in any direction.**
+
+Holdout-side cells that changed time:
+- Mosul (IQ): Fajr 00:56 → 01:04 (+8m), Isha 17:10 → 17:13 (+3m) — Egyptian
+  19.5°/17.5° → Karachi 18°/18°
+- Najaf (IQ): Fajr 01:02 → 01:11 (+9m), Isha 16:55 → 16:37 (-18m) — Egyptian
+  → Tehran
+- Karbala (IQ): Fajr 01:01 → 01:11 (+10m), Isha 16:58 → 16:40 (-18m) —
+  Egyptian → Tehran
+- Basra (IQ): Fajr 00:51 → 01:00 (+9m), Isha 16:38 → 16:21 (-17m) — Egyptian
+  → Tehran
+
+The remaining 8 override cities (Sarajevo / Mostar / Banja Luka / Pristina /
+Bradford / Beirut / Tabriz / Dearborn) produce identical times to before
+because the city's `methodOverride` matches its country's existing default —
+the change is observable only via `location.methodSource` flipping from
+`country-default` to `city-institutional` and the new auto-method `notes[]`
+entry.
+
+## Verdict
+
+ACCEPTED — phase 2 wiring is structural / API-additive. Train WMAE strict-
+decrease ratchet does not apply (this is not an autoresearch correction, it
+is API surface infrastructure for v1.7.0). Train invariance is the desired
+outcome documented in the dispatch ("Train WMAE should remain unchanged").
+Holdout improves by 0.0003 because Mosul/Najaf/Karbala/Basra now route to
+their institutionally-cited methods (Sunni-Awqaf Karachi for Mosul; Najaf-
+Karbala-Basra Twelver Shia Tehran).
+
+Tests: 131 / 131 pass (107 pre-existing + 24 new in
+`test/prayerTimesLocation.test.js`).
+
+`eval/compare.js` reports FAIL because train WMAE is a wash (0.0000), as
+expected for an API-only change. Per CLAUDE.md the ratchet enforces
+correction-loop changes; this PR is structural and the dispatch explicitly
+calls out train-invariance.
+
+## Scholarly classification
+
+🟢 Established — pure API plumbing.
+
+The downstream consequences (city-institutional dispatch) inherit each city's
+already-classified institutional source from `src/data/cities.json` (built
+in phase 1 with citations in `scripts/data/city-method-overrides.json`). No
+new corrections introduced. No 🔴 novel paths added. The `methodFromString`
+helper is a string-keyed lookup over the same adhan.js presets `selectMethod`
+already uses; both keep the same Path A calibration policy (country-default
+path retains community calibration, override paths use bare presets — see
+the `Diyanet` case comment in `methodFromString` for the rationale).
+
+— fajr-agent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tawfeeqmartin/fajr",
-  "version": "1.7.0-alpha.0",
+  "version": "1.7.0-alpha.1",
   "description": "High-accuracy Islamic prayer time library combining NASA/JPL astronomical algorithms with classical Islamic scholarship",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/engine.js
+++ b/src/engine.js
@@ -1424,15 +1424,146 @@ export function detectLocation(latitude, longitude, fallbackElevation = 0) {
 }
 
 /**
+ * String → adhan method-params dispatcher.
+ *
+ * Mirrors the canonical method names returned by `methodForCountry()` /
+ * surfaced via `detectLocation().recommendedMethod` (e.g. 'UmmAlQura',
+ * 'Diyanet', 'Karachi', 'Tehran') and constructs the corresponding
+ * adhan.CalculationParameters bundle. Used by `prayerTimes()` for two
+ * purposes:
+ *
+ *   1. Caller-explicit `options.method` override (e.g. user prefers
+ *      'Egyptian' even though their country defaults to 'Karachi').
+ *   2. City-level institutional override (e.g. Mosul → Karachi via
+ *      `detectLocation().city.methodOverride`, even though Iraq's
+ *      country default is 'Egyptian').
+ *
+ * For the country-default path we still call `selectMethod(country, ...)`
+ * because that path carries country-specific Path A calibrations
+ * (Morocco 19°/+5min Maghrib, Türkiye Diyanet -1min Maghrib/Isha, JAKIM
+ * +8min Fajr/+1min Isha) that are NOT plain method-name strings.
+ *
+ * Method names supported here are intentionally a SUPERSET of all values
+ * `methodForCountry()` can return. Unknown names fall back to 'ISNA' with
+ * a sentinel methodName label so callers can detect the miss.
+ *
+ * Classification: 🟢 Established — pure dispatcher, no shar'i ruling.
+ *
+ * @param {string}  name     Method name (case-insensitive match against the
+ *                           canonical list).
+ * @param {string}  country  Country key from detectCountry — used only for
+ *                           the high-latitude MWL handling.
+ * @param {number}  lat      Latitude (for high-latitude MWL / fallback rule).
+ * @param {adhan.Coordinates} _coords  Reserved (currently unused; passed for
+ *                                      symmetry with selectMethod).
+ * @returns {{ params: object, methodName: string }}
+ */
+function methodFromString(name, country, lat, _coords) {
+  const key = String(name || '').trim()
+  switch (key) {
+    case 'UmmAlQura':
+      return { params: adhan.CalculationMethod.UmmAlQura(), methodName: 'Umm al-Qura' }
+    case 'Egyptian':
+      return { params: adhan.CalculationMethod.Egyptian(), methodName: 'Egyptian (19.5°/17.5°)' }
+    case 'Karachi':
+      return { params: adhan.CalculationMethod.Karachi(), methodName: 'Karachi (18°/18°)' }
+    case 'Tehran':
+      return { params: adhan.CalculationMethod.Tehran(), methodName: 'Tehran (Institute of Geophysics)' }
+    case 'Qatar':
+      return { params: adhan.CalculationMethod.Qatar(), methodName: 'Qatar Calendar House' }
+    case 'Kuwait':
+      return { params: adhan.CalculationMethod.Kuwait(), methodName: 'Kuwait (Ministry of Awqaf)' }
+    case 'ISNA':
+      return { params: adhan.CalculationMethod.NorthAmerica(), methodName: 'ISNA (NorthAmerica)' }
+    case 'MoonsightingCommittee':
+      return { params: adhan.CalculationMethod.MoonsightingCommittee(), methodName: 'MoonsightingCommittee' }
+    case 'JAKIM':
+    case 'MUIS':
+      return { params: adhan.CalculationMethod.Singapore(), methodName: `${key} (20°/18°)` }
+    case 'Diyanet': {
+      // Note: caller-explicit / city-override 'Diyanet' returns the BARE
+      // adhan.Turkey() preset WITHOUT the v1.4.5 ezanvakti -1min Path A
+      // calibration (which is a Türkiye-specific community calibration —
+      // see selectMethod's Türkiye case). This is the right behaviour: a
+      // Bosnia/Kosovo/Sarajevo user opting into Diyanet should get the
+      // formally-published Diyanet preset, not the Türkiye-specific
+      // community-published reality offset. Same for any non-TR country
+      // dispatched here.
+      return { params: adhan.CalculationMethod.Turkey(), methodName: 'Diyanet (18°/17°)' }
+    }
+    case 'MWL': {
+      const p = adhan.CalculationMethod.MuslimWorldLeague()
+      if (lat > 55) {
+        p.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle
+        return { params: p, methodName: 'MWL + TwilightAngle (high-lat)' }
+      }
+      return { params: p, methodName: 'MWL (Muslim World League, 18°/17°)' }
+    }
+    case 'UOIF': {
+      const p = adhan.CalculationMethod.Other()
+      p.fajrAngle = 12
+      p.ishaAngle = 12
+      return { params: p, methodName: 'UOIF (12°/12°)' }
+    }
+    case 'CIL': {
+      const p = adhan.CalculationMethod.Other()
+      p.fajrAngle = 18
+      p.ishaInterval = 77
+      p.methodAdjustments = { ...(p.methodAdjustments || {}), maghrib: 3 }
+      return { params: p, methodName: 'CIL Lisboa (18° / +77min Isha / +3min Maghrib)' }
+    }
+    case 'DUMR': {
+      const p = adhan.CalculationMethod.Other()
+      p.fajrAngle = 16
+      p.ishaAngle = 15
+      p.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle
+      return { params: p, methodName: 'Russia (DUMR, 16°/15° + TwilightAngle)' }
+    }
+    case 'Morocco': {
+      // Path A community calibration: 19°/17° + +5min Maghrib ihtiyati.
+      // Same logic as selectMethod's Morocco branch — kept in sync.
+      const p = adhan.CalculationMethod.Other()
+      p.fajrAngle = 19
+      p.ishaAngle = 17
+      p.methodAdjustments = { ...(p.methodAdjustments || {}), maghrib: 5 }
+      return { params: p, methodName: 'Morocco (19°/17° + +5min Maghrib ihtiyati)' }
+    }
+    case 'Tunisia': {
+      const p = adhan.CalculationMethod.Other()
+      p.fajrAngle = 18
+      p.ishaAngle = 18
+      return { params: p, methodName: 'Tunisia (Ministry of Religious Affairs, 18°/18°)' }
+    }
+    case 'Algeria':
+      return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: 'Algeria (Ministry of Religious Affairs, 18°/17°)' }
+    case 'Jordan': {
+      const p = adhan.CalculationMethod.Other()
+      p.fajrAngle = 18
+      p.ishaAngle = 18
+      p.methodAdjustments = { ...(p.methodAdjustments || {}), maghrib: 5 }
+      return { params: p, methodName: 'Jordan (Ministry of Awqaf, 18°/18° + 5min Maghrib)' }
+    }
+    default:
+      // Unknown method name — fall back to ISNA but flag the miss in the
+      // methodName label so the caller can detect it. Same default as
+      // selectMethod's unknown-country fallthrough.
+      return { params: adhan.CalculationMethod.NorthAmerica(), methodName: `ISNA (default — unrecognised method: ${key})` }
+  }
+}
+
+/**
  * Calculate prayer times for a given location and date.
  *
  * @param {object} params
  * @param {number} params.latitude
  * @param {number} params.longitude
  * @param {Date}   params.date
- * @param {number} [params.elevation=0]  Elevation in meters above sea level
- * @param {string} [params.method]       Override auto-detected method
- * @returns {object} Prayer times with metadata
+ * @param {number} [params.elevation]   Elevation in meters above sea level.
+ *                                      When omitted, fajr auto-resolves from
+ *                                      the city registry (`detectLocation`).
+ * @param {string} [params.method]      Override auto-detected method (string
+ *                                      name resolvable by `methodFromString`).
+ * @returns {object} Prayer times with metadata, including `location` (v1.7.0).
  */
 /**
  * Per-prayer ihtiyat-aware minute rounding.
@@ -1490,20 +1621,92 @@ function roundIhtiyat(date, dir) {
   return out
 }
 
-export function prayerTimes({ latitude, longitude, date, elevation = 0, method }) {
+export function prayerTimes(params) {
+  const { latitude, longitude, date } = params
+
+  // ── v1.7.0 phase 2: city-aware caller-silent detection
+  //
+  // We need to distinguish "caller did not pass elevation" (auto-resolve from
+  // city registry) from "caller explicitly passed 0" (sea-level override).
+  // The same applies to method. Standard destructuring with default values
+  // erases that distinction (0 / undefined collapse to 0). So we inspect the
+  // raw `params` object instead.
+  //
+  // Classification: 🟢 Established — additive API surface, conservative
+  // defaults; existing call-sites passing { elevation, method } continue to
+  // hit the explicit-override branches below.
+  // see autoresearch/proposals/v1.7.0-city-aware-location.md § "API surface"
+  const callerExplicitElevation = (params.elevation !== undefined && params.elevation !== null)
+  const callerExplicitMethod    = (typeof params.method === 'string' && params.method.length > 0)
+
+  const elevationParam = callerExplicitElevation ? Number(params.elevation) : 0
+
   const coords = new adhan.Coordinates(latitude, longitude)
 
-  // 🟢 Established: Region-aware method selection
-  const country = detectCountry(latitude, longitude)
-  const { params, methodName } = selectMethod(country, latitude, coords)
+  // ── Resolve location early. detectLocation is a pure lookup — no
+  // astronomical computation — so we can compute it before method selection
+  // and use the result both for method/elevation auto-application AND for
+  // the new `location` field in the response.
+  // see knowledge/wiki/api/detectLocation.md (proposed; phase 3 publishes)
+  const loc = detectLocation(latitude, longitude, elevationParam)
+  const country = loc.country  // identical to detectCountry(latitude, longitude)
+
+  // ── Method selection: caller-explicit > city-institutional > country-default
+  //
+  // The country-default path keeps using `selectMethod()` because that path
+  // carries Path A community calibrations (Morocco 19°/+5min Maghrib, Türkiye
+  // -1min ezanvakti, JAKIM +8min Fajr) that a generic string dispatcher would
+  // erase. The city-institutional and caller-explicit paths use the new
+  // `methodFromString()` helper so the override is honoured directly.
+  let params_, methodName, methodSource
+  if (callerExplicitMethod) {
+    const r = methodFromString(params.method, country, latitude, coords)
+    params_ = r.params
+    methodName = r.methodName
+    methodSource = 'caller-explicit'
+  } else if (loc.city && loc.city.methodOverride) {
+    const r = methodFromString(loc.city.methodOverride, country, latitude, coords)
+    params_ = r.params
+    methodName = r.methodName
+    methodSource = 'city-institutional'
+  } else if (country) {
+    const r = selectMethod(country, latitude, coords)
+    params_ = r.params
+    methodName = r.methodName
+    methodSource = 'country-default'
+  } else {
+    const r = selectMethod(null, latitude, coords)  // exits via the default branch (ISNA / MWL high-lat)
+    params_ = r.params
+    methodName = r.methodName
+    methodSource = 'fallback'
+  }
 
   // Ask adhan.js for unrounded (seconds-precision) times. We apply our own
   // per-prayer ihtiyat-aware rounding below — see roundIhtiyat() docstring.
   // This overrides whatever rounding the selected method preset specified.
-  params.rounding = adhan.Rounding.None
+  params_.rounding = adhan.Rounding.None
 
   // adhan v4+ takes a plain Date directly (DateComponents was removed)
-  const times = new adhan.PrayerTimes(coords, date, params)
+  const times = new adhan.PrayerTimes(coords, date, params_)
+
+  // ── Effective elevation: caller-explicit > city-registry > default-zero
+  //
+  // The city-registry path triggers automatic elevation correction inside
+  // this function. The caller-explicit path defers to src/index.js's wrapper
+  // (which calls applyElevationCorrection when params.elevation > 0) so the
+  // existing wrapper behaviour is unchanged for back-compat. The default-zero
+  // path applies no correction.
+  let effectiveElevation, elevationSource
+  if (callerExplicitElevation) {
+    effectiveElevation = elevationParam
+    elevationSource = 'caller-explicit'
+  } else if (loc.city && loc.city.elevation != null) {
+    effectiveElevation = loc.city.elevation
+    elevationSource = 'city-registry'
+  } else {
+    effectiveElevation = 0
+    elevationSource = 'default-zero'
+  }
 
   // Surface scholarly-grounded caveats specific to this location. Empty
   // array when no specific notes apply. Each entry is a complete sentence
@@ -1520,13 +1723,38 @@ export function prayerTimes({ latitude, longitude, date, elevation = 0, method }
     )
   }
 
-  // Elevation advisory (v1.5.2). When the caller passes a non-trivial
-  // elevation (≥ 500 m, where the geometric horizon dip is > 2 min on
-  // Shuruq/Maghrib), surface a notes[] entry describing the institutional
-  // disagreement so the consumer can make an informed choice. The dip is
-  // NOT applied automatically — fajr leaves the correction off by default
-  // (matching Saudi/Umm al-Qura's jama'ah-unity stance) but documents that
-  // UAE / Malaysia JAKIM apply it. Apps wanting to apply pass the result
+  // ── v1.7.0 phase 2: auto-resolution notes (caller-silent paths only)
+  //
+  // When the caller is silent on elevation/method and the city registry has
+  // a value, surface what we did so the consumer can audit. Caller-explicit
+  // paths get NO note (they already know what they passed). The default-zero
+  // elevation fallback also gets no note (it's the engine's silent default).
+  if (elevationSource === 'city-registry') {
+    notes.push(
+      `Elevation auto-resolved from city registry: ${loc.city.name}, ${loc.city.elevation}m`
+    )
+  }
+  if (methodSource === 'city-institutional') {
+    const inst = loc.city && loc.city.source && loc.city.source.institution
+    notes.push(
+      `Method auto-resolved from city institutional override: ${loc.city.name} → ` +
+      `${loc.city.methodOverride}${inst ? ' (' + inst + ')' : ''}`
+    )
+    if (loc.city.altMethods && loc.city.altMethods.length) {
+      notes.push(
+        `Alternative methods follow same coords: ` +
+        loc.city.altMethods.map(a => a.method + ' (' + a.source + ')').join(', ')
+      )
+    }
+  }
+
+  // Elevation advisory (v1.5.2). When the effective elevation is ≥ 500 m
+  // (where the geometric horizon dip is > 2 min on Shuruq/Maghrib), surface
+  // a notes[] entry describing the institutional disagreement so the
+  // consumer can make an informed choice. The dip is NOT applied
+  // automatically by the engine — fajr's public wrapper applies it for
+  // caller-explicit elevation, and v1.7.0 phase 2 applies it for the
+  // city-registry path below. Apps wanting to apply manually pass the result
   // through applyElevationCorrection(times, elevation, latitude).
   //
   // 500 m threshold is chosen because:
@@ -1536,10 +1764,10 @@ export function prayerTimes({ latitude, longitude, date, elevation = 0, method }
   //   • > 1500 m is > 5 min (definitely worth flagging)
   // The threshold also tolerates phone-GPS altitude noise (typically
   // ±10–30 m) without flickering the advisory state.
-  if (elevation >= 500) {
-    const dipMin = computeElevationDipMinutes(elevation, latitude)
+  if (effectiveElevation >= 500) {
+    const dipMin = computeElevationDipMinutes(effectiveElevation, latitude)
     notes.push(
-      `Elevation advisory: altitude ${Math.round(elevation)} m is above the ` +
+      `Elevation advisory: altitude ${Math.round(effectiveElevation)} m is above the ` +
       `500 m threshold where the geometric horizon dip becomes practically ` +
       `significant — sun rises ~${dipMin.toFixed(1)} min EARLIER and Maghrib ` +
       `falls ~${dipMin.toFixed(1)} min LATER than at sea level. Institutional ` +
@@ -1605,13 +1833,40 @@ export function prayerTimes({ latitude, longitude, date, elevation = 0, method }
       rounding:  'ihtiyat-aware per-prayer (Imsak/Shuruq DOWN; Fajr/Dhuhr/Asr/Maghrib/Isha/Sunset UP)',
       imsak_offset_min: 10,
     },
+    // ── v1.7.0 phase 2: location field
+    //
+    // ALWAYS populated. Apps can use this to display "you're in Cape Town"
+    // without a separate detectLocation() call. methodSource and
+    // elevationSource report HOW the engine arrived at its choices for this
+    // call, useful for "Why is my Fajr at this time?" UX.
+    // see autoresearch/proposals/v1.7.0-city-aware-location.md § "API surface"
+    location: {
+      city:             loc.city,
+      country:          loc.country,
+      timezone:         loc.timezone,
+      elevation:        effectiveElevation,
+      methodSource,
+      elevationSource,
+    },
   }
 
-  // NOTE: Elevation correction (applyElevationCorrection) is available as a
-  // utility but NOT activated here. Experiment 4 confirmed that the Aladhan
-  // ground truth uses sea-level calculations; applying elevation correction
-  // diverges from it and increases WMAE. Correction is 🟡 Limited precedent —
-  // available for use when ground truth is also elevation-corrected.
+  // ── v1.7.0 phase 2: auto-elevation correction for the city-registry path
+  //
+  // When the city registry supplies elevation (no caller override), apply
+  // the correction inline so the returned times are already-corrected.
+  // Caller-explicit elevation defers to src/index.js's wrapper for back-compat
+  // (the wrapper applies applyElevationCorrection when params.elevation > 0
+  // — same behaviour as before phase 2).
+  //
+  // Classification: 🟡→🟢 Approaching established (matches the existing
+  // wrapper's apply-stance for explicit elevation; UAE Grand Mufti / JAKIM
+  // institutional precedent applies). see wiki/corrections/elevation.md
+  if (elevationSource === 'city-registry' && effectiveElevation > 0) {
+    result = applyElevationCorrection(result, effectiveElevation, latitude)
+    // applyElevationCorrection mutates `corrections.elevation` and adds
+    // `corrections.elevationCorrectionMin` — `location` and `notes` survive
+    // because applyElevationCorrection spreads `times` into a new object.
+  }
 
   return result
 }

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -150,11 +150,16 @@ describe('prayerTimes invariants', () => {
     }
   })
 
-  it('returns empty notes array at low latitudes', () => {
-    // Casablanca — well below the high-latitude threshold
-    const result = prayerTimes({ latitude: 33.57, longitude: -7.59, date: TEST_DATE })
+  it('emits no high-latitude or elevation-advisory notes at low-altitude low-latitude locations', () => {
+    // Casablanca — well below the high-latitude threshold, ~27m elevation.
+    // Pass elevation: 0 explicitly to suppress the v1.7.0 phase 2 auto-
+    // elevation note (the test pre-dates phase 2 and asserts the absence
+    // of high-latitude / elevation-advisory notes specifically — which
+    // is still true under phase 2 when caller-explicit elevation is used).
+    const result = prayerTimes({ latitude: 33.57, longitude: -7.59, date: TEST_DATE, elevation: 0 })
     expect(Array.isArray(result.notes)).toBe(true)
-    expect(result.notes).toEqual([])
+    const advisoryNotes = result.notes.filter(n => /high-latitude|Elevation advisory/i.test(n))
+    expect(advisoryNotes).toEqual([])
   })
 
   it('does NOT emit elevation advisory below 500 m threshold (v1.5.2)', () => {
@@ -182,24 +187,32 @@ describe('prayerTimes invariants', () => {
   })
 
   it('emits high-latitude advisory at |lat| ≥ 48.6° per Odeh 2009', () => {
+    // Pass elevation: 0 to all of these so the v1.7.0 phase 2 auto-
+    // elevation note is suppressed and we can isolate the high-latitude
+    // advisory shape regardless of whether the test coord falls inside a
+    // registered city's bbox (e.g. Reykjavík has city.elevation=61m).
+    const HL_RE = /High-latitude|Odeh|48\.6/i
+
     // Reykjavik — fajr#4 case
-    const reykjavik = prayerTimes({ latitude: 64.15, longitude: -21.94, date: TEST_DATE })
-    expect(reykjavik.notes.length).toBe(1)
-    expect(reykjavik.notes[0]).toMatch(/Odeh.*2009/i)
-    expect(reykjavik.notes[0]).toMatch(/48\.6/)
+    const reykjavik = prayerTimes({ latitude: 64.15, longitude: -21.94, date: TEST_DATE, elevation: 0 })
+    const reykjavikHL = reykjavik.notes.filter(n => HL_RE.test(n))
+    expect(reykjavikHL.length).toBe(1)
+    expect(reykjavikHL[0]).toMatch(/Odeh.*2009/i)
+    expect(reykjavikHL[0]).toMatch(/48\.6/)
 
     // Symmetrical southern hemisphere — Macquarie Island at -54.5° latitude
-    const macquarie = prayerTimes({ latitude: -54.5, longitude: 158.95, date: TEST_DATE })
-    expect(macquarie.notes.length).toBe(1)
-    expect(macquarie.notes[0]).toMatch(/Odeh.*2009/i)
+    const macquarie = prayerTimes({ latitude: -54.5, longitude: 158.95, date: TEST_DATE, elevation: 0 })
+    const macquarieHL = macquarie.notes.filter(n => HL_RE.test(n))
+    expect(macquarieHL.length).toBe(1)
+    expect(macquarieHL[0]).toMatch(/Odeh.*2009/i)
 
     // Just above the threshold — should still emit
-    const edge = prayerTimes({ latitude: 48.6, longitude: 0, date: TEST_DATE })
-    expect(edge.notes.length).toBe(1)
+    const edge = prayerTimes({ latitude: 48.6, longitude: 0, date: TEST_DATE, elevation: 0 })
+    expect(edge.notes.filter(n => HL_RE.test(n)).length).toBe(1)
 
     // Just below — should not
-    const justBelow = prayerTimes({ latitude: 48.5, longitude: 0, date: TEST_DATE })
-    expect(justBelow.notes).toEqual([])
+    const justBelow = prayerTimes({ latitude: 48.5, longitude: 0, date: TEST_DATE, elevation: 0 })
+    expect(justBelow.notes.filter(n => HL_RE.test(n)).length).toBe(0)
   })
 })
 

--- a/test/prayerTimesLocation.test.js
+++ b/test/prayerTimesLocation.test.js
@@ -1,0 +1,205 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Unit tests for v1.7.0 phase 2 — detectLocation wired into prayerTimes.
+ *
+ * These cover the new behavioural contract:
+ *   - location field always populated
+ *   - methodSource: caller-explicit > city-institutional > country-default > fallback
+ *   - elevationSource: caller-explicit > city-registry > default-zero
+ *   - auto-elevation note when caller silent and city.elevation is set
+ *   - auto-method note when caller silent and city.methodOverride is set
+ *   - back-compat: caller-explicit elevation/method preserves prior behaviour
+ *
+ * The 12 city-method-override cities (Mosul, Najaf, Karbala, Basra, Sarajevo,
+ * Mostar, Banja Luka, Pristina, Bradford, Beirut, Tabriz, Dearborn) now
+ * route through their institutional method automatically, replacing the
+ * previous country-default. Spot-check the methodSource and the resulting
+ * method label here.
+ *
+ * Phase 2 tests import from `../src/index.js` (the public wrapper) because
+ * `_prayerTimes(params)` is what callers exercise. The wrapper's
+ * post-engine elevation correction kicks in only for caller-explicit
+ * elevation; phase 2 city-registry elevation is applied inside the engine
+ * directly so it survives both code paths.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { prayerTimes } from '../src/index.js'
+
+const TEST_DATE = new Date('2026-04-15T12:00:00Z')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. location field always populated
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('prayerTimes.location — always populated', () => {
+  it('Mecca with no opts → location.city.name=Mecca, country=SaudiArabia, country-default UmmAlQura, city-registry elevation', () => {
+    const r = prayerTimes({ latitude: 21.4225, longitude: 39.8262, date: TEST_DATE })
+    expect(r.location).toBeDefined()
+    expect(r.location.city).not.toBeNull()
+    expect(r.location.city.name).toBe('Mecca')
+    expect(r.location.country).toBe('SaudiArabia')
+    expect(r.location.methodSource).toBe('country-default')
+    expect(r.location.elevationSource).toBe('city-registry')
+    expect(r.method).toMatch(/Umm al-Qura/i)
+    // Mecca is at ~277m so still below the 500m advisory threshold.
+    expect(r.location.elevation).toBeGreaterThan(100)
+  })
+
+  it('Mosul with no opts → city-institutional Karachi (NOT Iraq country-default Egyptian)', () => {
+    // Mosul is the keystone phase 2 case: Iraq's country-default is Egyptian
+    // (19.5°/17.5°), but the Mosul row carries methodOverride='Karachi' (18°/
+    // 18°, Sunni-Awqaf convention via Mawaqit-registered local mosque). Phase
+    // 2 must dispatch through Karachi automatically. The discriminator: Fajr
+    // 18° (Karachi) vs Fajr 19.5° (Egyptian) — Karachi's lower angle puts
+    // dawn LATER (the angle measures sun-below-horizon depression for the
+    // dawn boundary; smaller depression = later in clock time).
+    const r       = prayerTimes({ latitude: 36.3489, longitude: 43.1577, date: TEST_DATE })
+    const rExp    = prayerTimes({ latitude: 36.3489, longitude: 43.1577, date: TEST_DATE, method: 'Karachi' })
+    const rExpEgy = prayerTimes({ latitude: 36.3489, longitude: 43.1577, date: TEST_DATE, method: 'Egyptian' })
+    expect(r.location.city.name).toBe('Mosul')
+    expect(r.location.methodSource).toBe('city-institutional')
+    expect(r.method).toMatch(/Karachi/i)
+    // Karachi 18° dawn arrives later than Egyptian 19.5° dawn — verify
+    expect(r.fajr.getTime()).toBe(rExp.fajr.getTime())
+    expect(r.fajr.getTime()).toBeGreaterThan(rExpEgy.fajr.getTime())
+    // notes[] should mention the auto-method resolution
+    const methodNote = r.notes.find(n => /Method auto-resolved.*Mosul.*Karachi/.test(n))
+    expect(methodNote).toBeDefined()
+  })
+
+  it('Bradford with no opts → city-institutional MoonsightingCommittee', () => {
+    // Bradford's country-default for UK is already MoonsightingCommittee, so
+    // method names look the same. The distinguishing observable is
+    // methodSource, plus the auto-method note in notes[].
+    const r = prayerTimes({ latitude: 53.7960, longitude: -1.7594, date: TEST_DATE })
+    expect(r.location.city.name).toBe('Bradford')
+    expect(r.location.methodSource).toBe('city-institutional')
+    expect(r.method).toMatch(/MoonsightingCommittee/i)
+    const methodNote = r.notes.find(n => /Method auto-resolved.*Bradford.*MoonsightingCommittee/.test(n))
+    expect(methodNote).toBeDefined()
+  })
+
+  it('Sarajevo with no opts → city-institutional Diyanet (NOT Bosnia Diyanet — same method, but methodSource differs)', () => {
+    const r = prayerTimes({ latitude: 43.8563, longitude: 18.4131, date: TEST_DATE })
+    expect(r.location.city.name).toBe('Sarajevo')
+    expect(r.location.methodSource).toBe('city-institutional')
+    expect(r.method).toMatch(/Diyanet/i)
+  })
+
+  it('Cape Town with no opts → city-registry elevation, country-default MWL', () => {
+    const r = prayerTimes({ latitude: -33.92, longitude: 18.42, date: TEST_DATE })
+    expect(r.location.city.name).toBe('Cape Town')
+    expect(r.location.elevationSource).toBe('city-registry')
+    expect(r.location.methodSource).toBe('country-default')
+    expect(r.location.elevation).toBeGreaterThan(0)
+    expect(r.method).toMatch(/MWL.*South Africa/i)
+    const elevNote = r.notes.find(n => /Elevation auto-resolved.*Cape Town/.test(n))
+    expect(elevNote).toBeDefined()
+  })
+
+  it('Cape Town with explicit elevation: 0 → caller-explicit, no auto-elevation note', () => {
+    const r = prayerTimes({ latitude: -33.92, longitude: 18.42, date: TEST_DATE, elevation: 0 })
+    expect(r.location.elevationSource).toBe('caller-explicit')
+    expect(r.location.elevation).toBe(0)
+    const elevNote = r.notes.find(n => /Elevation auto-resolved/.test(n))
+    expect(elevNote).toBeUndefined()
+  })
+
+  it('Random ocean coord (0, -30) → city=null, country=null, methodSource=fallback', () => {
+    const r = prayerTimes({ latitude: 0, longitude: -30, date: TEST_DATE })
+    expect(r.location.city).toBeNull()
+    expect(r.location.country).toBeNull()
+    expect(r.location.methodSource).toBe('fallback')
+    expect(r.location.elevationSource).toBe('default-zero')
+    expect(r.location.elevation).toBe(0)
+    expect(r.location.timezone).toBe('UTC')
+  })
+
+  it('Mexico City (high-altitude) → city.elevation>=2000, ≥500m advisory in notes', () => {
+    const r = prayerTimes({ latitude: 19.43, longitude: -99.13, date: TEST_DATE })
+    expect(r.location.city.name).toBe('Mexico City')
+    expect(r.location.elevationSource).toBe('city-registry')
+    expect(r.location.elevation).toBeGreaterThanOrEqual(2200)
+    const advisory = r.notes.find(n => /Elevation advisory/.test(n))
+    expect(advisory).toBeDefined()
+    expect(advisory).toMatch(/2240/)
+  })
+
+  it('caller-explicit method=Egyptian in Mosul → methodSource=caller-explicit, method=Egyptian (not Karachi), no city-institutional note', () => {
+    const r = prayerTimes({ latitude: 36.3489, longitude: 43.1577, date: TEST_DATE, method: 'Egyptian' })
+    expect(r.location.methodSource).toBe('caller-explicit')
+    expect(r.method).toMatch(/Egyptian/i)
+    expect(r.method).not.toMatch(/Karachi/i)
+    const methodNote = r.notes.find(n => /Method auto-resolved/.test(n))
+    expect(methodNote).toBeUndefined()
+  })
+
+  it('caller-explicit elevation: 612 in Riyadh → caller-explicit, no auto-elevation note (existing behaviour preserved)', () => {
+    const r = prayerTimes({ latitude: 24.7136, longitude: 46.6753, date: TEST_DATE, elevation: 612 })
+    expect(r.location.elevationSource).toBe('caller-explicit')
+    expect(r.location.elevation).toBe(612)
+    const autoNote = r.notes.find(n => /Elevation auto-resolved/.test(n))
+    expect(autoNote).toBeUndefined()
+    // The legacy ≥500m advisory still fires regardless of source.
+    const advisory = r.notes.find(n => /Elevation advisory/.test(n))
+    expect(advisory).toBeDefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. The 12 city-method-override cities — methodSource sweep
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('prayerTimes.location — 12 city-method-override sweep', () => {
+  const cases = [
+    // [city,        lat,      lon,       expectedMethodPattern]
+    ['Mosul',       36.3489,  43.1577,  /Karachi/i],
+    ['Najaf',       31.9956,  44.3308,  /Tehran/i],
+    ['Karbala',     32.6149,  44.0241,  /Tehran/i],
+    ['Basra',       30.5081,  47.7836,  /Tehran/i],
+    ['Sarajevo',    43.8563,  18.4131,  /Diyanet/i],
+    ['Mostar',      43.3438,  17.8078,  /Diyanet/i],
+    ['Banja Luka',  44.7722,  17.1910,  /Diyanet/i],
+    ['Pristina',    42.6629,  21.1655,  /Diyanet/i],
+    ['Bradford',    53.7960, -1.7594,   /MoonsightingCommittee/i],
+    ['Beirut',      33.8938,  35.5018,  /Egyptian/i],
+    ['Tabriz',      38.0667,  46.2993,  /Tehran/i],
+    ['Dearborn',    42.3223, -83.1763,  /ISNA|NorthAmerica/i],
+  ]
+
+  it.each(cases)('%s → methodSource=city-institutional, method matches /%s/', (city, lat, lon, pattern) => {
+    const r = prayerTimes({ latitude: lat, longitude: lon, date: TEST_DATE })
+    expect(r.location.city.name).toBe(city)
+    expect(r.location.methodSource).toBe('city-institutional')
+    expect(r.method).toMatch(pattern)
+    // Auto-method note must include the city name and override
+    const methodNote = r.notes.find(n => /Method auto-resolved/.test(n))
+    expect(methodNote).toBeDefined()
+    expect(methodNote).toMatch(new RegExp(city.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Caller-silent vs caller-explicit symmetry
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('prayerTimes.location — caller-silent vs caller-explicit', () => {
+  it('caller-silent in Sarajevo and caller-explicit method=Diyanet produce same Fajr time (institutional override is a no-op for Bosnia)', () => {
+    const silent  = prayerTimes({ latitude: 43.8563, longitude: 18.4131, date: TEST_DATE })
+    const explicit = prayerTimes({ latitude: 43.8563, longitude: 18.4131, date: TEST_DATE, method: 'Diyanet' })
+    expect(silent.fajr.getTime()).toBe(explicit.fajr.getTime())
+    expect(silent.location.methodSource).toBe('city-institutional')
+    expect(explicit.location.methodSource).toBe('caller-explicit')
+  })
+
+  it('caller-explicit elevation overrides city-registry elevation', () => {
+    // Mexico City registry elevation is 2240m, but caller passes 0
+    const explicit = prayerTimes({ latitude: 19.43, longitude: -99.13, date: TEST_DATE, elevation: 0 })
+    expect(explicit.location.elevationSource).toBe('caller-explicit')
+    expect(explicit.location.elevation).toBe(0)
+    const advisory = explicit.notes.find(n => /Elevation advisory/.test(n))
+    expect(advisory).toBeUndefined()  // ≥500m advisory does NOT fire at 0m
+  })
+})


### PR DESCRIPTION
## Summary

Wires `detectLocation()` (shipped internally in PR #28) into the engine's `prayerTimes()` so callers automatically get city-aware behaviour when they don't override it explicitly.

- Auto-method: caller-silent + city has `methodOverride` → dispatch through institutional method (Mosul → Karachi, Najaf/Karbala/Basra → Tehran, Sarajevo/Mostar/Banja Luka → Diyanet, Bradford → MoonsightingCommittee, etc.)
- Auto-elevation: caller-silent + city has registered `elevation` → use it AND apply the correction inline
- New always-populated `location` field on the return value

## New `location` field schema

```ts
type Location = {
  city: City | null
  country: string | null
  timezone: string
  elevation: number
  methodSource:    'caller-explicit' | 'city-institutional' | 'country-default' | 'fallback'
  elevationSource: 'caller-explicit' | 'city-registry' | 'default-zero'
}
```

`location` is always present on the response (`city`/`country` may be `null` for ocean/Antarctic coordinates). Apps can use it to display "you're in Cape Town" without a second `detectLocation()` call.

## Behavioural spec — auto-apply when caller silent; respect caller overrides

| Field          | Caller-silent path                              | Caller-explicit path                                  |
| -------------- | ----------------------------------------------- | ----------------------------------------------------- |
| Method         | `city.methodOverride` → `country` default → `'ISNA'` | `params.method` (string) → `methodFromString` dispatcher |
| Elevation      | `city.elevation` → `0`                          | `params.elevation` (number, including `0` as override) |
| Auto-resolve note? | yes (only when filled by registry)          | no                                                    |
| Elevation correction | applied inline by engine                  | applied by `src/index.js` wrapper (unchanged)         |

Caller-explicit `elevation: 0` is a real override (sea-level forced). The engine distinguishes "caller passed 0" from "caller silent" by inspecting raw `params.elevation === undefined` rather than relying on a destructure default. Same for `method`.

## Test count + result

131 / 131 pass:
- 107 pre-existing (`test/engine.test.js` + `test/detectLocation.test.js`)
- 24 new in `test/prayerTimesLocation.test.js`:
  - location field shape (Mecca, Mosul, Bradford, Sarajevo, Cape Town silent + Cape Town `elevation: 0`, ocean coord, Mexico City, Mosul-with-explicit-Egyptian, Riyadh-with-explicit-612)
  - 12 city-method-override sweep (each verifies `methodSource='city-institutional'` + method label match + auto-method note)
  - caller-silent vs caller-explicit symmetry (Sarajevo identical times, Mexico City elevation override suppresses advisory)

Two pre-existing engine tests updated to filter out the new auto-elevation note (Casablanca and Reykjavík now have city-registry elevation, so a silent caller gets that note). Same-shape assertions, just more specific.

## Eval impact

```
                      before   after    Δ
Train WMAE (ratchet)  1.0668  1.0668   0.0000
Holdout WMAE          3.6627  3.6624  -0.0003
```

- **Train WMAE: unchanged** — train cells (Mawaqit Morocco, JAKIM Malaysia, Diyanet Türkiye, Aladhan API) have no city `methodOverride`, so the dispatch path is a no-op for the train set.
- **Holdout WMAE: -0.0003** — Mosul / Najaf / Karbala / Basra (in `eval/data/test/mawaqit.json`) now route through Karachi / Tehran / Tehran / Tehran respectively (their cited Sunni-Awqaf or Twelver Shia institutional methods) instead of Iraq's country-default Egyptian. The other 8 override cities produce identical times to before because the city's `methodOverride` matches its country's existing default — the change is observable only via `location.methodSource` and the auto-method note.
- Per-cell train deltas: all 0.00. Per-prayer signed-bias drift (train): 0.00. No region regression, no ihtiyat-unsafe drift.

`eval/compare.js` reports FAIL because train WMAE is a wash, which is the expected outcome for an API-only change (the dispatch explicitly says "Train WMAE should remain unchanged"). Phase 2 is structural / API-additive; the ratchet is for autoresearch correction-loop changes, not API surface.

## Sample diffs — Mosul / Bradford / Sarajevo + the 12-city sweep

| City        | Country default → city override | Times before                    | Times after                     | Source flip |
| ----------- | ------------------------------- | ------------------------------- | ------------------------------- | ----------- |
| Mosul       | Egyptian → Karachi              | Fajr 00:56, Isha 17:10          | Fajr 01:04 (+8m), Isha 17:13 (+3m) | yes — institutional |
| Najaf       | Egyptian → Tehran               | Fajr 01:02, Isha 16:55          | Fajr 01:11 (+9m), Isha 16:37 (-18m) | yes |
| Karbala     | Egyptian → Tehran               | Fajr 01:01, Isha 16:58          | Fajr 01:11 (+10m), Isha 16:40 (-18m) | yes |
| Basra       | Egyptian → Tehran               | Fajr 00:51, Isha 16:38          | Fajr 01:00 (+9m), Isha 16:21 (-17m) | yes |
| Bradford    | MoonsightingCommittee → MoonsightingCommittee | Fajr 03:26, Isha 20:20 | identical | only `methodSource` flips to `city-institutional` |
| Sarajevo    | Diyanet → Diyanet               | Fajr 02:20, Isha 19:09          | identical                       | only flag flip |
| Mostar      | Diyanet → Diyanet               | Fajr 02:24, Isha 19:09          | identical                       | only flag flip |
| Banja Luka  | Diyanet → Diyanet               | Fajr 02:21, Isha 19:17          | identical                       | only flag flip |
| Pristina    | Diyanet → Diyanet               | Fajr 02:13, Isha 18:54          | identical                       | only flag flip |
| Beirut      | Egyptian → Egyptian             | Fajr 01:32, Isha 17:35          | identical                       | only flag flip |
| Tabriz      | Tehran → Tehran                 | Fajr 00:49, Isha 16:42          | identical                       | only flag flip |
| Dearborn    | ISNA → ISNA                     | Fajr 09:30, Isha 01:38          | identical                       | only flag flip |

So 4 of 12 cities produce different clock times (the Iraq Sunni-Awqaf / Twelver Shia institutional split is the substantive change). The other 8 are flag-only changes that surface ikhtilaf to apps via `methodSource='city-institutional'` + the new auto-method note in `notes[]`.

## Phase 3 (next)

- Add `detectLocation` and `Location` types to `src/index.js` + `src/index.d.ts`
- Add `examples/agiftoftime/INTEGRATION.md` walkthrough for the `location` field
- README pass + agiftoftime cross-repo announcement issue per CLAUDE.md

## Classification

🟢 Established — pure API plumbing. Downstream consequences (city-institutional dispatch) inherit each city's already-classified institutional source from `src/data/cities.json` (built in phase 1 with citations in `scripts/data/city-method-overrides.json`). No new corrections introduced. No 🔴 Novel paths added.

## Test plan

- [x] `npm test` — 131 / 131 pass
- [x] `node eval/eval.js` — Train WMAE unchanged at 1.0668, Holdout 3.6624 (Δ -0.0003)
- [x] Engine + wrapper produce identical corrected times for caller-explicit and city-registry elevation paths
- [x] No `src/index.js` or `src/index.d.ts` modifications (phase 3 scope)
- [x] No `eval/*` modifications (CLAUDE.md rule 5/6)
- [x] All `notes[]` strings exact per spec; auto-method/auto-elevation only fire when caller is silent

— fajr-agent