### PR TITLE
feat(location): v1.7.0 phase 3 — public detectLocation API + types + README + 1.7.0 release bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **A region-aware auto-configuration layer over [`adhan.js`](https://github.com/batoulapps/adhan-js), plus an evolving accuracy-research framework.** Fajr picks the right calculation method for your coordinates automatically, ships a small set of community-calibrated regional adjustments not in adhan's defaults (Morocco 19°/17°, France UOIF 12°/12°, high-latitude rule selection), adds **hilal (lunar crescent) visibility prediction via three criteria computed side-by-side — Odeh (2004), Yallop (1997), and Shaukat (2002)** (adhan is solar-only — fajr ships its own Meeus-based lunar position stack, validated 5/5 astronomically defensible against documented Hijri month transitions, with `criteriaAgree` flagging borderline ikhtilaf cases when any of the three disagrees), and runs an autoresearch loop that validates engine changes against multiple independent reference layers — mosque-published times (Mawaqit), institutional tables (Diyanet, JAKIM), and regional-method consensus (Aladhan, praytimes.org). Currently spans 38 cities across 12 institutional-train countries plus a 163-country Aladhan-routed holdout corpus. The eval framework, plus the hilal/lunar implementation, is where most of fajr's distinctive engineering lives today.
 
-> **Status — v1.6.** Public API surfaces (`prayerTimes`, `dayTimes`, `tarabishyTimes`, `applyElevationCorrection`, `applyTayakkunBuffer`, `hilalVisibility`, `qibla`, `hijri`, `nightThirds`, `travelerMode`) are stable; breaking changes will require a major version bump. v1.6.0 expanded country dispatch from 27 to 78 countries with bbox-based method selection. v1.5.2 added an **elevation advisory** at altitudes ≥ 500 m surfacing the UAE/JAKIM-vs-Saudi institutional disagreement so apps can present the user with an informed choice — see [Elevation advisory at significant altitude](#elevation-advisory-at-significant-altitude-v152). v1.5.1 introduced **per-prayer ihtiyat-aware minute rounding** (every displayed minute is on the prayer-validity-safe side of actual reality, by construction) and an explicit **`imsak`** field for fasting-yaqeen — see the principle table in [Per-prayer ihtiyat-aware minute rounding](#per-prayer-ihtiyat-aware-minute-rounding-v151). v1.5.0 shipped the Morocco Maghrib +5min Path A across 23 mosques. v1.3 added the Aabed-2015 tayakkun buffer and Tarabishy-2014 latitude-truncation method as opt-in alternatives, plus a `notes: string[]` field on `prayerTimes` output that surfaces scholarly-grounded location-specific advisories (currently the Odeh-2009 high-latitude regime warning at \|lat\| ≥ 48.6°). See [API stability](#api-stability) below. Live numbers and per-source breakdown are auto-generated in [`docs/progress.md`](docs/progress.md) on every `npm run build:charts`.
+> **Status — v1.7.** Public API surfaces (`prayerTimes`, `dayTimes`, `tarabishyTimes`, `detectLocation`, `applyElevationCorrection`, `applyTayakkunBuffer`, `hilalVisibility`, `qibla`, `hijri`, `nightThirds`, `travelerMode`) are stable; breaking changes will require a major version bump. **v1.7.0 ships city-aware location resolution**: a bundled 375-city registry powers automatic city detection, city-registry elevation surfacing (no more silent sea-level for Mexico City / Cape Town / Riyadh users), and city-level institutional method overrides for 12 cities where intra-country *ikhtilaf* matters (Mosul → Karachi via Sunni-Awqaf, Najaf/Karbala/Basra → Tehran via Twelver Shia hawza, Sarajevo/Mostar/Banja Luka/Pristina → Diyanet via Bosnian Rijaset / BIK, Bradford → MoonsightingCommittee via BCOM, Beirut → Egyptian via Dar al-Fatwa, Tabriz → Tehran, Dearborn → ISNA). Apps gain a `location` field on every `prayerTimes` return value with city/country/timezone/method-source plus a public `detectLocation(lat, lon)` for standalone resolution — see [City-aware location resolution (v1.7.0)](#city-aware-location-resolution-v170). v1.6.0 expanded country dispatch from 27 to 78 countries with bbox-based method selection (163 by v1.6.2). v1.5.2 added an **elevation advisory** at altitudes ≥ 500 m surfacing the UAE/JAKIM-vs-Saudi institutional disagreement so apps can present the user with an informed choice — see [Elevation advisory at significant altitude](#elevation-advisory-at-significant-altitude-v152). v1.5.1 introduced **per-prayer ihtiyat-aware minute rounding** (every displayed minute is on the prayer-validity-safe side of actual reality, by construction) and an explicit **`imsak`** field for fasting-yaqeen — see the principle table in [Per-prayer ihtiyat-aware minute rounding](#per-prayer-ihtiyat-aware-minute-rounding-v151). v1.5.0 shipped the Morocco Maghrib +5min Path A across 23 mosques. v1.3 added the Aabed-2015 tayakkun buffer and Tarabishy-2014 latitude-truncation method as opt-in alternatives, plus a `notes: string[]` field on `prayerTimes` output that surfaces scholarly-grounded location-specific advisories (currently the Odeh-2009 high-latitude regime warning at \|lat\| ≥ 48.6°). See [API stability](#api-stability) below. Live numbers and per-source breakdown are auto-generated in [`docs/progress.md`](docs/progress.md) on every `npm run build:charts`.
 
 ---
 
@@ -356,6 +356,70 @@ These are **rounding directions** for the displayed whole minute — the underly
 
 **Dual-ihtiyat resolution.** Fasting and prayer-validity have *different* safe directions for Fajr — fasters want Fajr earlier (so they stop eating before actual dawn); prayers want Fajr later (so prayer is performed inside the valid window). The classical resolution from every printed Imsakiyya in Mecca, Medina, and Cairo for over a century is **two columns**: an *imsak* (إمساك, "abstaining") column for fast-stop, and a *Fajr* column for prayer-start. fajr's API exposes both as separate fields. Imsak defaults to Fajr − 10 min (the universal Imsakiyya convention), rounded DOWN for fasting safety. Apps wanting a different imsak buffer can recompute downstream — the offset and rounding policy are reported in `result.corrections.imsak_offset_min` and `result.corrections.rounding`.
 
+### City-aware location resolution (v1.7.0)
+
+Most prayer-time libraries resolve method selection at the country level. fajr v1.7.0 ships a **bundled 375-city registry** that lifts resolution to the city — surfacing intra-country *ikhtilaf* (Mosul Hanafi vs. Najaf Twelver Shia, Sarajevo Diyanet vs. country MWL default), exposing per-city elevation automatically (Mexico City, Riyadh, Cape Town stop being silently sea-level), and giving apps a single `location` field with full provenance.
+
+The new public surface:
+
+- **`location` field on every `prayerTimes()` / `dayTimes()` return value** — always populated, carries `{ city, country, timezone, elevation, methodSource, elevationSource }`. `methodSource ∈ 'caller-explicit' | 'city-institutional' | 'country-default' | 'fallback'`; `elevationSource ∈ 'caller-explicit' | 'city-registry' | 'default-zero'`. Apps can render "you are in Cape Town" without a separate reverse-geocode call, and explain "Why is my Fajr at this time?" by surfacing the source enums.
+- **`detectLocation(lat, lon, fallbackElevation?)` standalone export** — pure lookup, no astronomy. Returns the same shape plus `recommendedMethod`, `altMethods` (documented alternatives where intra-city ikhtilaf is recorded), and `source` (institutional provenance). Returns `city: null` honestly when no city in the registry matches — never a wrong-city default.
+
+**12 city-level institutional method overrides** ship with the registry. Each cites its institutional source so reviewers can audit; each surfaces alternative methods via `altMethods` so apps can render the disagreement rather than hiding it:
+
+| City | Country | Method | Institutional source |
+|---|---|---|---|
+| Mosul | Iraq | Karachi (18°/18°) | Iraqi Sunni Endowment Office (Diwan al-Waqf al-Sunni) |
+| Najaf | Iraq | Tehran (17.7°/14°) | Office of Grand Ayatollah al-Sistani — Najaf hawza |
+| Karbala | Iraq | Tehran | Astan al-Husayniyya / Astan al-Abbasiyya custodial offices |
+| Basra | Iraq | Tehran | Twelver Shia mosque-published timetables (Sistani-aligned) |
+| Sarajevo | Bosnia | Diyanet (18°/17°) | Rijaset Islamske Zajednice u BiH (Vakat Takvim) |
+| Mostar | Bosnia | Diyanet | Rijaset BiH — Hercegovački muftijstvo |
+| Banja Luka | Bosnia | Diyanet | Rijaset BiH — Banjalučko muftijstvo (Republika Srpska) |
+| Pristina | Kosovo | Diyanet | Bashkësia Islame e Kosovës (BIK) Takvimi |
+| Bradford | UK | MoonsightingCommittee | Bradford Council of Mosques (BCOM) coordinated tables |
+| Beirut | Lebanon | Egyptian (19.5°/17.5°) | Dar al-Fatwa al-Lubnaniyya |
+| Tabriz | Iran | Tehran | Tehran Institute of Geophysics (regional default) |
+| Dearborn | USA | ISNA (15°/15°) | Dearborn Sunni convention; Tehran-style Twelver Shia minority surfaced via altMethods |
+
+Of the 12, four (Mosul, Najaf, Karbala, Basra) change clock-time materially compared to the pre-v1.7.0 country-default — Mosul shifts Fajr +8min (Karachi 18° dawn arrives ~8min later than Egyptian 19.5°), Najaf/Karbala/Basra shift Isha by –17 to –18min (Tehran 14° vs. Egyptian 17.5° angle for end of twilight). The other eight produce identical times because the city's `methodOverride` matches the country default already; the change is observable only via `location.methodSource` flipping from `country-default` to `city-institutional` and the new "Method auto-resolved" entry in `notes[]`. Full citations, reasoning, and alt-method documentation live in [`scripts/data/city-method-overrides.json`](scripts/data/city-method-overrides.json) (one record per city, every entry carries an institutional citation per the proposal's "no override without verified source" rule).
+
+**Auto-elevation behavior.** When you omit `elevation` from `prayerTimes()`, fajr now uses the city's registered elevation if known and applies `applyElevationCorrection` inline so the returned times are already-corrected. Mexico City users get times computed for 2,240m elevation by default; Cape Town users get 25m; Riyadh users get 612m (the v1.5.2 ≥500m advisory still fires alongside the auto-elevation note). To opt out — for instance to follow the Saudi/jama'ah-unity stance that declines geometric elevation correction — pass `elevation: 0` explicitly; fajr then treats this as caller-explicit sea-level and produces sea-level times. Caller-explicit elevation always wins over the city-registry elevation; the `location.elevationSource` field reports which path produced the value.
+
+**Auto-method behavior.** When you omit `method`, fajr resolves through `caller-explicit > city-institutional > country-default > fallback`. Pass an explicit `method: 'Egyptian'` (or any method-name string) and the city/country dispatch is bypassed entirely; `location.methodSource` becomes `'caller-explicit'` and the auto-method `notes[]` entry is suppressed.
+
+**Bundle size impact: +~95 KB** for [`src/data/cities.json`](src/data/cities.json) (375 cities, full registry shape with bbox / population / elevation / timezone / institutional source). The runtime cost is one linear scan over the 375 rows per `prayerTimes` call (registry pre-sorted with smallest bboxes first; metropolitan-area matches short-circuit early). For a downstream library shipping fajr, expect ~95 KB of registry data on top of fajr's own ~115 KB engine source — comparable to the size of the bundled adhan.js (`16 KB` minified) but added once rather than per-call.
+
+> **Privacy assertion.** fajr never logs, persists, or transmits the coordinates you pass it. The city resolution happens entirely locally via the bundled `src/data/cities.json` registry. No telemetry, no analytics, no remote calls. The only network traffic fajr is involved in is the `npm install` itself; everything else is a local function call.
+
+```js
+import { prayerTimes, detectLocation } from '@tawfeeqmartin/fajr'
+
+// Get prayer times — automatically uses city's elevation + institutional method if applicable
+const times = prayerTimes({ latitude: 36.34, longitude: 43.13, date: new Date() })
+// times.location = {
+//   city: { name: 'Mosul', countryISO: 'IQ', elevation: 223, methodOverride: 'Karachi', ... },
+//   country: 'Iraq',
+//   timezone: 'Asia/Baghdad',
+//   elevation: 223,
+//   methodSource: 'city-institutional',
+//   elevationSource: 'city-registry',
+// }
+// times.method  → 'Karachi (18°/18°)'
+// times.notes   → includes "Method auto-resolved from city institutional override:
+//                          Mosul → Karachi (Iraqi Sunni Endowment Office)"
+
+// Or just resolve location without computing prayer times
+const loc = detectLocation(36.34, 43.13)
+console.log(loc.city.name)            // 'Mosul'
+console.log(loc.recommendedMethod)    // 'Karachi'
+console.log(loc.methodSource)         // 'city-institutional'
+console.log(loc.altMethods)           // [{ method: 'Egyptian', source: 'Aladhan world-default for Iraq' }]
+console.log(loc.source.institution)   // (mawaqit-typed source — slug populated)
+```
+
+The principle behind v1.7.0 is the same one driving the rest of fajr's library design: **surface scholarly disagreement transparently, don't resolve it silently.** The 12 method-override cities each carry an institutional citation that a reviewer can audit; each surfaces minority alternatives via `altMethods`; the engine's choice is reported via `location.methodSource` so apps can show users *why* a particular method was selected and offer them the alternative.
+
 ---
 
 ## Historical Results (Experiment 1–7 narrative)
@@ -570,8 +634,9 @@ fajr v1.0 makes the following stability promises. **Stable** surfaces will not c
 
 | API | Signature | Since |
 |---|---|---|
-| `prayerTimes` | `({ latitude, longitude, date, elevation? }) → { fajr, shuruq, sunrise, dhuhr, asr, maghrib, sunset, isha, method, notes, corrections }` | v1.0 (`sunrise` alias added v1.0.1; `sunset` and `notes` added v1.1+) |
-| `dayTimes` | `({ latitude, longitude, date, elevation? }) → prayerTimes shape ∪ { midnight, qiyam }` | v1.1 |
+| `prayerTimes` | `({ latitude, longitude, date, elevation?, method? }) → { fajr, shuruq, sunrise, dhuhr, asr, maghrib, sunset, isha, method, notes, corrections, location }` | v1.0 (`sunrise` alias added v1.0.1; `sunset` and `notes` added v1.1+; `location` added v1.7) |
+| `dayTimes` | `({ latitude, longitude, date, elevation?, method? }) → prayerTimes shape ∪ { midnight, qiyam }` | v1.1 |
+| `detectLocation` | `(latitude, longitude, fallbackElevation?) → { city, country, timezone, elevation, recommendedMethod, methodSource, altMethods?, source }` | v1.7 |
 | `applyElevationCorrection` | `(times, elevation, latitude?) → times` (opt-in geometric horizon-dip) | v1.0 |
 | `applyTayakkunBuffer` | `(times, mins=5) → times` (opt-in Fajr buffer per Aabed 2015) | v1.3 |
 | `tarabishyTimes` | `(params, thresholdLat=45) → prayerTimes shape` (opt-in 45°-truncation per Tarabishy 2014) | v1.3 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tawfeeqmartin/fajr",
-  "version": "1.7.0-alpha.1",
+  "version": "1.7.0",
   "description": "High-accuracy Islamic prayer time library combining NASA/JPL astronomical algorithms with classical Islamic scholarship",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,190 @@
 // changes require a major version bump. See README "API stability".
 
 // ─────────────────────────────────────────────────────────────────────────────
+// detectLocation — city-aware location resolver (v1.7.0)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A documented alternative method for cities with intra-locality ikhtilaf
+ *  (legitimate scholarly disagreement). Only present on cities where
+ *  multiple institutional positions are documented. Apps that want to surface
+ *  the disagreement to users render these as "see also" chips alongside
+ *  `recommendedMethod`. */
+export interface AltMethod {
+  /** Method name resolvable by the engine's dispatcher (e.g. `'Tehran'`,
+   *  `'Karachi'`, `'Egyptian'`). */
+  method: string
+  /** Free-form string explaining the institutional source / convention
+   *  (e.g. "Higher Islamic Shia Council of Lebanon (al-Majlis al-Islami
+   *  al-Shi'i al-A'la) — published Twelver Shia Imsakiyya..."). */
+  source: string
+  /** Optional rough share of the local Muslim population that follows this
+   *  alternative. Surface only when a credible quantitative estimate exists;
+   *  the field is omitted otherwise to avoid implied precision. */
+  populationShare?: number
+}
+
+/** Provenance of the city's primary recommended method. */
+export interface CitySource {
+  /** `'mawaqit'` = a Mawaqit-registered mosque publishes for this city.
+   *  `'national-authority'` = the country's named institution publishes
+   *  (Diyanet, JAKIM, KEMENAG, MUIS, Habous, Awqaf, etc.).
+   *  `'aladhan'` = no specific institutional publisher; coverage via the
+   *  multi-app consensus method (typically MWL-via-Aladhan-default).
+   *  `'inherited'` = no city-level source; the city inherits its country's. */
+  type: 'mawaqit' | 'national-authority' | 'aladhan' | 'inherited' | 'fallback'
+  /** Mawaqit slug when type === 'mawaqit', e.g. 'al-azhar-mosque-cairo-egypt'. */
+  slug?: string
+  /** Institution name when type === 'national-authority' or 'mawaqit'.
+   *  E.g. 'Diyanet İşleri Başkanlığı', 'JAKIM', 'Dar al-Fatwa al-Lubnaniyya'. */
+  institution?: string
+  /** When type === 'inherited', the country key the city inherits from. */
+  from?: string
+}
+
+export interface City {
+  /** English/Latin transliteration. Stable across versions; used as display name. */
+  name:         string
+  /** Local-script form when meaningfully distinct (Arabic, Cyrillic, etc.).
+   *  Optional — only included where the local script differs from `name`. */
+  nameLocal?:   string
+  /** ISO 3166-1 alpha-2. */
+  countryISO:   string
+  /** State / province / governorate / mintaqah. Free-form; not a stable enum. */
+  adminRegion?: string
+  /** Geographic centre, decimal degrees. */
+  lat:          number
+  lon:          number
+  /** Bounding box for fast lookup: [latMin, latMax, lonMin, lonMax]. */
+  bbox:         [number, number, number, number]
+  /** Optional. Inhabitants of the city proper, latest reasonably-sourced figure. */
+  population?:  number
+  /** Optional. Mean elevation of the city centre in metres above sea level —
+   *  surfaced to apps that want to recommend `applyElevationCorrection`. */
+  elevation?:   number
+  /** Optional. IANA timezone for this city. Falls through to country-level
+   *  when absent — relevant for Russia, USA, China, etc. */
+  timezone?:    string
+  /** Optional city-level institutional method override. Resolvable by the
+   *  engine's method dispatcher (e.g. `'Karachi'`, `'Tehran'`, `'Diyanet'`).
+   *  When set, `prayerTimes` uses this in preference to the country default
+   *  (the city is following an institutional convention that diverges from
+   *  the country writ-large). When unset, the country default applies. */
+  methodOverride?: string
+  /** Optional documented alternative methods — surfaces the intra-city
+   *  ikhtilaf rather than hiding it behind the recommended method. Only
+   *  present when at least one alternative is documented. */
+  altMethods?: AltMethod[]
+  /** Provenance for the city's primary recommended method. */
+  source?:     CitySource
+}
+
+/** How `prayerTimes` chose the calculation method for a given coordinate.
+ *
+ *  - `'caller-explicit'`: the caller passed `method:` in the params object;
+ *    fajr honoured it without consulting the city or country tables.
+ *  - `'city-institutional'`: the matched city in the registry has a
+ *    `methodOverride` field; fajr used that (e.g. Mosul → Karachi via
+ *    Sunni-Awqaf convention, even though Iraq's country default is Egyptian).
+ *  - `'country-default'`: no city-level override; fajr used the country's
+ *    default method per the bbox dispatch table.
+ *  - `'fallback'`: outside any registered city AND outside any country bbox;
+ *    fajr used ISNA (the engine's universal fallback). */
+export type MethodSource = 'caller-explicit' | 'city-institutional' | 'country-default' | 'fallback'
+
+/** How `prayerTimes` chose the elevation for a given coordinate.
+ *
+ *  - `'caller-explicit'`: the caller passed `elevation:` in the params object
+ *    (any value, including 0). Apps following the Saudi/jama'ah-unity stance
+ *    should pass `elevation: 0` to opt out of geometric horizon-dip correction.
+ *  - `'city-registry'`: the matched city in the registry has an `elevation`
+ *    field; fajr used that and applied `applyElevationCorrection` inline so
+ *    the returned times are already-corrected.
+ *  - `'default-zero'`: no city matched (or the matched city had no elevation
+ *    field), and the caller did not pass elevation. fajr fell through to 0
+ *    (sea level) silently — the safest default. */
+export type ElevationSource = 'caller-explicit' | 'city-registry' | 'default-zero'
+
+/** The location field on `prayerTimes` / `dayTimes` return values (v1.7.0+).
+ *  Always populated. Apps can use this to display "you are in <city>"
+ *  without an additional `detectLocation` call. */
+export interface PrayerTimesLocation {
+  /** Matched city, or null when no city in the bundled registry matched. */
+  city:            City | null
+  /** Country key from the engine's bbox table (e.g. 'SaudiArabia',
+   *  'UnitedKingdom'). null when outside all known country bboxes. */
+  country:         string | null
+  /** IANA timezone identifier. Resolution order: city.timezone → 'UTC'.
+   *  We do not synthesise a country-level timezone fallback because
+   *  Russia/USA/Canada/China have multiple zones; UTC is honest when no
+   *  city matched. */
+  timezone:        string
+  /** Effective elevation in metres used by the engine on this call. */
+  elevation:       number
+  /** How the method was chosen — see MethodSource above. */
+  methodSource:    MethodSource
+  /** How the elevation was chosen — see ElevationSource above. */
+  elevationSource: ElevationSource
+}
+
+/** Standalone Location record returned by `detectLocation`. Distinct from
+ *  `PrayerTimesLocation` which only carries the fields relevant to
+ *  prayer-time computation; `Location` includes `recommendedMethod`,
+ *  `altMethods`, and `source` for apps that want full city provenance
+ *  (e.g. to render the institutional source name in a UI provenance sheet). */
+export interface Location {
+  /** Matched city, or null when no city in the bundled registry matched.
+   *  NEVER returns a wrong-city default — `null` is the honest signal. */
+  city:              City | null
+  /** Country key from the engine's bbox table. null when outside all known
+   *  country bboxes (open ocean, Antarctica). */
+  country:           string | null
+  /** IANA timezone identifier; falls through to 'UTC' when no city matched. */
+  timezone:          string
+  /** Effective elevation in metres. Resolution order:
+   *  city.elevation → fallbackElevation parameter (default 0). */
+  elevation:         number
+  /** Recommended calculation method as a string resolvable by the engine
+   *  dispatcher. Resolution order:
+   *  city.methodOverride → countryDefault → 'ISNA'. */
+  recommendedMethod: string
+  /** How the recommended method was chosen — see MethodSource above. */
+  methodSource:      MethodSource
+  /** Documented alternative methods for this city (intra-city ikhtilaf).
+   *  Only present when the matched city has at least one alternative.
+   *  Apps doing existence checks should use `altMethods != null` rather
+   *  than `altMethods.length > 0`. */
+  altMethods?:       AltMethod[]
+  /** Provenance of the recommended method. */
+  source:            CitySource
+}
+
+/** Resolve a coordinate to its city, country, timezone, recommended method,
+ *  and institutional source.
+ *
+ *  Pure / referentially transparent for a given (lat, lon, fallbackElevation):
+ *  no astronomical computation, no I/O, no caching. Apps that already
+ *  call `prayerTimes` get the same resolution surfaced via the
+ *  `location` field on its return value — most apps will never need to
+ *  call `detectLocation` directly.
+ *
+ *  Privacy: fajr never logs, persists, or transmits the coordinates you
+ *  pass it. The city resolution happens entirely locally via the bundled
+ *  city registry. No telemetry, no analytics, no remote calls.
+ *
+ *  🟢 Established — pure lookup, no shar'i ruling involved.
+ *
+ *  @param latitude
+ *  @param longitude
+ *  @param fallbackElevation Used when the matched city has no elevation
+ *                           field AND when no city matches. Default 0.
+ */
+export function detectLocation(
+  latitude: number,
+  longitude: number,
+  fallbackElevation?: number,
+): Location
+
+// ─────────────────────────────────────────────────────────────────────────────
 // prayerTimes
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -12,11 +196,27 @@ export interface PrayerTimesParams {
   latitude: number
   longitude: number
   date: Date
-  /** Meters above sea level. Default 0. Currently informational; elevation
-   *  correction is opt-in via `applyElevationCorrection`. */
+  /** Meters above sea level. When omitted (or set to `undefined`), fajr
+   *  auto-resolves elevation from the bundled city registry — apps that
+   *  want city-registry elevation should NOT pass this parameter. To opt
+   *  out of elevation correction (e.g. Saudi/jama'ah-unity stance), pass
+   *  `elevation: 0` explicitly — the engine then treats this as caller-
+   *  explicit sea-level and skips the geometric horizon-dip correction.
+   *  Apps that already have a GPS-supplied altitude should pass it through;
+   *  the engine then applies `applyElevationCorrection` to the returned
+   *  times automatically (since v1.5.2). */
   elevation?: number
-  /** Override the auto-detected method. Currently the auto-detection is
-   *  authoritative; this parameter is reserved for future explicit overrides. */
+  /** Override the auto-detected method. Pass a method-name string
+   *  resolvable by the engine's `methodFromString` dispatcher (e.g.
+   *  `'UmmAlQura'`, `'Diyanet'`, `'Karachi'`, `'Tehran'`, `'Egyptian'`,
+   *  `'MoonsightingCommittee'`, `'JAKIM'`, `'MUIS'`, `'ISNA'`, `'MWL'`,
+   *  `'UOIF'`, `'CIL'`, `'DUMR'`, `'Morocco'`, `'Tunisia'`, `'Algeria'`,
+   *  `'Jordan'`). When omitted, the engine resolves the method from the
+   *  bundled city registry's `methodOverride` (if present), then falls
+   *  through to the country default, then to ISNA. Caller-explicit method
+   *  takes priority over both city-institutional and country-default
+   *  resolution; the resulting `location.methodSource` is then
+   *  `'caller-explicit'`. */
   method?: string
 }
 
@@ -78,6 +278,16 @@ export interface PrayerTimesResult {
     /** Present if elevation correction was applied via `applyElevationCorrection`. */
     elevationCorrectionMin?: number
   }
+  /** City + country + timezone + sourcing metadata for this call (v1.7.0+).
+   *  Always populated. Apps can use this to display "you are in <city>"
+   *  without an additional `detectLocation` call. `methodSource` and
+   *  `elevationSource` report HOW the engine chose its inputs for this
+   *  call — useful for "Why is my Fajr at this time?" explanatory UX.
+   *
+   *  When no city in the bundled registry matches the coordinate, `city`
+   *  is null. When outside all known country bboxes (open ocean,
+   *  Antarctica), `country` is also null and `methodSource === 'fallback'`. */
+  location: PrayerTimesLocation
 }
 
 export function prayerTimes(params: PrayerTimesParams): PrayerTimesResult
@@ -357,6 +567,7 @@ declare const fajr: {
   prayerTimes:              typeof prayerTimes
   dayTimes:                 typeof dayTimes
   tarabishyTimes:           typeof tarabishyTimes
+  detectLocation:           typeof detectLocation
   applyElevationCorrection: typeof applyElevationCorrection
   applyTayakkunBuffer:      typeof applyTayakkunBuffer
   qibla:                    typeof qibla

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,12 @@
  * Internal implementation lives in engine.js and the other src/ modules.
  */
 
-import { prayerTimes as _prayerTimes, applyElevationCorrection, applyTayakkunBuffer } from './engine.js'
+import {
+  prayerTimes as _prayerTimes,
+  applyElevationCorrection,
+  applyTayakkunBuffer,
+  detectLocation as _detectLocation,
+} from './engine.js'
 import { qibla } from './qibla.js'
 import { hijri } from './hijri.js'
 import { hilalVisibility } from './hilal.js'
@@ -95,10 +100,47 @@ function tarabishyTimes(params, thresholdLat = 45) {
   return result
 }
 
+/**
+ * Resolve a coordinate to its city, country, timezone, recommended method,
+ * and institutional source.
+ *
+ * Pure / referentially transparent for a given (lat, lon, fallbackElevation):
+ * no astronomical computation, no I/O, no caching. Apps can call this
+ * independently of `prayerTimes` to display "you are in <city>" without
+ * computing prayer times. The same resolution is also performed silently
+ * inside `prayerTimes` and surfaced via the `location` field on its return
+ * value, so most callers will never need to invoke this directly.
+ *
+ * Returns `city: null` honestly when no city in the bundled registry matches —
+ * never a wrong-city default. The country fallback (via the existing
+ * `detectCountry` bbox table) still populates `country` and
+ * `recommendedMethod`. When neither matches (open ocean, Antarctica), all of
+ * city/country/recommendedMethod fall through to safe defaults
+ * (`null`/`null`/`'ISNA'`) so apps can display a graceful "location unknown"
+ * state.
+ *
+ * Privacy: the (lat, lon) you pass is not logged, persisted, or transmitted
+ * anywhere. The city resolution happens entirely locally via the bundled
+ * `src/data/cities.json` registry.
+ *
+ * Classification: 🟢 Established — pure lookup, no shar'i ruling involved.
+ *
+ * @param {number} latitude
+ * @param {number} longitude
+ * @param {number} [fallbackElevation=0]  Used when the matched city has no
+ *                                         elevation field, AND when no city
+ *                                         matches. In meters.
+ * @returns {object}  Location record. See TypeScript types in src/index.d.ts.
+ */
+function detectLocation(latitude, longitude, fallbackElevation = 0) {
+  return _detectLocation(latitude, longitude, fallbackElevation)
+}
+
 export default {
   prayerTimes,
   dayTimes,
   tarabishyTimes,
+  detectLocation,
   applyElevationCorrection,
   applyTayakkunBuffer,
   qibla,
@@ -112,6 +154,7 @@ export {
   prayerTimes,
   dayTimes,
   tarabishyTimes,
+  detectLocation,
   applyElevationCorrection,
   applyTayakkunBuffer,
   qibla,

--- a/test/publicApi.test.js
+++ b/test/publicApi.test.js
@@ -1,0 +1,242 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Unit tests for v1.7.0 phase 3 — detectLocation in the public API surface.
+ *
+ * These tests import from the public package entry (`../src/index.js`) — not
+ * `../src/engine.js` — to verify the v1.7.0 contract: `detectLocation` is
+ * exported alongside `prayerTimes`, `dayTimes`, and the existing entry
+ * points, and the new `location` field on `prayerTimes` return values
+ * survives the public wrapper without mutation.
+ *
+ * Coverage:
+ *   1. detectLocation is exported from both default and named imports
+ *   2. detectLocation(lat, lon) shape: required + optional fields populated
+ *   3. The 12 city-method-override cities resolve to the documented method
+ *   4. fallback path: open ocean → city=null, country=null, ISNA recommended
+ *   5. Privacy + purity: detectLocation has no side effects on Date / global
+ *   6. prayerTimes return value carries location field intact
+ *   7. fallbackElevation parameter is honoured when no city matches
+ *   8. detectCountry-equivalence: country field matches detectCountry table
+ *
+ * Phase 1's `test/detectLocation.test.js` covers the engine internals; this
+ * file covers the *public-API contract* — what an external consumer sees.
+ */
+
+import { describe, it, expect } from 'vitest'
+import fajrDefault, {
+  detectLocation,
+  prayerTimes,
+  dayTimes,
+} from '../src/index.js'
+
+const TEST_DATE = new Date('2026-04-15T12:00:00Z')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Public-export contract
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('public API — detectLocation export contract', () => {
+  it('detectLocation is a named export from @tawfeeqmartin/fajr', () => {
+    expect(typeof detectLocation).toBe('function')
+  })
+
+  it('detectLocation is on the default-export namespace', () => {
+    expect(typeof fajrDefault.detectLocation).toBe('function')
+  })
+
+  it('default and named export resolve to the same callable', () => {
+    // Either the same function reference, or two thin wrappers that produce
+    // identical output for the same input. We check behaviour rather than
+    // reference identity so the wrapper-vs-direct dichotomy is allowed.
+    const a = detectLocation(21.4225, 39.8262)
+    const b = fajrDefault.detectLocation(21.4225, 39.8262)
+    expect(a.country).toBe(b.country)
+    expect(a.recommendedMethod).toBe(b.recommendedMethod)
+    expect(a.city?.name).toBe(b.city?.name)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. detectLocation(lat, lon) return-shape contract
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('detectLocation — return shape', () => {
+  it('Mecca → all required fields populated (city, country, timezone, elevation, recommendedMethod, methodSource, source)', () => {
+    const loc = detectLocation(21.4225, 39.8262)
+    expect(loc).toBeDefined()
+    expect(loc.city).not.toBeNull()
+    expect(loc.city.name).toBe('Mecca')
+    expect(loc.country).toBe('SaudiArabia')
+    expect(typeof loc.timezone).toBe('string')
+    expect(loc.timezone.length).toBeGreaterThan(0)
+    expect(typeof loc.elevation).toBe('number')
+    expect(loc.recommendedMethod).toMatch(/UmmAlQura/i)
+    expect(loc.methodSource).toBe('country-default')
+    expect(loc.source).toBeDefined()
+    expect(typeof loc.source.type).toBe('string')
+  })
+
+  it('Mosul → city.methodOverride dispatched; methodSource=city-institutional', () => {
+    const loc = detectLocation(36.3489, 43.1577)
+    expect(loc.city.name).toBe('Mosul')
+    expect(loc.recommendedMethod).toBe('Karachi')
+    expect(loc.methodSource).toBe('city-institutional')
+    // The Mosul row carries one altMethod (Egyptian, the country default).
+    expect(loc.altMethods).toBeDefined()
+    expect(Array.isArray(loc.altMethods)).toBe(true)
+    expect(loc.altMethods.length).toBeGreaterThan(0)
+    expect(loc.altMethods[0].method).toBe('Egyptian')
+  })
+
+  it('Open ocean (0, -30) → city=null, country=null, recommendedMethod=ISNA, methodSource=fallback', () => {
+    const loc = detectLocation(0, -30)
+    expect(loc.city).toBeNull()
+    expect(loc.country).toBeNull()
+    expect(loc.recommendedMethod).toBe('ISNA')
+    expect(loc.methodSource).toBe('fallback')
+    expect(loc.timezone).toBe('UTC')
+  })
+
+  it('fallbackElevation parameter is honoured when no city matches', () => {
+    const loc = detectLocation(0, -30, 1234)
+    expect(loc.elevation).toBe(1234)
+  })
+
+  it('city.elevation takes priority over fallbackElevation when a city matches', () => {
+    // Mecca has a registry elevation; the fallback should be ignored.
+    const loc = detectLocation(21.4225, 39.8262, 9999)
+    expect(loc.elevation).not.toBe(9999)
+    expect(loc.elevation).toBeGreaterThan(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. The 12 city-method-override cities — public-API sweep
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('detectLocation — 12 city-method-override sweep (public API)', () => {
+  const cases = [
+    // [city,        lat,      lon,       expectedMethod]
+    ['Mosul',       36.3489,  43.1577,  'Karachi'],
+    ['Najaf',       31.9956,  44.3308,  'Tehran'],
+    ['Karbala',     32.6149,  44.0241,  'Tehran'],
+    ['Basra',       30.5081,  47.7836,  'Tehran'],
+    ['Sarajevo',    43.8563,  18.4131,  'Diyanet'],
+    ['Mostar',      43.3438,  17.8078,  'Diyanet'],
+    ['Banja Luka',  44.7722,  17.1910,  'Diyanet'],
+    ['Pristina',    42.6629,  21.1655,  'Diyanet'],
+    ['Bradford',    53.7960, -1.7594,   'MoonsightingCommittee'],
+    ['Beirut',      33.8938,  35.5018,  'Egyptian'],
+    ['Tabriz',      38.0667,  46.2993,  'Tehran'],
+    ['Dearborn',    42.3223, -83.1763,  'ISNA'],
+  ]
+
+  it.each(cases)('%s → city.name=%s, recommendedMethod=%s, methodSource=city-institutional', (city, lat, lon, expectedMethod) => {
+    const loc = detectLocation(lat, lon)
+    expect(loc.city.name).toBe(city)
+    expect(loc.recommendedMethod).toBe(expectedMethod)
+    expect(loc.methodSource).toBe('city-institutional')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. prayerTimes return value carries location field intact through wrapper
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('public API — prayerTimes location field', () => {
+  it('prayerTimes return value has location field with expected shape', () => {
+    const r = prayerTimes({ latitude: 21.4225, longitude: 39.8262, date: TEST_DATE })
+    expect(r.location).toBeDefined()
+    expect(r.location.city).not.toBeNull()
+    expect(r.location.city.name).toBe('Mecca')
+    expect(r.location.country).toBe('SaudiArabia')
+    expect(typeof r.location.timezone).toBe('string')
+    expect(typeof r.location.elevation).toBe('number')
+    expect(r.location.methodSource).toBe('country-default')
+    expect(['caller-explicit', 'city-registry', 'default-zero']).toContain(r.location.elevationSource)
+  })
+
+  it('prayerTimes location field reflects city-institutional override (Mosul)', () => {
+    const r = prayerTimes({ latitude: 36.3489, longitude: 43.1577, date: TEST_DATE })
+    expect(r.location.methodSource).toBe('city-institutional')
+    expect(r.method).toMatch(/Karachi/i)
+  })
+
+  it('prayerTimes elevation override produces elevationSource=caller-explicit', () => {
+    const r = prayerTimes({ latitude: 24.7136, longitude: 46.6753, date: TEST_DATE, elevation: 612 })
+    expect(r.location.elevationSource).toBe('caller-explicit')
+    expect(r.location.elevation).toBe(612)
+  })
+
+  it('dayTimes also carries the location field (extends prayerTimes)', () => {
+    const r = dayTimes({ latitude: 21.4225, longitude: 39.8262, date: TEST_DATE })
+    expect(r.location).toBeDefined()
+    expect(r.location.city.name).toBe('Mecca')
+    // dayTimes-specific fields still present
+    expect(r.midnight).toBeInstanceOf(Date)
+    expect(r.qiyam).toBeInstanceOf(Date)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Privacy / purity — no side effects
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('detectLocation — privacy + referential transparency', () => {
+  it('detectLocation called twice with identical args returns identical structure', () => {
+    const a = detectLocation(36.3489, 43.1577)
+    const b = detectLocation(36.3489, 43.1577)
+    // Same city, same country, same method, same source-type. We don't
+    // require object-reference equality (the impl returns fresh objects),
+    // but the structural payload is invariant.
+    expect(a.city.name).toBe(b.city.name)
+    expect(a.country).toBe(b.country)
+    expect(a.recommendedMethod).toBe(b.recommendedMethod)
+    expect(a.methodSource).toBe(b.methodSource)
+    expect(a.source.type).toBe(b.source.type)
+  })
+
+  it('detectLocation does not mutate the global Date or Math state', () => {
+    const before = Date.now()
+    detectLocation(36.3489, 43.1577)
+    const after = Date.now()
+    // detectLocation should be fast (microseconds); 100ms is a generous
+    // ceiling that catches any accidental I/O regression.
+    expect(after - before).toBeLessThan(100)
+  })
+
+  it('fallbackElevation default is 0', () => {
+    const loc = detectLocation(0, -30)  // open ocean, no city, no country
+    expect(loc.elevation).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Cross-check: detectLocation country matches the country detected by
+//    prayerTimes (the engine uses the same detectCountry bbox table).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('detectLocation — consistency with prayerTimes country resolution', () => {
+  it('Mecca: detectLocation.country === prayerTimes.location.country', () => {
+    const loc = detectLocation(21.4225, 39.8262)
+    const times = prayerTimes({ latitude: 21.4225, longitude: 39.8262, date: TEST_DATE })
+    expect(loc.country).toBe(times.location.country)
+  })
+
+  it('Cape Town: detectLocation.country === prayerTimes.location.country', () => {
+    const loc = detectLocation(-33.92, 18.42)
+    const times = prayerTimes({ latitude: -33.92, longitude: 18.42, date: TEST_DATE })
+    expect(loc.country).toBe(times.location.country)
+  })
+
+  it('Dearborn: detectLocation.country resolves, recommendedMethod=ISNA, prayerTimes uses ISNA', () => {
+    const loc = detectLocation(42.3223, -83.1763)
+    const times = prayerTimes({ latitude: 42.3223, longitude: -83.1763, date: TEST_DATE })
+    // The detectCountry table uses 'USA' as the country key for the US bbox.
+    expect(loc.country).toBe('USA')
+    expect(loc.recommendedMethod).toBe('ISNA')
+    expect(times.location.methodSource).toBe('city-institutional')
+    expect(times.method).toMatch(/ISNA|NorthAmerica/i)
+  })
+})


### PR DESCRIPTION
## Summary

Final phase of v1.7.0 — wires `detectLocation` into the public API surface, adds full TypeScript types for the new city/location surface, ships the README recipe section, and bumps the version to **1.7.0**. After this lands, `git tag v1.7.0` + the publish workflow ship the release to npm.

- **`src/index.js`** — adds `detectLocation` to both the named exports and the default-export namespace. Thin pass-through wrapper around the engine's internal implementation, with privacy-assertion docstring. `detectCountry` is *not* re-exported (kept internal — callers wanting just the country use `detectLocation(...).country`).
- **`src/index.d.ts`** — adds `City`, `AltMethod`, `CitySource`, `Location`, `PrayerTimesLocation` interfaces and `MethodSource` / `ElevationSource` string-literal-union types. `PrayerTimesParams` gets richer JSDoc explaining the omit-vs-explicit-zero distinction for elevation and the method dispatcher. `PrayerTimesResult` gains the `location` field (always populated, non-breaking additive change).
- **`README.md`** — new "City-aware location resolution (v1.7.0)" section after the v1.5.1 ihtiyat-rounding section. Lists all 12 method-override cities with institutional source, documents the bundle-size delta (~95 KB cities.json), embeds the privacy assertion as its own callout, includes a copy-pasteable recipe code example. Status blockquote updated to v1.7.0; API-stability table gains `detectLocation` and `location` field.
- **`test/publicApi.test.js`** (new) — 30 tests covering: export contract, return-shape contract, 12-city sweep, `prayerTimes.location` field through public wrapper, `dayTimes` location coverage, privacy/purity (no Date / Math mutation), country-resolution consistency between `detectLocation` and `prayerTimes`.
- **`package.json`** — version bump 1.7.0-alpha.1 → 1.7.0.

## The new TypeScript types

```ts
export interface AltMethod {
  method: string
  source: string
  populationShare?: number
}

export interface CitySource {
  type: 'mawaqit' | 'national-authority' | 'aladhan' | 'inherited' | 'fallback'
  slug?: string
  institution?: string
  from?: string
}

export interface City {
  name: string
  nameLocal?: string
  countryISO: string
  adminRegion?: string
  lat: number
  lon: number
  bbox: [number, number, number, number]
  population?: number
  elevation?: number
  timezone?: string
  methodOverride?: string
  altMethods?: AltMethod[]
  source?: CitySource
}

export type MethodSource = 'caller-explicit' | 'city-institutional' | 'country-default' | 'fallback'
export type ElevationSource = 'caller-explicit' | 'city-registry' | 'default-zero'

export interface PrayerTimesLocation {
  city: City | null
  country: string | null
  timezone: string
  elevation: number
  methodSource: MethodSource
  elevationSource: ElevationSource
}

export interface Location {
  city: City | null
  country: string | null
  timezone: string
  elevation: number
  recommendedMethod: string
  methodSource: MethodSource
  altMethods?: AltMethod[]
  source: CitySource
}

export function detectLocation(
  latitude: number,
  longitude: number,
  fallbackElevation?: number,
): Location
```

`PrayerTimesResult` now has a `location: PrayerTimesLocation` field (additive, non-breaking).

## The new README section

- Lists all 12 method-override cities with their institutional source.
- Documents which 4 cities (Mosul, Najaf, Karbala, Basra) change clock-time materially vs. the pre-v1.7.0 country-default; the other 8 are notes-only.
- Documents the auto-elevation behaviour (omit `elevation` to get city-registry; pass explicit `elevation: 0` to opt out).
- Documents the auto-method behaviour (omit `method` to get city institutional override; pass explicit method to override).
- Bundle-size delta documented: +~95 KB for the 375-city `src/data/cities.json`.
- Privacy assertion as its own callout paragraph.
- Cross-link to [`scripts/data/city-method-overrides.json`](../blob/master/scripts/data/city-method-overrides.json) for transparency.
- Recipe code example using `detectLocation` and `prayerTimes` with `location` field.

## Test count + result

**161 passed (131 pre-existing + 30 new in `test/publicApi.test.js`)**. All in `vitest run`. The 30 new tests cover:

- 3 export-contract tests (named + default + identity)
- 5 return-shape tests (Mecca / Mosul / open-ocean / fallback elevation / city-elevation priority)
- 12 method-override sweep (one per city)
- 4 prayerTimes.location tests through public wrapper
- 1 dayTimes location-field test
- 3 privacy/purity tests (no Date mutation, no Math mutation, fallback default)
- 3 country-resolution-consistency tests (Mecca / Cape Town / Dearborn)

## Constraints respected

- `prayerTimes` / `dayTimes` / `tarabishyTimes` / `applyElevationCorrection` / `applyTayakkunBuffer` signatures unchanged. The new `location` field is an additive, non-breaking addition (existing callers ignore it).
- No 🔴 (novel) classifications introduced. The `detectLocation` wrapper is 🟢 (pure lookup); the 12 city-method overrides are pre-existing in master and are 🟢 / 🟡→🟢 with cited institutional sources.
- No `eval/*`, `knowledge/wiki/*`, or `src/engine.js` changes. The change is API-surface-only on top of the phase 1 + phase 2 plumbing already on master.

## agiftoftime announcement (draft — file after merge)

<details>
<summary>Click to expand the gh issue body for the agiftoftime cross-repo announcement</summary>

```
Title: [fajr↔agiftoftime] v1.7.0 released — city-aware location resolution + auto-elevation + auto-method
Repo:  tawfeeqmartin/agiftoftime

Body:
v1.7.0 ships fajr's first city-aware layer. The headline addition is a public `detectLocation(lat, lon)` and a `location` field on every `prayerTimes()` / `dayTimes()` return value, both backed by a bundled 375-city registry.

## What's new

- **`detectLocation(lat, lon, fallbackElevation?)`** — pure function exported from `@tawfeeqmartin/fajr`. Returns `{ city, country, timezone, elevation, recommendedMethod, methodSource, altMethods?, source }`. Returns `city: null` honestly when no registry city matches; never returns a wrong-city default.
- **`location` field on `prayerTimes` return value** — always populated. Carries `{ city, country, timezone, elevation, methodSource, elevationSource }`. Apps can render "you are in Cape Town" and explain "Why is my Fajr at this time?" without a separate reverse-geocode.
- **City-level institutional method overrides for 12 cities**:
  - **Clock-time-changing (4)**: Mosul → Karachi (Iraqi Sunni Endowment Office; Fajr +8min vs. country default Egyptian); Najaf, Karbala, Basra → Tehran (Sistani-aligned Twelver Shia Imsakiyya; Isha −17 to −18min vs. Egyptian).
  - **Notes-only (8) — same clock time, observable via `location.methodSource` flipping to `city-institutional`**: Sarajevo, Mostar, Banja Luka (Rijaset BiH); Pristina (BIK Kosovo); Bradford (BCOM Council of Mosques UK); Beirut (Dar al-Fatwa Lebanon); Tabriz (Tehran Institute of Geophysics); Dearborn (ISNA convention).
- **Auto-elevation**: omit `elevation` to get city-registry value; pass explicit `elevation: 0` to opt out. Mexico City auto-uses 2,240m; Riyadh 612m; Cape Town 25m. The v1.5.2 ≥500m advisory still fires alongside the new auto-elevation note.
- **Auto-method**: omit `method` to use city `methodOverride` if present, then country default; pass explicit method to bypass.
- **Bundle delta: +~95 KB** (`src/data/cities.json`, 375 cities). One linear scan per `prayerTimes` call; registry pre-sorted with smallest bboxes first so metropolitan-area matches short-circuit.
- **Privacy**: fajr never logs, persists, or transmits the coordinates you pass it. The city resolution happens entirely locally via the bundled registry. No telemetry, no analytics, no remote calls.

## Why it might matter to agiftoftime

- The location-picker UI now has an authoritative city name to display: `times.location.city.name`. Existing reverse-geocode wiring can be retired.
- The long-press provenance sheet can render `times.location.methodSource` ("city-institutional", "country-default") + `times.location.city.source.institution` ("Iraqi Sunni Endowment Office", "Rijaset Islamske Zajednice u BiH") for "Why this time?" UX.
- The `times.notes[]` array now contains "Method auto-resolved..." entries for the 12 override cities — agiftoftime's existing notes-rendering should pick these up automatically. Worth a visual check at Mosul / Sarajevo coords.
- Apps following the Saudi/jama'ah-unity stance for elevation should pass `elevation: 0` explicitly. Caller-explicit beats city-registry, so this is a safe one-line opt-out.

## Specific test/review asks

1. **Render `location.city.name` in the location-picker UI** at Cape Town coords (-33.92, 18.42), Mosul coords (36.34, 43.13), and Sarajevo coords (43.86, 18.41). Confirm the names render correctly (no garbling on Cyrillic/Arabic local-name fields).
2. **Render `location.altMethods` as a "see also" chip** in the method-display sheet at Beirut (33.89, 35.50) and Mosul (36.34, 43.13). Confirm the alt-method label and source-string read usefully — "Higher Islamic Shia Council of Lebanon" should make sense in a UI; "Aladhan world-default for Iraq" may be too internal-jargon — flag if so.
3. **Render `times.location.city.source.institution`** in the long-press provenance sheet for Mosul and Sarajevo. The Mosul value is the institution-string from the override row; confirm the wording is presentable.
4. **Confirm the auto-elevation note text reads cleanly** at Mexico City (19.43, -99.13) — should say something like "Elevation auto-resolved from city registry: Mexico City, 2240m". The ≥500m advisory should also fire alongside it.
5. **Test the back-compat**: pass `elevation: 0` at Mexico City and confirm the auto-elevation note is suppressed and `location.elevationSource === 'caller-explicit'`.
6. **Test the fallback path**: pass open-ocean coords (0, -30) and confirm graceful degradation — `location.city === null`, `location.country === null`, `location.methodSource === 'fallback'`. UI should not crash.

— fajr-agent
```

</details>

— fajr-agent