### PR TITLE
fix(asr): v1.7.1 — Maldives + Sri Lanka Shafi Asr (resolves #26)

### DIFF
--- a/autoresearch/logs/2026-05-03-03-15-v1.7.1-maldives-srilanka-asr.md
+++ b/autoresearch/logs/2026-05-03-03-15-v1.7.1-maldives-srilanka-asr.md
@@ -1,0 +1,80 @@
+# AutoResearch Run — 2026-05-03 03:15 UTC — v1.7.1 Maldives + Sri Lanka Asr school explicit
+
+## Hypothesis
+Issue #26 reported that Maldives + Sri Lanka were dispatching to `adhan.CalculationMethod.Karachi()` and that the Karachi preset defaults to **Hanafi Asr** (2× shadow), producing an Asr time ~30–60 min later than the Shafi'i-majority institutional convention in both countries. The fix proposed was to set `madhab = adhan.Madhab.Shafi` explicitly.
+
+## Wiki sources consulted
+- `knowledge/wiki/regions/maldives.md` — flagged comment-vs-code drift ("Umm al-Qura" comment vs Karachi code) and Asr-school open question
+- `knowledge/wiki/regions/srilanka.md` — flagged Asr-school open question; ACJU Shafi'i majority noted
+
+## Independent verification before change
+Inspected adhan-js source (`node_modules/adhan/lib/esm/CalculationParameters.js`) and confirmed via runtime probe:
+
+```js
+const adhan = require('adhan')
+const p = adhan.CalculationMethod.Karachi()
+console.log(p.madhab) // 'shafi'
+```
+
+**Finding:** The premise of issue #26 is incorrect. adhan-js's `CalculationParameters` constructor sets `madhab = Madhab.Shafi` as the class-level default (line 7 of CalculationParameters.js), and **none of the `CalculationMethod.*` factories override it**. So `Karachi()`, `MuslimWorldLeague()`, `Egyptian()`, etc. all return Shafi-Asr params by default. The Karachi-preset-is-Hanafi-Asr claim in the wiki and the issue body is a bug in the prior wiki write, not a bug in the code.
+
+Cross-checked against Aladhan API:
+- `https://api.aladhan.com/v1/timingsByCity?city=Male&country=Maldives` → method 1 (Karachi 18°/18°), `school=STANDARD` (Shafi). Asr 15:23 (Indian/Maldives).
+- `https://api.aladhan.com/v1/timingsByCity?city=Colombo&country=Sri+Lanka` → method 1 (Karachi 18°/18°), `school=STANDARD` (Shafi).
+
+So the Aladhan world default for both countries matches what the engine *was already producing*.
+
+## Change made
+`src/engine.js` `selectMethod()`:
+
+- `case 'Maldives':` — switched from a one-liner `return { params: adhan.CalculationMethod.Karachi(), ... }` to a block that explicitly sets `p.madhab = adhan.Madhab.Shafi` before return. Comment rewritten: previously incorrectly referenced "Umm al-Qura per IslamicFinder/MuslimPro Malé default" — corrected to cite Aladhan world default for Malé (method 1, Karachi, Standard Asr) and the multi-app convention. methodName updated from "Karachi (Maldives, Aladhan world default)" → "Karachi 18°/18° + Shafi Asr (Maldives Ministry of Islamic Affairs)".
+- `case 'SriLanka':` — same explicit-Shafi pattern. methodName updated from "Karachi (Sri Lanka, ACJU regional)" → "Karachi 18°/18° + Shafi Asr (Sri Lanka ACJU)".
+
+Both cases now classified `🟡→🟢 Approaching established` (Aladhan world default + multi-app convention; Ministry of Islamic Affairs / ACJU primary-source citation pending).
+
+Also updated `knowledge/wiki/regions/maldives.md` and `knowledge/wiki/regions/srilanka.md` to:
+1. Correct the wiki claim that "Karachi preset includes Hanafi Asr" — it does not; adhan-js's class-level default is Shafi.
+2. Close the "Open questions" sections by documenting the v1.7.1 resolution.
+3. Note the engine.js comment-vs-code drift (Maldives) is now reconciled.
+
+Bumped `package.json` version 1.7.0 → 1.7.1.
+
+## Before WMAE (run 2026-05-03T02:48:48.153Z, master tip pre-fix)
+```
+Train (ratchet)         WMAE  1.0668
+Holdout (test, 2980 entries)  WMAE  3.6624
+```
+
+## After WMAE (run 2026-05-03T03:14:34.776Z, with fix applied)
+```
+Train (ratchet)         WMAE  1.0668  (Δ  0.00)
+Holdout (test, 2980 entries)  WMAE  3.6624  (Δ  0.00)
+```
+
+## Per-region deltas
+All 38 train cells: Δ = 0.00 minutes. (Confirmed via `node eval/compare.js` per-cell breakdown.)
+
+## Signed-bias deltas
+All four tracked prayers (Fajr / Maghrib / Isha / Shuruq): Δ = 0.00 minutes. No ihtiyat-direction drift.
+
+## Sample Asr time delta — Malé + Colombo, 2026-05-02
+| Location | Karachi default (before) | Karachi + explicit Shafi (after) | Counterfactual: Karachi + Hanafi |
+|----------|--------------------------|-----------------------------------|----------------------------------|
+| Malé (4.18°N, 73.51°E) | 10:21 UTC | 10:21 UTC (no change, Δ=0 min) | 11:26 UTC (+65 min — what issue #26 thought we were shipping) |
+| Colombo (6.93°N, 79.86°E) | 09:54 UTC | 09:54 UTC (no change, Δ=0 min) | 11:01 UTC (+67 min — what issue #26 thought we were shipping) |
+
+The fix is a **defense-in-depth** change: explicit madhab assignment ensures the population continues to receive Shafi Asr even if a future adhan-js release alters its class-level default. Without the explicit assignment, ~2.5M Muslims in Maldives + Sri Lanka would silently be exposed to a 65–67 minute Asr drift if upstream's default changed.
+
+## Verdict
+ACCEPTED on documentary/correctness grounds, NOT autoresearch ratchet grounds.
+
+`node eval/compare.js` returns FAIL ("Train WMAE did not strictly decrease") — wash rejection. This is correct ratchet behaviour: the change is a no-op in the train cells. The user explicitly noted in the dispatch instructions that wash-rejection is fine for a holdout-only correctness fix that defends against upstream drift and reconciles wiki/code/comment claims.
+
+Holdout WMAE also unchanged (Maldives + Sri Lanka holdout cells: 0 fixtures currently, so any improvement would have shown up only after the next fetch-aladhan run pulls Malé/Colombo data into `eval/data/test/`).
+
+Net effect: explicit madhab + corrected comments + corrected wiki + reconciled engine.js dispatch comment for Maldives + version bump 1.7.0 → 1.7.1.
+
+## Scholarly classification
+🟡→🟢 — Approaching established. Aladhan world default for both Malé and Colombo is `Karachi 18°/18° + Standard (Shafi) Asr`, reproducibly verified via API on 2026-05-02. ACJU and Maldives Ministry of Islamic Affairs primary-source citations remain pending (websites are user-agent-restricted and require deeper data hunt). Population: ~530k (Maldives, ~100% Sunni Shafi'i) + ~2.1M (Sri Lanka, Sunni Shafi'i Moor majority via ACJU). The explicit-Shafi assignment is institutionally aligned and matches multi-app convention.
+
+— fajr-agent

--- a/knowledge/wiki/regions/maldives.md
+++ b/knowledge/wiki/regions/maldives.md
@@ -7,29 +7,29 @@
 - **Madhab:** Sunni Shafi'i (overwhelmingly)
 
 ## Calculation method (as implemented in fajr)
-- **adhan.js method:** `Karachi` (18°/18°)
+- **adhan.js method:** `Karachi` (18°/18°) with explicit `madhab = Madhab.Shafi`
 - **Fajr angle:** 18°
 - **Isha angle:** 18°
-- **Asr school:** Hanafi (2× shadow) — *via the Karachi preset, which sets Hanafi Asr; this is a known mismatch since Maldives is Shafi'i*
+- **Asr school:** Standard (Shafi, 1× shadow length) — set explicitly in `selectMethod()` since v1.7.1
 - **Special offsets:** none
-- **Classification:** 🟢 Established (Aladhan world default for Malé)
+- **Classification:** 🟡→🟢 Approaching established (Aladhan world default + multi-app convention; Ministry of Islamic Affairs primary-source citation pending)
 
 ## Why this method
-The Aladhan API's default for Malé is "Karachi" (method 1), and IslamicFinder/Muslim Pro multi-app consensus aligns with the same 18°/18° angle pair — note that the engine.js comment notes "Maldives Ministry of Islamic Affairs: Umm al-Qura per IslamicFinder/MuslimPro Malé default" but the **shipped code uses `Karachi`**. This is a comment-vs-code drift to flag for the engine team.
+The Aladhan API's default for Malé is method 1 (`Karachi`, "University of Islamic Sciences, Karachi"), with `school=STANDARD` (Shafi Asr) — verified via `https://api.aladhan.com/v1/timingsByCity?city=Male&country=Maldives` on 2026-05-02. IslamicFinder/Muslim Pro multi-app consensus aligns with the same 18°/18° angle pair + Shafi Asr.
 
-**Asr school caveat:** The Karachi method preset includes Hanafi Asr (2× shadow) but Maldives is overwhelmingly Shafi'i (Standard Asr, 1× shadow). This produces an Asr time ~30–60 minutes later than the Maldivian institutional convention. A future refinement should switch Maldives to `Other` with explicit `fajrAngle = 18°, ishaAngle = 18°, madhab = Standard` if Maldivian institutional Imsakiyya confirms Standard Asr.
+**v1.7.1 fix (issue #26):** Earlier versions of this page and the engine.js comment mentioned "Umm al-Qura per IslamicFinder/MuslimPro Malé default" — that was incorrect; the actual Aladhan default is Karachi-angles, not Umm al-Qura. Both have been reconciled. The wiki claim that "Karachi preset includes Hanafi Asr (2× shadow)" was also incorrect — adhan-js's `CalculationMethod.Karachi()` returns `Madhab.Shafi` by default. The v1.7.1 fix sets madhab explicitly to defend against any future change in the upstream default.
 
 ## Known points of ikhtilaf within the country
 - None known at the institutional level — Maldives is religiously homogeneous.
 
-## Open questions
-- **Engine.js comment-vs-code drift** — the engine.js comment mentions "Umm al-Qura per IslamicFinder/MuslimPro Malé default" but the shipped routing is `Karachi`. Either the comment or the code needs correction. Recommend: verify against the Maldives Ministry of Islamic Affairs published Imsakiyya, then update both comment and code consistently.
-- **Asr school mismatch** — Karachi preset is Hanafi Asr; Maldives is Shafi'i (Standard Asr). Needs verification + fix.
+## Resolution log
+- **2026-05-02 (v1.7.1)** — Asr-school open question resolved. adhan-js's `CalculationMethod.Karachi()` already defaults to `Madhab.Shafi`, so no behavior change for Malé Asr; the v1.7.1 fix made the Shafi madhab explicit in the dispatch and corrected the comment-vs-code drift. Aladhan default for Malé verified as method 1 (Karachi) + Standard Asr (Shafi).
 
 ## Sources
 - Maldives Ministry of Islamic Affairs: https://www.islamicaffairs.gov.mv/
-- Aladhan API regional-default routing for `MV`
-- Multi-app convention (Muslim Pro Malé)
+- Aladhan API regional-default routing for `MV` — verified 2026-05-02: `method=1 (Karachi, 18°/18°)`, `school=STANDARD (Shafi)`
+- Multi-app convention (Muslim Pro Malé, IslamicFinder)
 
 ## Last reviewed
+- 2026-05-02 by fajr-agent (v1.7.1 — Asr-school resolution per issue #26)
 - 2026-05-02 by fajr-agent (initial creation per v1.6.0 audit log)

--- a/knowledge/wiki/regions/srilanka.md
+++ b/knowledge/wiki/regions/srilanka.md
@@ -7,30 +7,33 @@
 - **Madhab:** Sunni Shafi'i (overwhelmingly — Moor community); Hanafi (Indian-origin Memon community); Twelver Shi'a (small Bohra minority)
 
 ## Calculation method (as implemented in fajr)
-- **adhan.js method:** `Karachi` (18°/18°, Hanafi Asr)
+- **adhan.js method:** `Karachi` (18°/18°) with explicit `madhab = Madhab.Shafi`
 - **Fajr angle:** 18°
 - **Isha angle:** 18°
-- **Asr school:** Hanafi (2× shadow) — *note: Sri Lanka is majority Shafi'i; this may be a mismatch*
+- **Asr school:** Standard (Shafi, 1× shadow length) — set explicitly in `selectMethod()` since v1.7.1
 - **Special offsets:** none
-- **Classification:** 🟡 Limited precedent
+- **Classification:** 🟡→🟢 Approaching established (regional convention + Aladhan default; ACJU primary-source citation pending)
 
 ## Why this method
-ACJU is Sri Lanka's primary Sunni religious authority, established in 1924 and headquartered in Colombo. ACJU publishes Ramadan Imsakiyya and recommends adhan timings; aligned with the broader **South Asian regional Karachi 18°/18° convention** for the angle pair. However, Sri Lanka's Sunni majority is Shafi'i (1× shadow Asr), not Hanafi (2× shadow Asr) — using `adhan.CalculationMethod.Karachi()` produces a Hanafi-Asr output that is ~30–60 minutes later than the institutional Shafi'i convention.
+ACJU is Sri Lanka's primary Sunni religious authority, established in 1924 and headquartered in Colombo. ACJU publishes Ramadan Imsakiyya and recommends adhan timings; aligned with the broader **South Asian regional Karachi 18°/18° convention** for the angle pair. Sri Lanka's Sunni majority is Shafi'i (1× shadow Asr), not Hanafi.
 
-This is a known limitation; a future refinement should switch Sri Lanka to `Other` with explicit Standard Asr if ACJU's published Imsakiyya confirms.
+The Aladhan API default for Colombo is method 1 (`Karachi`, "University of Islamic Sciences, Karachi"), with `school=STANDARD` (Shafi Asr) — verified via `https://api.aladhan.com/v1/timingsByCity?city=Colombo&country=Sri+Lanka` on 2026-05-02. This matches ACJU's Shafi-majority convention.
+
+**v1.7.1 fix (issue #26):** Earlier versions of this page incorrectly claimed `adhan.CalculationMethod.Karachi()` ships Hanafi Asr (2× shadow) — but adhan-js's `Karachi()` actually defaults to `Madhab.Shafi`. The shipped Asr time has always been the Shafi-majority value; v1.7.1 makes the madhab assignment explicit in `selectMethod()` so future adhan-js default changes don't silently break the population.
 
 ## Known points of ikhtilaf within the country
-- **Shafi'i Moor majority** vs. **Hanafi Memon minority** — Asr time difference (Shafi'i 1× shadow earlier; Hanafi 2× shadow later).
+- **Shafi'i Moor majority** vs. **Hanafi Memon minority** — Asr time difference (Shafi'i 1× shadow earlier; Hanafi 2× shadow later, ~30–60 min depending on latitude/season).
 - **Bohra and Twelver Shi'a minorities** — follow their own conventions; not currently differentiated.
+- A future v1.7.x city-level override could route Memon-community mosques (predominantly in Colombo's Pettah district + select pockets) to a Hanafi-Asr variant.
 
-## Open questions
-- **Asr school mismatch** — Karachi preset is Hanafi Asr; Sri Lanka majority is Shafi'i (Standard Asr). Needs verification against ACJU Imsakiyya + fix.
-- Citation pending — primary-source verification from ACJU pending.
+## Resolution log
+- **2026-05-02 (v1.7.1)** — Asr-school open question resolved. adhan-js's `CalculationMethod.Karachi()` already defaults to `Madhab.Shafi`, so no behavior change for Colombo Asr; the v1.7.1 fix made the Shafi madhab explicit in the dispatch. Aladhan default for Colombo verified as method 1 (Karachi) + Standard Asr (Shafi). Memon-Hanafi minority noted for potential future city-level override.
 
 ## Sources
 - All Ceylon Jamiyyathul Ulama: https://acju.lk/
-- Aladhan API regional-default routing for `LK`
-- Multi-app convention (Muslim Pro Colombo)
+- Aladhan API regional-default routing for `LK` — verified 2026-05-02: `method=1 (Karachi, 18°/18°)`, `school=STANDARD (Shafi)`
+- Multi-app convention (Muslim Pro Colombo, IslamicFinder)
 
 ## Last reviewed
+- 2026-05-02 by fajr-agent (v1.7.1 — Asr-school resolution per issue #26)
 - 2026-05-02 by fajr-agent (initial creation per v1.6.0 audit log)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tawfeeqmartin/fajr",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "High-accuracy Islamic prayer time library combining NASA/JPL astronomical algorithms with classical Islamic scholarship",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/engine.js
+++ b/src/engine.js
@@ -806,14 +806,41 @@ function selectMethod(country, lat, coords) {
       return { params: adhan.CalculationMethod.MuslimWorldLeague(), methodName: 'MWL (Mozambique default)' }
 
     // ─── South Asia non-Pakistan ──────────────────────────────────────────
-    case 'Maldives':
-      // Maldives Ministry of Islamic Affairs: Umm al-Qura per IslamicFinder/
-      // MuslimPro Malé default. ~100% Sunni Shafi'i. Classification: 🟢.
-      return { params: adhan.CalculationMethod.Karachi(), methodName: 'Karachi (Maldives, Aladhan world default)' }
-    case 'SriLanka':
-      // All Ceylon Jamiyyathul Ulama / ACJU (Sunni Shafi'i): South Asian
-      // Karachi 18°/18° regional convention. Classification: 🟡.
-      return { params: adhan.CalculationMethod.Karachi(), methodName: 'Karachi (Sri Lanka, ACJU regional)' }
+    case 'Maldives': {
+      // Maldives Ministry of Islamic Affairs (~100% Sunni Shafi'i):
+      // Karachi 18°/18° angles + Standard (Shafi) Asr. Confirmed against
+      // Aladhan world default for Malé (method=1, school=STANDARD).
+      // v1.7.1 fix (issue #26): previous comment claimed "Umm al-Qura per
+      // IslamicFinder/MuslimPro Malé default" — code/comment drift; both
+      // now reconciled. The madhab is set explicitly to defend against any
+      // future change in adhan.js's default; today's default is already
+      // Shafi but explicit intent is safer.
+      // Classification: 🟡→🟢 Approaching established (Aladhan world default
+      // + multi-app convention; Ministry of Islamic Affairs primary-source
+      // citation pending).
+      // see knowledge/wiki/regions/maldives.md
+      const p = adhan.CalculationMethod.Karachi()
+      p.madhab = adhan.Madhab.Shafi
+      return { params: p, methodName: 'Karachi 18°/18° + Shafi Asr (Maldives Ministry of Islamic Affairs)' }
+    }
+    case 'SriLanka': {
+      // Sri Lanka — All Ceylon Jamiyyathul Ulama (ACJU, Sunni Shafi'i):
+      // Karachi 18°/18° angles + Standard (Shafi) Asr. Confirmed against
+      // Aladhan world default for Colombo (method=1, school=STANDARD).
+      // v1.7.1 fix (issue #26): previous comment did not state Asr school;
+      // now made explicit. The madhab is set explicitly so future adhan.js
+      // default changes don't silently break the Shafi-majority population.
+      // ~10% of Sri Lanka's ~22M is Muslim (Moor majority Shafi'i + Memon
+      // minority Hanafi); this dispatch serves the Shafi'i majority. A
+      // future v1.7.x city-level override could route Memon-community
+      // mosques to a Hanafi-Asr variant.
+      // Classification: 🟡→🟢 Approaching established (regional convention
+      // + Aladhan default; ACJU primary-source citation pending).
+      // see knowledge/wiki/regions/srilanka.md
+      const p = adhan.CalculationMethod.Karachi()
+      p.madhab = adhan.Madhab.Shafi
+      return { params: p, methodName: 'Karachi 18°/18° + Shafi Asr (Sri Lanka ACJU)' }
+    }
     case 'Bangladesh':
       // Islamic Foundation Bangladesh: same Karachi 18°/18° as Pakistan
       // (Hanafi). ITL/arabeyes documents BD in Karachi cluster.


### PR DESCRIPTION
## Summary

Resolves issue #26 — Maldives + Sri Lanka Asr school dispatch. Investigation found the issue's stated premise (\`adhan.CalculationMethod.Karachi()\` defaults to Hanafi Asr) is **incorrect**: adhan-js's \`CalculationParameters\` class-level default is \`Madhab.Shafi\`, and none of the preset factories override it. The shipped Asr time has always been Shafi-majority for both countries.

The fix is therefore documentary + defensive:
- **\`src/engine.js\`** — set \`p.madhab = adhan.Madhab.Shafi\` explicitly in both case blocks. Any future change in adhan-js's class-level default cannot silently expose ~2.5M Shafi'i Muslims to a ~65 min Asr drift.
- **\`src/engine.js\` Maldives comment** — corrected (was: "Umm al-Qura per IslamicFinder/MuslimPro Malé default" — same comment-vs-code drift the v1.6.0 audit caught).
- **\`knowledge/wiki/regions/maldives.md\` + \`srilanka.md\`** — correct the prior wiki claim that Karachi preset ships Hanafi Asr (it doesn't); close the Asr-school "Open questions" sections.
- **\`package.json\`** — 1.7.0 → 1.7.1.

Verification: queried Aladhan API world default for both Malé and Colombo (2026-05-02) — both return method 1 (Karachi 18°/18°) with \`school=STANDARD\` (Shafi).

## Sample Asr time delta — 2026-05-02

| Location | Karachi default (before) | Karachi + explicit Shafi (after) | Counterfactual: Karachi + Hanafi |
|----------|--------------------------|-----------------------------------|----------------------------------|
| Malé (4.18°N, 73.51°E) | 10:21 UTC | 10:21 UTC (Δ=0) | 11:26 UTC (+65 min) |
| Colombo (6.93°N, 79.86°E) | 09:54 UTC | 09:54 UTC (Δ=0) | 11:01 UTC (+67 min) |

Behavioural change: 0 min (defence-in-depth — explicit assignment locks the intent so a future adhan-js default flip can't drift either population by ~65 min silently).

## Eval

```
Train WMAE     1.0668 → 1.0668  (Δ  0.00, wash — expected)
Holdout WMAE   3.6624 → 3.6624  (Δ  0.00)
```

\`node eval/compare.js\` returns FAIL ("Train WMAE did not strictly decrease"). This is correct ratchet behaviour — the change is a no-op in train cells. Per the dispatch instructions for this fix: wash-rejection is fine for a holdout-only correctness fix that defends against upstream drift and reconciles wiki/code/comment claims.

## Classification

🟡→🟢 Approaching established — Aladhan world default + multi-app convention; ACJU + Maldives Ministry of Islamic Affairs primary-source citations remain pending.

Closes #26

## Test plan

- [x] \`npm test\` — all 161 tests pass
- [x] \`node eval/eval.js\` — train WMAE 1.0668, holdout WMAE 3.6624 (no drift)
- [x] \`node eval/compare.js\` — wash rejection (expected for documentary fix)
- [x] Asr time deltas verified for Malé + Colombo on 2026-05-02
- [x] Aladhan API world default verified for both countries (method=1, school=STANDARD)
- [x] adhan-js class-level Madhab default verified (\`Madhab.Shafi\` per \`CalculationParameters.js\`)
- [x] Bismillah headers present (engine.js)
- [x] Both case blocks carry 🟡→🟢 classification + wiki citation
- [x] No public API change (\`src/index.js\`, \`src/index.d.ts\` untouched)
- [x] Autoresearch log filed at \`autoresearch/logs/2026-05-03-03-15-v1.7.1-maldives-srilanka-asr.md\`

— fajr-agent