### PR TITLE
feat(location): v1.7.3 — nearestCity for offline display label (resolves #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **A region-aware auto-configuration layer over [`adhan.js`](https://github.com/batoulapps/adhan-js), plus an evolving accuracy-research framework.** Fajr picks the right calculation method for your coordinates automatically, ships a small set of community-calibrated regional adjustments not in adhan's defaults (Morocco 19°/17°, France UOIF 12°/12°, high-latitude rule selection), adds **hilal (lunar crescent) visibility prediction via three criteria computed side-by-side — Odeh (2004), Yallop (1997), and Shaukat (2002)** (adhan is solar-only — fajr ships its own Meeus-based lunar position stack, validated 5/5 astronomically defensible against documented Hijri month transitions, with `criteriaAgree` flagging borderline ikhtilaf cases when any of the three disagrees), and runs an autoresearch loop that validates engine changes against multiple independent reference layers — mosque-published times (Mawaqit), institutional tables (Diyanet, JAKIM), and regional-method consensus (Aladhan, praytimes.org). Currently spans 38 cities across 12 institutional-train countries plus a 163-country Aladhan-routed holdout corpus. The eval framework, plus the hilal/lunar implementation, is where most of fajr's distinctive engineering lives today.
 
-> **Status — v1.7.** Public API surfaces (`prayerTimes`, `dayTimes`, `tarabishyTimes`, `detectLocation`, `applyElevationCorrection`, `applyTayakkunBuffer`, `hilalVisibility`, `qibla`, `hijri`, `nightThirds`, `travelerMode`) are stable; breaking changes will require a major version bump. **v1.7.0 ships city-aware location resolution**: a bundled 375-city registry powers automatic city detection, city-registry elevation surfacing (no more silent sea-level for Mexico City / Cape Town / Riyadh users), and city-level institutional method overrides for 12 cities where intra-country *ikhtilaf* matters (Mosul → Karachi via Sunni-Awqaf, Najaf/Karbala/Basra → Tehran via Twelver Shia hawza, Sarajevo/Mostar/Banja Luka/Pristina → Diyanet via Bosnian Rijaset / BIK, Bradford → MoonsightingCommittee via BCOM, Beirut → Egyptian via Dar al-Fatwa, Tabriz → Tehran, Dearborn → ISNA). Apps gain a `location` field on every `prayerTimes` return value with city/country/timezone/method-source plus a public `detectLocation(lat, lon)` for standalone resolution — see [City-aware location resolution (v1.7.0)](#city-aware-location-resolution-v170). v1.6.0 expanded country dispatch from 27 to 78 countries with bbox-based method selection (163 by v1.6.2). v1.5.2 added an **elevation advisory** at altitudes ≥ 500 m surfacing the UAE/JAKIM-vs-Saudi institutional disagreement so apps can present the user with an informed choice — see [Elevation advisory at significant altitude](#elevation-advisory-at-significant-altitude-v152). v1.5.1 introduced **per-prayer ihtiyat-aware minute rounding** (every displayed minute is on the prayer-validity-safe side of actual reality, by construction) and an explicit **`imsak`** field for fasting-yaqeen — see the principle table in [Per-prayer ihtiyat-aware minute rounding](#per-prayer-ihtiyat-aware-minute-rounding-v151). v1.5.0 shipped the Morocco Maghrib +5min Path A across 23 mosques. v1.3 added the Aabed-2015 tayakkun buffer and Tarabishy-2014 latitude-truncation method as opt-in alternatives, plus a `notes: string[]` field on `prayerTimes` output that surfaces scholarly-grounded location-specific advisories (currently the Odeh-2009 high-latitude regime warning at \|lat\| ≥ 48.6°). See [API stability](#api-stability) below. Live numbers and per-source breakdown are auto-generated in [`docs/progress.md`](docs/progress.md) on every `npm run build:charts`.
+> **Status — v1.7.** Public API surfaces (`prayerTimes`, `dayTimes`, `tarabishyTimes`, `detectLocation`, `nearestCity`, `applyElevationCorrection`, `applyTayakkunBuffer`, `hilalVisibility`, `qibla`, `hijri`, `nightThirds`, `travelerMode`) are stable; breaking changes will require a major version bump. **v1.7.3 adds `nearestCity(lat, lon)`** — a kNN-fuzzy *display-only* lookup that always returns a city + haversine distance in km, for downstream apps that want to render "near \<City\> (\<distance\> km)" labels when the user's GPS resolves outside any registered city's bbox. The strict `detectLocation` containment continues to drive prayer-time dispatch unchanged. **v1.7.0 ships city-aware location resolution**: a bundled 375-city registry powers automatic city detection, city-registry elevation surfacing (no more silent sea-level for Mexico City / Cape Town / Riyadh users), and city-level institutional method overrides for 12 cities where intra-country *ikhtilaf* matters (Mosul → Karachi via Sunni-Awqaf, Najaf/Karbala/Basra → Tehran via Twelver Shia hawza, Sarajevo/Mostar/Banja Luka/Pristina → Diyanet via Bosnian Rijaset / BIK, Bradford → MoonsightingCommittee via BCOM, Beirut → Egyptian via Dar al-Fatwa, Tabriz → Tehran, Dearborn → ISNA). Apps gain a `location` field on every `prayerTimes` return value with city/country/timezone/method-source plus a public `detectLocation(lat, lon)` for standalone resolution — see [City-aware location resolution (v1.7.0)](#city-aware-location-resolution-v170). v1.6.0 expanded country dispatch from 27 to 78 countries with bbox-based method selection (163 by v1.6.2). v1.5.2 added an **elevation advisory** at altitudes ≥ 500 m surfacing the UAE/JAKIM-vs-Saudi institutional disagreement so apps can present the user with an informed choice — see [Elevation advisory at significant altitude](#elevation-advisory-at-significant-altitude-v152). v1.5.1 introduced **per-prayer ihtiyat-aware minute rounding** (every displayed minute is on the prayer-validity-safe side of actual reality, by construction) and an explicit **`imsak`** field for fasting-yaqeen — see the principle table in [Per-prayer ihtiyat-aware minute rounding](#per-prayer-ihtiyat-aware-minute-rounding-v151). v1.5.0 shipped the Morocco Maghrib +5min Path A across 23 mosques. v1.3 added the Aabed-2015 tayakkun buffer and Tarabishy-2014 latitude-truncation method as opt-in alternatives, plus a `notes: string[]` field on `prayerTimes` output that surfaces scholarly-grounded location-specific advisories (currently the Odeh-2009 high-latitude regime warning at \|lat\| ≥ 48.6°). See [API stability](#api-stability) below. Live numbers and per-source breakdown are auto-generated in [`docs/progress.md`](docs/progress.md) on every `npm run build:charts`.
 
 ---
 
@@ -420,6 +420,43 @@ console.log(loc.source.institution)   // (mawaqit-typed source — slug populate
 
 The principle behind v1.7.0 is the same one driving the rest of fajr's library design: **surface scholarly disagreement transparently, don't resolve it silently.** The 12 method-override cities each carry an institutional citation that a reviewer can audit; each surfaces minority alternatives via `altMethods`; the engine's choice is reported via `location.methodSource` so apps can show users *why* a particular method was selected and offer them the alternative.
 
+### Nearest-city display label (v1.7.3)
+
+`detectLocation(lat, lon)` is bbox-precise — it returns `city: null` honestly when the user's GPS resolves outside any of the 375 registered cities. That's the right answer for *computation* (apps should never silently apply a possibly-distant city's institutional method to a user who is not in that city), but it leaves apps without a label when they want to render "near \<City\>" in their UI.
+
+v1.7.3 introduces a separate, deliberately-narrower function for that:
+
+```js
+import { nearestCity } from '@tawfeeqmartin/fajr'
+
+const r = nearestCity(-27.4, 153.0)
+// → { city: { name: 'Brisbane', countryISO: 'AU', ... }, distanceKm: 7.8 }
+```
+
+`nearestCity` is **kNN-fuzzy** — a linear haversine scan over the 375-row registry that always returns a city, never null. It is **DISPLAY-ONLY**. The two functions are deliberately separate:
+
+| Function | Resolution | Returns null? | Used for |
+|---|---|---|---|
+| `detectLocation(lat, lon)` | Bbox-precise containment | Yes — when outside every registered bbox | Method override, elevation, prayer-time dispatch |
+| `nearestCity(lat, lon)` | kNN haversine (always-nearest) | No — always returns a city | UI label only, never affects dispatch |
+
+Recipe — try `detectLocation` first, fall back to `nearestCity` for the label:
+
+```js
+import { detectLocation, nearestCity } from '@tawfeeqmartin/fajr'
+
+const loc = detectLocation(lat, lon)
+const label = loc.city
+  ? loc.city.name
+  : `near ${nearestCity(lat, lon).city.name} (${nearestCity(lat, lon).distanceKm.toFixed(1)} km)`
+```
+
+This separation is load-bearing: a user 80 km outside any registered city gets the honest "near Brisbane (78 km)" UI label *and* fajr's prayer-time computation continues to use the country-default dispatch (not Brisbane's institutional override). The display-only contract is what keeps the dispatch path's accuracy promise intact while still giving downstream apps a graceful label.
+
+For coordinates very far from any city (deep ocean, polar research stations), `distanceKm` will be in the thousands — apps may want to suppress the label above some threshold (e.g. 200 km) to avoid showing "near Christchurch (3,400 km)" in the Antarctic.
+
+Classification: 🟢 Established — pure lookup, no shar'i ruling involved.
+
 ---
 
 ## Historical Results (Experiment 1–7 narrative)
@@ -637,6 +674,7 @@ fajr v1.0 makes the following stability promises. **Stable** surfaces will not c
 | `prayerTimes` | `({ latitude, longitude, date, elevation?, method? }) → { fajr, shuruq, sunrise, dhuhr, asr, maghrib, sunset, isha, method, notes, corrections, location }` | v1.0 (`sunrise` alias added v1.0.1; `sunset` and `notes` added v1.1+; `location` added v1.7) |
 | `dayTimes` | `({ latitude, longitude, date, elevation?, method? }) → prayerTimes shape ∪ { midnight, qiyam }` | v1.1 |
 | `detectLocation` | `(latitude, longitude, fallbackElevation?) → { city, country, timezone, elevation, recommendedMethod, methodSource, altMethods?, source }` | v1.7 |
+| `nearestCity` | `(latitude, longitude) → { city, distanceKm }` (kNN-fuzzy display-only label; never null) | v1.7.3 |
 | `applyElevationCorrection` | `(times, elevation, latitude?) → times` (opt-in geometric horizon-dip) | v1.0 |
 | `applyTayakkunBuffer` | `(times, mins=5) → times` (opt-in Fajr buffer per Aabed 2015) | v1.3 |
 | `tarabishyTimes` | `(params, thresholdLat=45) → prayerTimes shape` (opt-in 45°-truncation per Tarabishy 2014) | v1.3 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tawfeeqmartin/fajr",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "High-accuracy Islamic prayer time library combining NASA/JPL astronomical algorithms with classical Islamic scholarship",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/engine.js
+++ b/src/engine.js
@@ -1450,6 +1450,113 @@ export function detectLocation(latitude, longitude, fallbackElevation = 0) {
   return out
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// v1.7.3: nearestCity — kNN-fuzzy display-only city lookup
+//
+// Resolves a (lat, lon) coordinate to the geographically nearest city in the
+// bundled registry, with the haversine distance in km. Always returns a city —
+// never null. Exists for one purpose: letting downstream apps render a
+// human-readable "near <City> (<distance> km)" label when the user's GPS
+// resolves outside any registered city's bbox (so detectLocation returned
+// city: null).
+//
+// CRITICAL CONTRACT (the user pushed back on this explicitly):
+//   nearestCity is DISPLAY-ONLY. It MUST NOT affect prayer-time computation.
+//   The dispatch path (method override + elevation) continues to use
+//   detectLocation's strict bbox containment. nearestCity is never called
+//   from inside prayerTimes() or detectLocation(). If a future change wants
+//   to use nearestCity for "snap-to-nearest-city" method dispatch when the
+//   user is < N km from a registered city, that is a separate (v1.8.0+)
+//   design decision — and one with shar'i implications, since it would
+//   silently apply a city's institutional method to a user who is not in
+//   that city.
+//
+// see knowledge/wiki/api/detectLocation.md (proposed)
+// Classification: 🟢 Established — pure lookup, no shar'i ruling involved.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute great-circle distance between two (lat, lon) points in kilometres
+ * using the haversine formula. Private helper for nearestCity. Earth-radius
+ * convention: mean radius 6371 km (sufficient for display-label distances;
+ * the < 0.5% latitude-dependent flattening error is below visual resolution
+ * for "near <City>" UI).
+ *
+ * @param {number} lat1
+ * @param {number} lon1
+ * @param {number} lat2
+ * @param {number} lon2
+ * @returns {number}  distance in km
+ */
+function haversineKm(lat1, lon1, lat2, lon2) {
+  const R = 6371  // Earth mean radius, km
+  const dLat = (lat2 - lat1) * Math.PI / 180
+  const dLon = (lon2 - lon1) * Math.PI / 180
+  const a = Math.sin(dLat / 2) ** 2 +
+            Math.cos(lat1 * Math.PI / 180) *
+            Math.cos(lat2 * Math.PI / 180) *
+            Math.sin(dLon / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+/**
+ * kNN-fuzzy lookup: return the closest city in the bundled registry to
+ * (lat, lon), along with the haversine distance in km.
+ *
+ * DISPLAY-ONLY. Does NOT affect prayer-time dispatch — use `detectLocation`
+ * for that (which is bbox-precise and returns `city: null` honestly when
+ * outside any registered bbox). The two functions are deliberately separate:
+ *
+ *   detectLocation(lat, lon)  → bbox-precise; null when outside;
+ *                                drives method + elevation dispatch
+ *   nearestCity(lat, lon)     → kNN-fuzzy; never null;
+ *                                display label only
+ *
+ * Typical usage from a downstream app:
+ *
+ *   const loc = detectLocation(lat, lon)
+ *   if (loc.city) {
+ *     label = loc.city.name                                  // bbox-precise
+ *   } else {
+ *     const near = nearestCity(lat, lon)
+ *     label = `near ${near.city.name} (${near.distanceKm.toFixed(1)} km)`
+ *   }
+ *
+ * Implementation: linear scan O(n) over 375 entries; ~50 microseconds per
+ * call. No need for a k-d tree or grid bucket at this scale.
+ *
+ * Always returns a city; the registry covers every populated continent so
+ * no input — including mid-ocean or polar coordinates — produces null.
+ * For coordinates very far from any city (open ocean, deep Antarctica),
+ * `distanceKm` will be in the thousands — apps may want to suppress the
+ * label above some threshold (e.g. 200 km) to avoid showing "near
+ * Christchurch (3,400 km)" on a polar research station.
+ *
+ * Privacy: the (lat, lon) you pass is not logged, persisted, or transmitted
+ * anywhere. The lookup happens entirely locally via the bundled
+ * `src/data/cities.json` registry.
+ *
+ * Classification: 🟢 Established — pure lookup, no shar'i ruling involved.
+ *
+ * @param {number} latitude   degrees
+ * @param {number} longitude  degrees
+ * @returns {{ city: object, distanceKm: number }}  always non-null city
+ */
+export function nearestCity(latitude, longitude) {
+  const list = (citiesRegistry && citiesRegistry.cities) || []
+  let best = null
+  let bestDist = Infinity
+  for (let i = 0; i < list.length; i++) {
+    const c = list[i]
+    const d = haversineKm(latitude, longitude, c.lat, c.lon)
+    if (d < bestDist) {
+      bestDist = d
+      best = c
+    }
+  }
+  return { city: best, distanceKm: bestDist }
+}
+
 /**
  * String → adhan method-params dispatcher.
  *

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -189,6 +189,56 @@ export function detectLocation(
 ): Location
 
 // ─────────────────────────────────────────────────────────────────────────────
+// nearestCity — kNN-fuzzy display-only city lookup (v1.7.3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Result of `nearestCity(lat, lon)`. The `city` field is always non-null —
+ *  the registry covers every populated continent so no input produces a null
+ *  match. For coordinates very far from any city (open ocean, deep
+ *  Antarctica), `distanceKm` will be in the thousands; apps may want to
+ *  suppress the label above some threshold to avoid showing
+ *  "near Christchurch (3,400 km)" on a polar research station. */
+export interface NearestCityResult {
+  /** Closest city in the bundled registry. Always populated — never null. */
+  city: City
+  /** Great-circle (haversine) distance in km from (lat, lon) to `city.lat / city.lon`. */
+  distanceKm: number
+}
+
+/** kNN-fuzzy display-label lookup: return the closest city in the bundled
+ *  registry to (lat, lon), with the haversine distance in km.
+ *
+ *  **DISPLAY-ONLY.** For prayer-time dispatch (method override + elevation),
+ *  use `detectLocation` instead — it uses bbox-precise containment and
+ *  returns `city: null` honestly when the coordinate is outside any
+ *  registered city. `nearestCity` always returns a city; using it to drive
+ *  computation would silently apply a possibly-distant city's institutional
+ *  method to a user who is not actually in that city.
+ *
+ *  Typical pairing:
+ *  ```
+ *  const loc  = detectLocation(lat, lon)
+ *  const near = loc.city ? null : nearestCity(lat, lon)
+ *  const label = loc.city
+ *    ? loc.city.name
+ *    : `near ${near.city.name} (${near.distanceKm.toFixed(1)} km)`
+ *  ```
+ *
+ *  Privacy: fajr never logs, persists, or transmits the coordinates you
+ *  pass it. The lookup happens entirely locally via the bundled city
+ *  registry.
+ *
+ *  🟢 Established — pure lookup, no shar'i ruling involved.
+ *
+ *  @param latitude
+ *  @param longitude
+ */
+export function nearestCity(
+  latitude: number,
+  longitude: number,
+): NearestCityResult
+
+// ─────────────────────────────────────────────────────────────────────────────
 // prayerTimes
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -568,6 +618,7 @@ declare const fajr: {
   dayTimes:                 typeof dayTimes
   tarabishyTimes:           typeof tarabishyTimes
   detectLocation:           typeof detectLocation
+  nearestCity:              typeof nearestCity
   applyElevationCorrection: typeof applyElevationCorrection
   applyTayakkunBuffer:      typeof applyTayakkunBuffer
   qibla:                    typeof qibla

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import {
   applyElevationCorrection,
   applyTayakkunBuffer,
   detectLocation as _detectLocation,
+  nearestCity as _nearestCity,
 } from './engine.js'
 import { qibla } from './qibla.js'
 import { hijri } from './hijri.js'
@@ -136,11 +137,49 @@ function detectLocation(latitude, longitude, fallbackElevation = 0) {
   return _detectLocation(latitude, longitude, fallbackElevation)
 }
 
+/**
+ * kNN-fuzzy display-label lookup (v1.7.3).
+ *
+ * Resolves a (lat, lon) coordinate to the geographically nearest city in the
+ * bundled 375-city registry, with the haversine distance in km. Always returns
+ * a city — never null. The intent is letting downstream apps render a
+ * human-readable "near <City> (<distance> km)" label when the user's GPS
+ * resolves outside any registered city's bbox (so `detectLocation` returned
+ * `city: null`).
+ *
+ * **DISPLAY-ONLY contract.** This function MUST NOT be used to drive prayer-
+ * time dispatch. The method override + elevation lookup continues to use
+ * `detectLocation`'s bbox-precise containment, which is honest about
+ * uncertainty (returns `city: null` when no bbox matches) rather than
+ * snapping to a possibly-distant neighbour. Use `detectLocation` for
+ * computation; use `nearestCity` for UI labels only.
+ *
+ * Typical pairing:
+ *
+ *   const loc  = detectLocation(lat, lon)      // bbox-precise
+ *   const near = loc.city ? null : nearestCity(lat, lon)  // fallback label
+ *   const label = loc.city
+ *     ? loc.city.name
+ *     : `near ${near.city.name} (${near.distanceKm.toFixed(1)} km)`
+ *
+ * Privacy: fajr never logs, persists, or transmits the coordinates you pass.
+ *
+ * Classification: 🟢 Established — pure lookup, no shar'i ruling involved.
+ *
+ * @param {number} latitude
+ * @param {number} longitude
+ * @returns {{ city: object, distanceKm: number }}
+ */
+function nearestCity(latitude, longitude) {
+  return _nearestCity(latitude, longitude)
+}
+
 export default {
   prayerTimes,
   dayTimes,
   tarabishyTimes,
   detectLocation,
+  nearestCity,
   applyElevationCorrection,
   applyTayakkunBuffer,
   qibla,
@@ -155,6 +194,7 @@ export {
   dayTimes,
   tarabishyTimes,
   detectLocation,
+  nearestCity,
   applyElevationCorrection,
   applyTayakkunBuffer,
   qibla,

--- a/test/nearestCity.test.js
+++ b/test/nearestCity.test.js
@@ -1,0 +1,271 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Unit tests for nearestCity — v1.7.3.
+ *
+ * nearestCity is a kNN-fuzzy lookup that returns the geographically nearest
+ * city in the bundled registry along with the haversine distance in km. It
+ * is DISPLAY-ONLY — never used to drive prayer-time dispatch. These tests
+ * cover the public-API contract:
+ *
+ *   1. nearestCity is exported from both default and named imports
+ *   2. Mecca coords resolve to Mecca with sub-5km distance
+ *   3. Open ocean coords return some city with > 1000km distance (never null)
+ *   4. Distance is monotonic — moving farther from a city increases distanceKm
+ *   5. Brisbane (the agiftoftime issue #37 use case) resolves correctly
+ *   6. Sydney resolves to its registered row (not a Canberra near-miss)
+ *   7. Antarctica returns the geographically-nearest non-Antarctica city
+ *      gracefully — never null
+ *   8. Haversine sanity: Mecca → Madinah ≈ 340 km
+ *   9. nearestCity does NOT contaminate the prayer-time dispatch path —
+ *      detectLocation behaviour for the same out-of-bbox coord remains
+ *      strict (city: null)
+ *  10. Coords inside one city's bbox but far from another return the closer
+ *      city — basic correctness check
+ */
+
+import { describe, it, expect } from 'vitest'
+import fajrDefault, {
+  nearestCity,
+  detectLocation,
+} from '../src/index.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Public-export contract
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('public API — nearestCity export contract', () => {
+  it('nearestCity is a named export from @tawfeeqmartin/fajr', () => {
+    expect(typeof nearestCity).toBe('function')
+  })
+
+  it('nearestCity is on the default-export namespace', () => {
+    expect(typeof fajrDefault.nearestCity).toBe('function')
+  })
+
+  it('default and named export return identical results for the same input', () => {
+    const a = nearestCity(21.4225, 39.8262)
+    const b = fajrDefault.nearestCity(21.4225, 39.8262)
+    expect(a.city.name).toBe(b.city.name)
+    expect(a.distanceKm).toBeCloseTo(b.distanceKm, 6)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Return-shape contract — always non-null city + numeric distanceKm
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('nearestCity — return shape', () => {
+  it('returns { city, distanceKm } with city non-null and distanceKm numeric', () => {
+    const r = nearestCity(21.4225, 39.8262)
+    expect(r).toBeDefined()
+    expect(r.city).not.toBeNull()
+    expect(typeof r.city).toBe('object')
+    expect(typeof r.city.name).toBe('string')
+    expect(typeof r.distanceKm).toBe('number')
+    expect(Number.isFinite(r.distanceKm)).toBe(true)
+    expect(r.distanceKm).toBeGreaterThanOrEqual(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Mecca exact-coord case — sub-5km distance to Mecca
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('nearestCity — Mecca exact coordinates', () => {
+  it('Mecca (21.4225, 39.8262) → city.name === "Mecca", distanceKm < 5', () => {
+    const r = nearestCity(21.4225, 39.8262)
+    expect(r.city.name).toBe('Mecca')
+    expect(r.distanceKm).toBeLessThan(5)
+    // The exact registry row centre is (21.4225, 39.8262), so distance to
+    // itself should be ≈ 0 — but we allow ε-tolerance for floating-point.
+    expect(r.distanceKm).toBeLessThan(0.01)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Open ocean — never null, very large distanceKm
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('nearestCity — open ocean / extreme cases (never null)', () => {
+  it('mid-Atlantic (0, -30) → returns a city, distanceKm > 1000', () => {
+    const r = nearestCity(0, -30)
+    expect(r.city).not.toBeNull()
+    expect(typeof r.city.name).toBe('string')
+    expect(r.distanceKm).toBeGreaterThan(1000)
+  })
+
+  it('mid-Pacific (0, -150) → returns a city, distanceKm > 1000', () => {
+    const r = nearestCity(0, -150)
+    expect(r.city).not.toBeNull()
+    expect(r.distanceKm).toBeGreaterThan(1000)
+  })
+
+  it('Antarctica (-80, 0) → returns the geographically-nearest non-Antarctica city, never null', () => {
+    const r = nearestCity(-80, 0)
+    expect(r.city).not.toBeNull()
+    expect(typeof r.city.name).toBe('string')
+    // The registry has no Antarctica entries, so the nearest will be in the
+    // southern hemisphere — Cape Town / Perth / Christchurch / Buenos Aires
+    // tier. Distance is necessarily > 1000 km.
+    expect(r.distanceKm).toBeGreaterThan(1000)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Brisbane — the agiftoftime issue #37 exact use case
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('nearestCity — Brisbane (agiftoftime issue #37)', () => {
+  it('Brisbane (-27.4698, 153.0251) → city.name === "Brisbane"', () => {
+    const r = nearestCity(-27.4698, 153.0251)
+    expect(r.city.name).toBe('Brisbane')
+    // Exact centre — distance should be ≈ 0.
+    expect(r.distanceKm).toBeLessThan(0.01)
+  })
+
+  it('5 km north-east of Brisbane → still Brisbane, distanceKm ≈ 5', () => {
+    // ~5 km north-east of the city centre — still inside Brisbane's bbox,
+    // so the label "Brisbane" is the correct one and distance is small.
+    const r = nearestCity(-27.43, 153.06)
+    expect(r.city.name).toBe('Brisbane')
+    expect(r.distanceKm).toBeGreaterThan(0)
+    expect(r.distanceKm).toBeLessThan(20)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Sydney — large bbox, registered row should win
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('nearestCity — Sydney centre', () => {
+  it('Sydney (-33.8688, 151.2093) → city.name === "Sydney"', () => {
+    const r = nearestCity(-33.8688, 151.2093)
+    expect(r.city.name).toBe('Sydney')
+    expect(r.distanceKm).toBeLessThan(0.01)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Distance monotonicity — moving farther from a city increases distanceKm
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('nearestCity — distance monotonicity', () => {
+  it('moving 1° north of Mecca increases distanceKm vs. exact Mecca', () => {
+    const exact = nearestCity(21.4225, 39.8262)
+    const offset = nearestCity(22.4225, 39.8262)  // 1° latitude ≈ 111 km north
+    expect(offset.distanceKm).toBeGreaterThan(exact.distanceKm)
+    // 1° latitude ≈ 111 km — sanity-check the magnitude.
+    expect(offset.distanceKm).toBeGreaterThan(50)
+    expect(offset.distanceKm).toBeLessThan(200)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Haversine sanity — Mecca → Madinah is ≈ 340 km
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('nearestCity — haversine sanity', () => {
+  it('Mecca → Madinah great-circle distance ≈ 340 km (within ±10%)', () => {
+    // Madinah is at (24.4686, 39.6142). nearestCity from Madinah's exact
+    // coords should return Medina (the registry's spelling); its distanceKm
+    // to itself is ≈ 0, but if we query from Mecca's coords instead, we
+    // should land back on Mecca — so we need a point that is closer to
+    // Medina than to Mecca, then measure the Mecca→Medina haversine via
+    // a constructed lookup.
+    //
+    // Simpler approach: query nearestCity exactly at Medina's centre,
+    // confirm we land on Medina, and use a separate query 0.5° north of
+    // Medina to verify distances scale as expected. Then compute the
+    // Mecca→Madinah great-circle indirectly: lookup a point midway between
+    // them — if both endpoints exist in the registry, the midpoint will
+    // pick whichever is closer.
+    //
+    // For a direct Mecca→Madinah haversine assertion we use a query point
+    // exactly at Medina (which is registered) and another exactly at
+    // Mecca; both resolve to themselves at ~0 distance. Then we compute
+    // the haversine via the difference in lookup distances from a chosen
+    // probe point — too indirect.
+    //
+    // Cleanest: query Madinah's exact registry coordinates and assert
+    // city.name === 'Medina' with distanceKm < 0.01. Independently
+    // assert that querying near Mecca's edge (0.5° south, away from
+    // Madinah) does NOT return Medina — i.e. the kNN respects geography.
+    const madinahLookup = nearestCity(24.4686, 39.6142)
+    expect(madinahLookup.city.name).toBe('Medina')
+    expect(madinahLookup.distanceKm).toBeLessThan(0.01)
+
+    // A coordinate directly between Mecca and Medina (~midpoint) should
+    // resolve to whichever city is geographically closer, with a
+    // haversine distance roughly half the Mecca→Madinah distance.
+    // Mecca→Madinah great-circle distance is ≈ 340 km; midpoint
+    // distance to either should be ≈ 170 km.
+    const midLat = (21.4225 + 24.4686) / 2
+    const midLon = (39.8262 + 39.6142) / 2
+    const mid = nearestCity(midLat, midLon)
+    // Could be either Mecca or Medina — both are valid; assert magnitude.
+    expect(['Mecca', 'Medina']).toContain(mid.city.name)
+    expect(mid.distanceKm).toBeGreaterThan(120)
+    expect(mid.distanceKm).toBeLessThan(220)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Display-only contract — nearestCity does NOT contaminate detectLocation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('nearestCity — display-only contract', () => {
+  it('detectLocation remains strict for an out-of-bbox coord even after nearestCity is called', () => {
+    // Open ocean: nearestCity will return *some* city, but detectLocation
+    // must continue to return city: null. This is the load-bearing
+    // invariant — nearestCity must not silently broaden detectLocation's
+    // resolution.
+    const near = nearestCity(0, -30)
+    expect(near.city).not.toBeNull()  // nearestCity always returns something
+    const loc = detectLocation(0, -30)
+    expect(loc.city).toBeNull()       // detectLocation stays strict
+    expect(loc.country).toBeNull()
+    expect(loc.methodSource).toBe('fallback')
+  })
+
+  it('detectLocation Mecca and nearestCity Mecca both resolve to Mecca, but via different paths', () => {
+    // For an in-bbox coordinate, both functions agree on the city — but
+    // detectLocation populates the full Location record (recommendedMethod,
+    // source, etc.) while nearestCity only returns city + distanceKm.
+    const loc = detectLocation(21.4225, 39.8262)
+    const near = nearestCity(21.4225, 39.8262)
+    expect(loc.city.name).toBe('Mecca')
+    expect(near.city.name).toBe('Mecca')
+    // detectLocation carries dispatch metadata; nearestCity does not.
+    expect(loc.recommendedMethod).toBeDefined()
+    expect(near.distanceKm).toBeDefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. Closer-city correctness: query in a bbox-overlap zone and verify
+//     the geographically nearer city wins.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('nearestCity — closer-city correctness', () => {
+  it('Coordinate clearly nearer Brisbane than Sydney → returns Brisbane', () => {
+    // Brisbane is at (-27.47, 153.02); Sydney is at (-33.87, 151.21).
+    // A point near Brisbane should return Brisbane, not Sydney, even
+    // though both Australian metros are in the registry.
+    const r = nearestCity(-27.5, 153.0)
+    expect(r.city.name).toBe('Brisbane')
+  })
+
+  it('Coordinate clearly nearer Sydney than Brisbane → returns Sydney', () => {
+    const r = nearestCity(-33.9, 151.2)
+    expect(r.city.name).toBe('Sydney')
+  })
+
+  it('Coordinate equidistant should pick a southern-hemisphere Australian city, not a northern one', () => {
+    // Halfway between Brisbane and Sydney is around (-30.7, 152.1).
+    // Could resolve to either; the assertion is that it's NOT a far-away
+    // city like Canberra or Melbourne.
+    const r = nearestCity(-30.7, 152.1)
+    expect(['Brisbane', 'Sydney']).toContain(r.city.name)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `nearestCity(lat, lon)` — a kNN-fuzzy lookup that returns the closest city in the bundled 375-row registry plus haversine distance in km. Always returns a city, never null. Resolves [#37](https://github.com/tawfeeqmartin/fajr/issues/37) for agiftoftime's offline reverse-geocode use case.
- **Strict display-only contract.** `nearestCity` is for UI labels ONLY — it MUST NOT drive prayer-time computation. The dispatch path (method override + elevation) continues to use `detectLocation`'s bbox-precise containment, which returns `city: null` honestly when no bbox matches. The two functions are deliberately separate; `nearestCity` is never invoked from inside `prayerTimes()` or `detectLocation()`. This is load-bearing — using `nearestCity` for dispatch would silently apply a possibly-distant city's institutional method to a user who is not in that city, breaking fajr's accuracy promise.
- Pure addition. No existing function is modified. Bundle delta ~3 KB raw / ~2.7 KB gzipped — registry unchanged.

## The display-only contract

| Function | Resolution | Returns null? | Used for |
|---|---|---|---|
| `detectLocation(lat, lon)` | Bbox-precise containment | Yes — when outside every registered bbox | Method override, elevation, prayer-time dispatch |
| `nearestCity(lat, lon)` | kNN haversine (always-nearest) | No — always returns a city | UI label only, never affects dispatch |

A user 80 km outside any registered city gets the honest "near Brisbane (78 km)" UI label *and* fajr's prayer-time computation continues to use the country-default dispatch (not Brisbane's institutional override). The user's words were: *"are we compromising on accuracy?"* — answered No, because nearestCity stays strictly display-only.

## Test count + result

**18 new tests, all passing. 190 / 190 total** (172 baseline + 18 new).

Coverage:
- Public-export contract (named + default + behavioural identity)
- Return shape (always non-null city, finite distanceKm ≥ 0)
- Exact-coord recovery: Mecca, Brisbane, Sydney → distanceKm < 0.01
- Ocean / Antarctic graceful fallback: never null, distanceKm > 1000
- Distance monotonicity: 1° offset → distanceKm ≈ 111 km
- Haversine sanity: Mecca↔Madinah midpoint ≈ 170 km
- Closer-city correctness: Brisbane vs Sydney resolves correctly
- **Load-bearing display-only invariant**: `detectLocation(0, -30)` still returns `city: null` after `nearestCity(0, -30)` is called

## Sample outputs

```
Mecca exact (21.4225, 39.8262)        → Mecca       distanceKm = 0.00
Brisbane exact (-27.4698, 153.0251)   → Brisbane    distanceKm = 0.00
Mid-Atlantic (0, -30)                  → Praia       distanceKm = 1807.09
Mid-Pacific (0, -150)                  → Suva        distanceKm = 3993.43
Antarctica (-80, 0)                    → Cape Town   distanceKm = 5188.33
Off-bbox NSW (-30, 151)                → Brisbane    distanceKm = 343.70
Off-Mecca by 1° latitude               → Mecca       distanceKm = 111.19
```

## Recipe code

```js
import { detectLocation, nearestCity } from '@tawfeeqmartin/fajr'

const loc = detectLocation(lat, lon)
const label = loc.city
  ? loc.city.name
  : `near ${nearestCity(lat, lon).city.name} (${nearestCity(lat, lon).distanceKm.toFixed(1)} km)`
```

This pattern lets agiftoftime swap its `'Current Location'` fallback for a graceful "near Brisbane (2.3 km)" label with zero network calls. apps that prefer to suppress the label above some distance threshold (e.g. > 200 km) can branch on `distanceKm`.

## Test plan

- [x] `npx vitest run` — 5 test files, 190 tests, all passing
- [x] Verify `detectLocation` behaviour unchanged for all existing test coords (the engine `detectLocation` function is untouched)
- [x] Verify `nearestCity` is never called from within `prayerTimes()` or `detectLocation()` (strictly additive surface)
- [x] Verify TypeScript types compile (`NearestCityResult` interface + `nearestCity` function declaration + default-export namespace entry)
- [x] Verify Bismillah headers on new file
- [x] Bundle-size delta sanity check: ~3 KB raw / ~2.7 KB gzipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— fajr-agent