### PR TITLE
chore(morocco): add Habous snapshot workflow

### DIFF
--- a/.github/workflows/habous-morocco-snapshot.yml
+++ b/.github/workflows/habous-morocco-snapshot.yml
@@ -1,0 +1,133 @@
+# بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+# Bismillah ir-Rahman ir-Rahim
+#
+# Captures Morocco Habous current Hijri-month city tables before the live
+# endpoint rolls over. The workflow opens a review PR with a source snapshot
+# under fixtures/, not eval/data. Promotion into eval remains a separate human
+# review step.
+
+name: Morocco Habous monthly snapshot
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Hijri months do not align with Gregorian months. Run three times/month so
+    # each official monthly table is likely captured before Habous rolls over.
+    - cron: '17 5 5,15,25 * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: habous-morocco-snapshot
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch current Habous monthly table
+        run: |
+          set -euo pipefail
+          mkdir -p fixtures/habous-morocco/monthly /tmp/habous
+          node scripts/fetch-habous-morocco-month.js \
+            --allow-insecure-habous-cert \
+            --out /tmp/habous/current.json
+
+      - name: Normalize snapshot path
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+
+          const input = '/tmp/habous/current.json'
+          const fixtures = JSON.parse(readFileSync(input, 'utf8'))
+          if (!Array.isArray(fixtures) || fixtures.length === 0) {
+            throw new Error('Habous monthly snapshot did not produce fixture rows')
+          }
+
+          const dates = fixtures
+            .flatMap(fixture => (fixture.dates || []).map(row => row.date))
+            .sort()
+          if (dates.length === 0) {
+            throw new Error('Habous monthly snapshot did not contain dated rows')
+          }
+
+          const start = dates[0]
+          const end = dates[dates.length - 1]
+          const outPath = `fixtures/habous-morocco/monthly/${start}_to_${end}.json`
+
+          if (!existsSync(outPath)) {
+            writeFileSync(outPath, `${JSON.stringify(fixtures, null, 2)}\n`)
+          }
+
+          writeFileSync(process.env.GITHUB_ENV, [
+            `HABOUS_SNAPSHOT_PATH=${outPath}`,
+            `HABOUS_SNAPSHOT_START=${start}`,
+            `HABOUS_SNAPSHOT_END=${end}`,
+            `HABOUS_SNAPSHOT_ROWS=${dates.length}`,
+            '',
+          ].join('\n'), { flag: 'a' })
+          NODE
+
+      - name: Validate snapshot tests
+        run: npm test
+
+      - name: Open snapshot PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- fixtures/habous-morocco/monthly; then
+            echo "No new Habous monthly snapshot to commit."
+            exit 0
+          fi
+
+          branch="automation/habous-morocco-${HABOUS_SNAPSHOT_START}-to-${HABOUS_SNAPSHOT_END}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add "$HABOUS_SNAPSHOT_PATH"
+          git commit -m "data(morocco): capture Habous monthly snapshot ${HABOUS_SNAPSHOT_START} to ${HABOUS_SNAPSHOT_END}"
+          git push --force-with-lease origin "$branch"
+
+          existing="$(gh pr list --head "$branch" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "Snapshot PR already exists: #$existing"
+            exit 0
+          fi
+
+          cat > /tmp/habous-snapshot-pr-body.md <<EOF
+          Automated Habous Morocco monthly snapshot.
+
+          - Source: Ministry of Habous current Hijri-month city tables
+          - Date range: ${HABOUS_SNAPSHOT_START} to ${HABOUS_SNAPSHOT_END}
+          - Rows: ${HABOUS_SNAPSHOT_ROWS} dated prayer rows
+          - Output: \`${HABOUS_SNAPSHOT_PATH}\`
+
+          This stores source evidence under \`fixtures/\` only. Promotion into
+          \`eval/data/\` remains a separate curated PR.
+
+          Refs #92.
+          Refs #103.
+          EOF
+
+          gh pr create \
+            --base master \
+            --head "$branch" \
+            --title "data(morocco): capture Habous monthly snapshot ${HABOUS_SNAPSHOT_START} to ${HABOUS_SNAPSHOT_END}" \
+            --body-file /tmp/habous-snapshot-pr-body.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added `test/habousMoroccoFixture.test.js`, a focused holdout gate that keeps
   fajr's Morocco five-prayer output close to the official Habous monthly city
   fixture and validates the fixture source metadata.
+- Added a scheduled Morocco Habous snapshot workflow that opens review PRs with
+  future official monthly table captures under `fixtures/habous-morocco/`.
 
 ### Fixed — Diyanet city-ID mapping guardrail
 
@@ -79,6 +81,8 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
   the five prayer times and treats Sunrise as loose source sanity only because
   Moroccan published Sunrise can encode mosque-practice ihtiyat rather than a
   pure astronomical calculation.
+- Scheduled Habous captures are source snapshots only. Promotion into
+  `eval/data/` remains a separate curated fixture PR.
 - The Diyanet mapping fix does not promote a new yearly Turkiye fixture. It
   prevents future bad fixture generation; curated fixture promotion still needs
   a separate PR with cross-source spot checks.

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -111,6 +111,10 @@ Snapshot tooling:
   `https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville={id}` into
   fixture-shaped JSON. It prints to stdout by default and writes only when
   `--out` is supplied.
+- [`.github/workflows/habous-morocco-snapshot.yml`](../.github/workflows/habous-morocco-snapshot.yml)
+  runs recurring captures and opens review PRs with new source snapshots under
+  [`fixtures/habous-morocco/`](../fixtures/habous-morocco/). These are archived
+  evidence, not automatic eval fixtures.
 - The 2026-05-05 probe produced 990 current-month rows across the 33 mapped
   Moroccan cities. Internet Archive recovery was useful but sparse: 7
   Rabat/default monthly snapshots and 3 Casablanca snapshots. That supports
@@ -138,6 +142,7 @@ Raw/source locations:
 - `eval/data/test/morocco-habous.json`
 - `scripts/data/habous-morocco-cities.json`
 - `scripts/data/mawaqit-mosques.json`
+- `fixtures/habous-morocco/`
 - `scripts/fetch-morocco-habous.js`
 - `scripts/fetch-habous-morocco-month.js`
 - `scripts/fetch-mawaqit.js`

--- a/fixtures/habous-morocco/README.md
+++ b/fixtures/habous-morocco/README.md
@@ -1,0 +1,38 @@
+# Morocco Habous Source Snapshots
+
+This directory stores official Morocco Habous monthly-table captures before the
+live endpoint rolls over.
+
+These files are source evidence, not ratchet fixtures. They are intentionally
+kept outside `eval/data/` until a maintainer promotes a reviewed subset into the
+holdout corpus.
+
+## Capture Workflow
+
+`.github/workflows/habous-morocco-snapshot.yml` runs on a schedule and by manual
+dispatch. It calls:
+
+```bash
+node scripts/fetch-habous-morocco-month.js --allow-insecure-habous-cert --out /tmp/habous/current.json
+```
+
+Then it opens a PR with a new file under:
+
+```txt
+fixtures/habous-morocco/monthly/YYYY-MM-DD_to_YYYY-MM-DD.json
+```
+
+The path is based on the Gregorian date range in the official monthly table. If
+that range was already captured, the workflow exits without opening a duplicate
+PR.
+
+## Promotion Rule
+
+Do not move these snapshots into `eval/data/` mechanically. A curated fixture PR
+should first verify:
+
+- the Habous `ville` mapping matches `scripts/data/habous-morocco-cities.json`;
+- the table source is the official Imsakiyya page, not the current-day API
+  mirror;
+- the rows parse to the expected Gregorian date range;
+- per-city residuals are understood before any Morocco calibration change.


### PR DESCRIPTION
## Summary

- add a scheduled/manual GitHub Actions workflow that captures Morocco Habous current Hijri-month city tables before the live endpoint rolls over
- store future captures under `fixtures/habous-morocco/monthly/YYYY-MM-DD_to_YYYY-MM-DD.json`
- open review PRs automatically when a new date range is captured
- document that `fixtures/` snapshots are source evidence only and must not be promoted into `eval/data/` mechanically

## Why

PR #116 added a CI gate for the current official Habous monthly fixture. This PR adds the recurring capture path so future months are preserved for the larger #92/#103 multi-season corpus instead of disappearing when the live Habous endpoint updates.

## Verification

- `git diff --check`
- `node --check scripts/fetch-habous-morocco-month.js`
- `npm --cache /private/tmp/fajr-npm-cache test` (344/344)

## Safety

- no engine calculation changes
- no `eval/data` changes
- no package/dependency changes
- automated captures land under `fixtures/` for review before any fixture promotion

Refs #92.
Refs #103.