### PR TITLE
Add city geometry bbox audit scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.swp
 .DS_Store
 .claude/
+.cache/
 .env
 .env.local
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added a scheduled Morocco Habous snapshot workflow that opens review PRs with
   future official monthly table captures under `fixtures/habous-morocco/`.
 
+### Added — city geometry bbox audit scaffold
+
+- Added `scripts/audit-city-geometry.js` and `scripts/lib/geometry-audit.js`,
+  a no-network advisory audit path for comparing reviewed cached GeoJSON
+  geometries against the shipped city bbox registry.
+- Added [docs/city-geometry-audit.md](docs/city-geometry-audit.md), documenting
+  why raw municipal polygons stay out of the runtime package, which sources are
+  safe for audit vs bundled derivation, and which Morocco/current-warning rows
+  should be reviewed first.
+- Added focused geometry helper tests covering GeoJSON bbox extraction,
+  polygon holes, multipolygons, deterministic grid sampling, and bbox coverage
+  metrics.
+
 ### Fixed — Diyanet city-ID mapping guardrail
 
 - Added `scripts/data/diyanet-ezanvakti-cities.json`, a verified mapping from
@@ -86,6 +99,10 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - The Diyanet mapping fix does not promote a new yearly Turkiye fixture. It
   prevents future bad fixture generation; curated fixture promotion still needs
   a separate PR with cross-source spot checks.
+- The city geometry audit scaffold does not change `detectLocation()`, city
+  bboxes, package runtime behavior, or prayer-time calculations. It exits
+  cleanly until `scripts/data/city-geometry-sources.json` is curated with
+  reviewed external IDs and cached geometry.
 
 ## [1.8.0] — 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/@tawfeeqmartin/fajr.svg)](https://www.npmjs.com/package/@tawfeeqmartin/fajr)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-Last refreshed: 2026-05-06
+Last refreshed: 2026-05-08
 
 `fajr` is an offline JavaScript library for Islamic prayer times, qibla, Hijri dates, and hilal visibility. It builds on [`adhan.js`](https://github.com/batoulapps/adhan-js), then adds:
 
@@ -24,6 +24,7 @@ Core docs:
 - [SCOREBOARD.md](SCOREBOARD.md) - generated release health, WMAE, coverage, and open-issue snapshot.
 - [docs/progress.md](docs/progress.md) - generated WMAE dashboard and trend charts.
 - [docs/data-sources.md](docs/data-sources.md) - source inventory and fixture-refresh status.
+- [docs/city-geometry-audit.md](docs/city-geometry-audit.md) - build-time QA plan for reverse-geolocation bboxes.
 - [examples/agiftoftime/INTEGRATION.md](examples/agiftoftime/INTEGRATION.md) - app-side integration guide for [A Gift of Time](https://agiftoftime.app).
 
 ## Install
@@ -274,6 +275,7 @@ Hilal output is astronomical possibility, not a religious ruling. See [docs/hila
 | Generated eval dashboard | [docs/progress.md](docs/progress.md) |
 | Integration in A Gift of Time | [examples/agiftoftime/INTEGRATION.md](examples/agiftoftime/INTEGRATION.md) |
 | Source inventory | [docs/data-sources.md](docs/data-sources.md) |
+| City bbox geometry audit | [docs/city-geometry-audit.md](docs/city-geometry-audit.md) |
 | Scholarly review brief | [docs/scholar-review-brief.md](docs/scholar-review-brief.md) |
 | Hilal historical analysis | [docs/hilal-historical-analysis.md](docs/hilal-historical-analysis.md) |
 | Release log | [CHANGELOG.md](CHANGELOG.md) |

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -1,0 +1,119 @@
+# City Geometry Audit
+
+Last refreshed: 2026-05-08
+
+`detectLocation()` intentionally ships a compact offline bbox registry rather
+than raw municipal polygons. The bbox layer is fast and small enough for
+browser/mobile use, but it still needs independent geometry QA because many
+rows begin as population-radius rectangles and are only tightened when a leak
+is found.
+
+The geometry audit workflow is advisory. It compares reviewed external city
+geometry against `src/data/cities.json`, emits reports, and proposes rows for
+human review. It must not mutate the runtime registry automatically.
+
+## Policy
+
+- Runtime stays bbox-based and offline.
+- Raw WOF/OSM/Overture/official polygons stay in `.cache/city-geometry/`, not
+  in `src/`, not in git, and not in the npm package.
+- OSM and Overture are audit-only by default because their city geometry is
+  ODbL. Do not ship OSM/Overture-derived bboxes under the MIT package without
+  explicit license review.
+- Who's On First / Geocode Earth is the preferred bulk locality source, but
+  row-level source provenance still needs review before using derived values.
+- geoBoundaries, Natural Earth, GeoNames, HDX/OCHA, and official local sources
+  can support audits, but their granularity and licenses differ by country.
+- GADM is not suitable for bundled fajr data because its license is
+  academic/non-commercial and restricts redistribution.
+
+## Source Map
+
+Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
+The source map stores metadata and cache pointers only:
+
+```json
+{
+  "$schema_doc": "Build-time geometry source map for auditing src/data/cities.json bboxes. Raw geometry stays outside npm in .cache/city-geometry.",
+  "version": 1,
+  "updated": "2026-05-08",
+  "cacheRoot": ".cache/city-geometry",
+  "cities": [
+    {
+      "cityKey": "Rabat|MA",
+      "priority": ["phase-1-morocco", "habous"],
+      "review": {
+        "status": "unreviewed",
+        "issue": 118,
+        "notes": ["Habous ID is prayer-time provenance, not geometry."]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:<reviewed-id>",
+          "cacheFile": "MA/rabat/wof-locality.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Use stable provider IDs: WOF IDs/GIDs, OSM relation IDs, Overture GERS IDs, or
+official local authority IDs. Do not store Nominatim `place_id`; it is not a
+stable external identifier.
+
+## Running
+
+With reviewed IDs and cached GeoJSON present:
+
+```bash
+node scripts/audit-city-geometry.js
+node scripts/audit-city-geometry.js --format json
+node scripts/audit-city-geometry.js --sources scripts/data/city-geometry-sources.json --cache-dir .cache/city-geometry
+```
+
+If `scripts/data/city-geometry-sources.json` is absent, the script exits cleanly
+and prints a setup message. That is intentional while the source map is being
+curated.
+
+## First Audit Targets
+
+Start with rows where geometry quality affects source provenance or existing
+validator warnings:
+
+- Morocco Habous clusters: Rabat/Sale/Temara, Agadir/Inezgane,
+  Casablanca/Berrechid/Settat, Fes/Sefrou/Meknes, Tangier/Tetouan/Nador/Oujda.
+- Current registry warnings: Jerusalem PS/IL routing, Brazzaville/Kinshasa,
+  Basel/Mulhouse.
+- High-risk metro/border clusters: Cairo/Giza/6th of October,
+  Dubai/Sharjah/Ajman, Singapore/Johor Bahru, Kuala Lumpur/Shah Alam,
+  Toronto/Mississauga/Laval/Montreal, Lahore/Sialkot/Gujranwala,
+  Basra/Ahvaz/Kuwait City, Damascus/Homs/Gaziantep.
+- Large heuristic bboxes such as Karachi, Istanbul, Jakarta, Bangalore, Dhaka,
+  Tokyo, Seoul, Moscow, Melbourne, Sydney, Shanghai, Lagos, London, New York.
+
+Western Sahara / Laayoune should be handled in a separate reviewed pass because
+Moroccan official/Habous framing, ISO `EH`, OSM, WOF, and other boundary
+sources encode political geography differently. A geometry audit must not
+silently change method dispatch or country identity.
+
+## Reports
+
+The report should distinguish geometry QA from prayer-time math. A bbox change
+may alter city/source/method provenance, but it is not a WMAE improvement unless
+fixtures prove a calculation change.
+
+Each row should report at minimum:
+
+- city key and provider stable ID;
+- source license/use status;
+- center-inside-geometry status;
+- registry bbox vs geometry bbox overlap;
+- sampled overcoverage and undercoverage;
+- cross-border and sibling-overlap risks;
+- whether any proposed bbox change is human-reviewed.

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -142,6 +142,9 @@ Raw/source locations:
 - `eval/data/test/morocco-habous.json`
 - `scripts/data/habous-morocco-cities.json`
 - `scripts/data/mawaqit-mosques.json`
+- `scripts/data/city-geometry-sources.json` (planned source map for
+  reviewed external geometry IDs; see
+  [city geometry audit](city-geometry-audit.md))
 - `fixtures/habous-morocco/`
 - `scripts/fetch-morocco-habous.js`
 - `scripts/fetch-habous-morocco-month.js`

--- a/scripts/audit-city-geometry.js
+++ b/scripts/audit-city-geometry.js
@@ -1,0 +1,189 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Build-time advisory audit for city bbox rows against cached GeoJSON
+ * geometry. This script never downloads data and never mutates cities.json.
+ *
+ * Expected source-map shape:
+ * {
+ *   "version": 1,
+ *   "cities": [
+ *     {
+ *       "cityKey": "Rabat|MA",
+ *       "geometries": [
+ *         {
+ *           "provider": "wof",
+ *           "stableId": "whosonfirst:locality:...",
+ *           "license": "Who's On First License",
+ *           "cacheFile": "MA/rabat.geojson",
+ *           "confidence": "candidate"
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import cityModule from '../src/data/cities.json' with { type: 'json' }
+import { compareCityBboxToGeojson } from './lib/geometry-audit.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, '..')
+
+const args = parseArgs(process.argv.slice(2))
+const sourcePath = path.resolve(ROOT, args.sources || 'scripts/data/city-geometry-sources.json')
+const format = args.format || 'markdown'
+
+if (!fs.existsSync(sourcePath)) {
+  console.log(`[audit-city-geometry] no source map found at ${path.relative(ROOT, sourcePath)}`)
+  console.log('[audit-city-geometry] create scripts/data/city-geometry-sources.json after stable external IDs are reviewed')
+  process.exit(0)
+}
+
+const sourceMap = JSON.parse(fs.readFileSync(sourcePath, 'utf8'))
+const cacheDir = path.resolve(ROOT, args.cacheDir || sourceMap.cacheRoot || '.cache/city-geometry')
+const registry = cityModule.cities || []
+const registryByKey = new Map(registry.map(city => [cityKey(city.name, city.countryISO), city]))
+const rows = []
+
+for (const entry of sourceMap.cities || []) {
+  const parsed = parseCityEntry(entry)
+  const city = registryByKey.get(cityKey(parsed.city, parsed.countryISO))
+  if (!city) {
+    rows.push({
+      city: parsed.city,
+      countryISO: parsed.countryISO,
+      provider: null,
+      stableId: null,
+      status: 'city-not-found',
+    })
+    continue
+  }
+
+  for (const source of geometrySourcesForEntry(entry)) {
+    const cacheFile = source.cacheFile || source.geometryFile
+    if (!cacheFile) {
+      rows.push(sourceRow(city, source, { status: 'missing-cache-file' }))
+      continue
+    }
+
+    const geometryPath = path.resolve(cacheDir, cacheFile)
+    if (!geometryPath.startsWith(cacheDir + path.sep) && geometryPath !== cacheDir) {
+      rows.push(sourceRow(city, source, { status: 'cache-path-outside-cache-dir' }))
+      continue
+    }
+    if (!fs.existsSync(geometryPath)) {
+      rows.push(sourceRow(city, source, { status: 'cache-file-not-found' }))
+      continue
+    }
+
+    const geojson = JSON.parse(fs.readFileSync(geometryPath, 'utf8'))
+    rows.push(sourceRow(city, source, compareCityBboxToGeojson(city, geojson)))
+  }
+}
+
+if (format === 'json') {
+  console.log(JSON.stringify(report(rows), null, 2))
+} else {
+  printMarkdown(rows)
+}
+
+function sourceRow(city, source, result) {
+  return {
+    cityKey: `${city.name}|${city.countryISO}`,
+    city: city.name,
+    countryISO: city.countryISO,
+    provider: source.provider || null,
+    stableId: source.stableId || source.id || null,
+    license: source.license || null,
+    sourceConfidence: source.sourceConfidence || source.confidence || null,
+    matchConfidence: source.matchConfidence || null,
+    licenseUse: source.licenseUse || null,
+    reviewStatus: source.reviewStatus || null,
+    ...result,
+  }
+}
+
+function report(rows) {
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    sourcePath: path.relative(ROOT, sourcePath),
+    registryPath: 'src/data/cities.json',
+    cacheDir: path.relative(ROOT, cacheDir),
+    summary: {
+      sourceCandidatesChecked: rows.length,
+      checked: rows.filter(row => row.status === 'checked').length,
+      missingCacheFiles: rows.filter(row => row.status === 'cache-file-not-found').length,
+      missingGeometry: rows.filter(row => row.status === 'missing-geometry').length,
+      cityNotFound: rows.filter(row => row.status === 'city-not-found').length,
+    },
+    rows,
+  }
+}
+
+function cityKey(name, iso) {
+  return `${String(name).toLowerCase()}|${String(iso).toUpperCase()}`
+}
+
+function parseCityEntry(entry) {
+  if (entry.cityKey) {
+    const [city, countryISO] = String(entry.cityKey).split('|')
+    return { city, countryISO }
+  }
+  return { city: entry.city, countryISO: entry.countryISO }
+}
+
+function geometrySourcesForEntry(entry) {
+  if (Array.isArray(entry.geometries)) return entry.geometries
+  if (entry.provider || entry.stableId || entry.cacheFile || entry.geometryFile) return [entry]
+  return []
+}
+
+function parseArgs(argv) {
+  const out = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--sources') out.sources = argv[++i]
+    else if (arg === '--cache-dir') out.cacheDir = argv[++i]
+    else if (arg === '--format') out.format = argv[++i]
+  }
+  return out
+}
+
+function printMarkdown(rows) {
+  console.log('# City Geometry Bbox Audit')
+  console.log('')
+  console.log(`Source map: ${path.relative(ROOT, sourcePath)}`)
+  console.log(`Cache dir: ${path.relative(ROOT, cacheDir)}`)
+  console.log(`Rows checked: ${rows.length}`)
+  console.log('')
+  console.log('| City | ISO | Provider | Stable ID | Status | Review | License use | Center in geometry | Registry outside geom bbox | Geom bbox outside registry |')
+  console.log('|---|---|---|---|---|---|---|---:|---:|---:|')
+  for (const row of rows) {
+    console.log([
+      row.city,
+      row.countryISO,
+      row.provider || '-',
+      row.stableId || '-',
+      row.status,
+      row.reviewStatus || '-',
+      row.licenseUse || '-',
+      row.centerInsideGeometry == null ? '-' : String(row.centerInsideGeometry),
+      percent(row.registryBboxOutsideGeometryBboxRatio),
+      percent(row.geometryBboxOutsideRegistryBboxRatio),
+    ].map(markdownCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'))
+  }
+}
+
+function percent(value) {
+  return value == null ? '-' : `${(value * 100).toFixed(1)}%`
+}
+
+function markdownCell(value) {
+  return String(value).replaceAll('|', '\\|')
+}

--- a/scripts/lib/geometry-audit.js
+++ b/scripts/lib/geometry-audit.js
@@ -1,0 +1,218 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Geometry helpers for build-time city-bbox auditing.
+ *
+ * These functions deliberately use plain GeoJSON and small, dependency-free
+ * geometry primitives. They are for registry QA reports, not prayer-time
+ * calculation. Runtime detectLocation() remains the compact bbox resolver.
+ */
+
+const EPS = 1e-12
+
+export function bboxAreaDeg2(bbox) {
+  const [latMin, latMax, lonMin, lonMax] = bbox
+  return Math.max(0, latMax - latMin) * Math.max(0, lonMax - lonMin)
+}
+
+export function bboxContainsPoint(bbox, lat, lon) {
+  const [latMin, latMax, lonMin, lonMax] = bbox
+  return lat >= latMin && lat <= latMax && lon >= lonMin && lon <= lonMax
+}
+
+export function bboxIntersection(a, b) {
+  const out = [
+    Math.max(a[0], b[0]),
+    Math.min(a[1], b[1]),
+    Math.max(a[2], b[2]),
+    Math.min(a[3], b[3]),
+  ]
+  return out[0] <= out[1] && out[2] <= out[3] ? out : null
+}
+
+export function bboxForGeojson(input) {
+  const coords = []
+  collectCoordinates(input, coords)
+  if (!coords.length) return null
+
+  let latMin = Infinity
+  let latMax = -Infinity
+  let lonMin = Infinity
+  let lonMax = -Infinity
+  for (const [lon, lat] of coords) {
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue
+    if (lat < latMin) latMin = lat
+    if (lat > latMax) latMax = lat
+    if (lon < lonMin) lonMin = lon
+    if (lon > lonMax) lonMax = lon
+  }
+  if (!Number.isFinite(latMin)) return null
+  return [latMin, latMax, lonMin, lonMax]
+}
+
+export function geojsonContainsPoint(input, lat, lon) {
+  if (!input) return false
+  if (input.type === 'Feature') return geojsonContainsPoint(input.geometry, lat, lon)
+  if (input.type === 'FeatureCollection') {
+    return input.features.some(feature => geojsonContainsPoint(feature, lat, lon))
+  }
+  if (input.type === 'GeometryCollection') {
+    return input.geometries.some(geometry => geojsonContainsPoint(geometry, lat, lon))
+  }
+  if (input.type === 'Polygon') return polygonContainsPoint(input.coordinates, lat, lon)
+  if (input.type === 'MultiPolygon') {
+    return input.coordinates.some(polygon => polygonContainsPoint(polygon, lat, lon))
+  }
+  if (input.type === 'Point') {
+    return Math.abs(input.coordinates[0] - lon) < EPS &&
+      Math.abs(input.coordinates[1] - lat) < EPS
+  }
+  return false
+}
+
+export function compareCityBboxToGeojson(city, geojson) {
+  const registryBbox = city.bbox
+  const geometryBbox = bboxForGeojson(geojson)
+  if (!geometryBbox) {
+    return {
+      city: city.name,
+      countryISO: city.countryISO,
+      status: 'missing-geometry',
+    }
+  }
+
+  const intersection = bboxIntersection(registryBbox, geometryBbox)
+  const registryArea = bboxAreaDeg2(registryBbox)
+  const geometryArea = bboxAreaDeg2(geometryBbox)
+  const intersectionArea = intersection ? bboxAreaDeg2(intersection) : 0
+
+  return {
+    city: city.name,
+    countryISO: city.countryISO,
+    status: 'checked',
+    registryBbox,
+    geometryBbox,
+    centerInsideGeometry: geojsonContainsPoint(geojson, city.lat, city.lon),
+    centerInsideRegistryBbox: bboxContainsPoint(registryBbox, city.lat, city.lon),
+    bboxIntersection: intersection,
+    registryBboxAreaDeg2: registryArea,
+    geometryBboxAreaDeg2: geometryArea,
+    bboxIntersectionAreaDeg2: intersectionArea,
+    registryBboxOutsideGeometryBboxRatio: ratio(registryArea - intersectionArea, registryArea),
+    geometryBboxOutsideRegistryBboxRatio: ratio(geometryArea - intersectionArea, geometryArea),
+    coverage: sampleCoverage(city.bbox, geojson, geometryBbox),
+  }
+}
+
+export function gridSamplesForBbox(bbox, side = gridSideForBbox(bbox)) {
+  const [latMin, latMax, lonMin, lonMax] = bbox
+  const out = []
+  for (let y = 0; y < side; y++) {
+    for (let x = 0; x < side; x++) {
+      out.push({
+        lat: latMin + ((y + 0.5) / side) * (latMax - latMin),
+        lon: lonMin + ((x + 0.5) / side) * (lonMax - lonMin),
+      })
+    }
+  }
+  return out
+}
+
+export function gridSideForBbox(bbox) {
+  const [latMin, latMax, lonMin, lonMax] = bbox
+  const centerLat = (latMin + latMax) / 2
+  const heightKm = Math.abs(latMax - latMin) * 111.32
+  const widthKm = Math.abs(lonMax - lonMin) * 111.32 * Math.max(0.1, Math.cos(centerLat * Math.PI / 180))
+  return clamp(21, 81, Math.ceil(Math.max(widthKm, heightKm) / 2))
+}
+
+export function sampleCoverage(registryBbox, geojson, geometryBbox = bboxForGeojson(geojson)) {
+  const registrySamples = gridSamplesForBbox(registryBbox)
+  const registryOutsideGeometry = registrySamples.filter(
+    point => !geojsonContainsPoint(geojson, point.lat, point.lon)
+  )
+
+  const geometrySamples = geometryBbox ? gridSamplesForBbox(geometryBbox) : []
+  const insideGeometry = geometrySamples.filter(
+    point => geojsonContainsPoint(geojson, point.lat, point.lon)
+  )
+  const geometryOutsideRegistry = insideGeometry.filter(
+    point => !bboxContainsPoint(registryBbox, point.lat, point.lon)
+  )
+
+  return {
+    registryGridSide: Math.sqrt(registrySamples.length),
+    geometryGridSide: geometrySamples.length ? Math.sqrt(geometrySamples.length) : 0,
+    overcoverageRatio: ratio(registryOutsideGeometry.length, registrySamples.length),
+    undercoverageRatio: ratio(geometryOutsideRegistry.length, insideGeometry.length),
+    registrySampleCount: registrySamples.length,
+    geometrySampleCount: insideGeometry.length,
+  }
+}
+
+function ratio(numerator, denominator) {
+  if (!denominator) return 0
+  return Math.max(0, numerator) / denominator
+}
+
+function clamp(min, max, value) {
+  return Math.max(min, Math.min(max, value))
+}
+
+function polygonContainsPoint(polygon, lat, lon) {
+  if (!polygon.length) return false
+  if (!ringContainsPoint(polygon[0], lat, lon)) return false
+  for (let i = 1; i < polygon.length; i++) {
+    if (ringContainsPoint(polygon[i], lat, lon)) return false
+  }
+  return true
+}
+
+function ringContainsPoint(ring, lat, lon) {
+  let inside = false
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i]
+    const [xj, yj] = ring[j]
+
+    if (pointOnSegment(lon, lat, xi, yi, xj, yj)) return true
+
+    const intersects = ((yi > lat) !== (yj > lat)) &&
+      (lon < (xj - xi) * (lat - yi) / (yj - yi) + xi)
+    if (intersects) inside = !inside
+  }
+  return inside
+}
+
+function pointOnSegment(x, y, x1, y1, x2, y2) {
+  const cross = (x - x1) * (y2 - y1) - (y - y1) * (x2 - x1)
+  if (Math.abs(cross) > EPS) return false
+
+  const minX = Math.min(x1, x2) - EPS
+  const maxX = Math.max(x1, x2) + EPS
+  const minY = Math.min(y1, y2) - EPS
+  const maxY = Math.max(y1, y2) + EPS
+  return x >= minX && x <= maxX && y >= minY && y <= maxY
+}
+
+function collectCoordinates(input, out) {
+  if (!input) return
+  if (input.type === 'Feature') return collectCoordinates(input.geometry, out)
+  if (input.type === 'FeatureCollection') {
+    for (const feature of input.features || []) collectCoordinates(feature, out)
+    return
+  }
+  if (input.type === 'GeometryCollection') {
+    for (const geometry of input.geometries || []) collectCoordinates(geometry, out)
+    return
+  }
+  collectCoordinateArray(input.coordinates, out)
+}
+
+function collectCoordinateArray(value, out) {
+  if (!Array.isArray(value)) return
+  if (value.length >= 2 && typeof value[0] === 'number' && typeof value[1] === 'number') {
+    out.push(value)
+    return
+  }
+  for (const child of value) collectCoordinateArray(child, out)
+}

--- a/test/geometryAudit.test.js
+++ b/test/geometryAudit.test.js
@@ -1,0 +1,166 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+
+import { describe, expect, it } from 'vitest'
+import {
+  bboxForGeojson,
+  bboxIntersection,
+  compareCityBboxToGeojson,
+  geojsonContainsPoint,
+  gridSamplesForBbox,
+  gridSideForBbox,
+  sampleCoverage,
+} from '../scripts/lib/geometry-audit.js'
+
+describe('geometry audit helpers', () => {
+  const squareWithHole = {
+    type: 'Feature',
+    properties: { name: 'Test City' },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],
+        [[4, 4], [6, 4], [6, 6], [4, 6], [4, 4]],
+      ],
+    },
+  }
+
+  it('computes bbox in fajr lat-min/lat-max/lon-min/lon-max order', () => {
+    expect(bboxForGeojson(squareWithHole)).toEqual([0, 10, 0, 10])
+  })
+
+  it('handles polygon shells, holes, and boundary points', () => {
+    expect(geojsonContainsPoint(squareWithHole, 2, 2)).toBe(true)
+    expect(geojsonContainsPoint(squareWithHole, 5, 5)).toBe(false)
+    expect(geojsonContainsPoint(squareWithHole, 0, 5)).toBe(true)
+    expect(geojsonContainsPoint(squareWithHole, 12, 5)).toBe(false)
+  })
+
+  it('handles multipolygons', () => {
+    const multipolygon = {
+      type: 'MultiPolygon',
+      coordinates: [
+        [[[20, 20], [21, 20], [21, 21], [20, 21], [20, 20]]],
+        [[[30, 30], [31, 30], [31, 31], [30, 31], [30, 30]]],
+      ],
+    }
+    expect(bboxForGeojson(multipolygon)).toEqual([20, 31, 20, 31])
+    expect(geojsonContainsPoint(multipolygon, 20.5, 20.5)).toBe(true)
+    expect(geojsonContainsPoint(multipolygon, 25, 25)).toBe(false)
+    expect(geojsonContainsPoint(multipolygon, 30.5, 30.5)).toBe(true)
+  })
+
+  it('handles FeatureCollection and GeometryCollection inputs', () => {
+    const collection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [-1, -2] },
+          properties: {},
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'GeometryCollection',
+            geometries: [
+              {
+                type: 'Polygon',
+                coordinates: [[[40, 40], [41, 40], [41, 41], [40, 41], [40, 40]]],
+              },
+            ],
+          },
+          properties: {},
+        },
+      ],
+    }
+    expect(bboxForGeojson(collection)).toEqual([-2, 41, -1, 41])
+    expect(geojsonContainsPoint(collection, -2, -1)).toBe(true)
+    expect(geojsonContainsPoint(collection, 40.5, 40.5)).toBe(true)
+    expect(geojsonContainsPoint(collection, 20, 20)).toBe(false)
+  })
+
+  it('returns null bbox and false containment for empty geometry', () => {
+    const empty = { type: 'Polygon', coordinates: [] }
+    expect(bboxForGeojson(empty)).toBeNull()
+    expect(geojsonContainsPoint(empty, 0, 0)).toBe(false)
+  })
+
+  it('computes bbox intersections', () => {
+    expect(bboxIntersection([0, 10, 0, 10], [5, 15, 2, 8])).toEqual([5, 10, 2, 8])
+    expect(bboxIntersection([0, 1, 0, 1], [2, 3, 2, 3])).toBeNull()
+  })
+
+  it('compares registry bbox against external geometry bbox', () => {
+    const city = {
+      name: 'Test City',
+      countryISO: 'TC',
+      lat: 2,
+      lon: 2,
+      bbox: [0, 3, 0, 3],
+    }
+    const result = compareCityBboxToGeojson(city, squareWithHole)
+    expect(result.status).toBe('checked')
+    expect(result.centerInsideGeometry).toBe(true)
+    expect(result.centerInsideRegistryBbox).toBe(true)
+    expect(result.geometryBbox).toEqual([0, 10, 0, 10])
+    expect(result.registryBboxOutsideGeometryBboxRatio).toBe(0)
+    expect(result.geometryBboxOutsideRegistryBboxRatio).toBe(0.91)
+    expect(result.coverage.overcoverageRatio).toBe(0)
+    expect(result.coverage.undercoverageRatio).toBeGreaterThan(0.7)
+  })
+
+  it('separates center-inside-geometry from center-inside-registry-bbox', () => {
+    const city = {
+      name: 'Offset City',
+      countryISO: 'OC',
+      lat: 2,
+      lon: 2,
+      bbox: [20, 21, 20, 21],
+    }
+    const result = compareCityBboxToGeojson(city, squareWithHole)
+    expect(result.status).toBe('checked')
+    expect(result.centerInsideGeometry).toBe(true)
+    expect(result.centerInsideRegistryBbox).toBe(false)
+    expect(result.bboxIntersection).toBeNull()
+  })
+
+  it('reports missing geometry when no usable coordinates exist', () => {
+    const city = {
+      name: 'Missing Geometry City',
+      countryISO: 'MG',
+      lat: 0,
+      lon: 0,
+      bbox: [0, 1, 0, 1],
+    }
+    expect(compareCityBboxToGeojson(city, { type: 'FeatureCollection', features: [] })).toEqual({
+      city: 'Missing Geometry City',
+      countryISO: 'MG',
+      status: 'missing-geometry',
+    })
+  })
+
+  it('uses deterministic grid samples for coverage estimates', () => {
+    expect(gridSideForBbox([0, 0.1, 0, 0.1])).toBe(21)
+    const samples = gridSamplesForBbox([0, 1, 0, 1], 3)
+    expect(samples).toEqual([
+      { lat: 1 / 6, lon: 1 / 6 },
+      { lat: 1 / 6, lon: 0.5 },
+      { lat: 1 / 6, lon: 5 / 6 },
+      { lat: 0.5, lon: 1 / 6 },
+      { lat: 0.5, lon: 0.5 },
+      { lat: 0.5, lon: 5 / 6 },
+      { lat: 5 / 6, lon: 1 / 6 },
+      { lat: 5 / 6, lon: 0.5 },
+      { lat: 5 / 6, lon: 5 / 6 },
+    ])
+  })
+
+  it('clamps grid side and returns deterministic coverage results', () => {
+    expect(gridSideForBbox([0, 0.01, 0, 0.01])).toBe(21)
+    expect(gridSideForBbox([0, 100, 0, 100])).toBe(81)
+    const first = sampleCoverage([0, 3, 0, 3], squareWithHole)
+    const second = sampleCoverage([0, 3, 0, 3], squareWithHole)
+    expect(second).toEqual(first)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the first build-time geometry audit scaffold for #118:

- dependency-free GeoJSON helpers for bbox extraction, point-in-polygon, multipolygons/holes, deterministic grid sampling, and coverage estimates;
- no-network `scripts/audit-city-geometry.js` CLI that reads reviewed source-map rows and cached GeoJSON only;
- geometry audit policy doc and README/data-source/changelog links;
- focused no-network unit tests.

## Intentional boundaries

- No changes to `src/engine.js`, `src/data/cities.json`, eval data, prayer math, or public API.
- No raw WOF/OSM/Overture/official geometry is committed.
- `.cache/` is ignored so external polygons remain local/build-time artifacts.
- `scripts/data/city-geometry-sources.json` is not created here; stable IDs should be curated in a follow-up PR instead of guessed.

## Verification

- `npx vitest run test/geometryAudit.test.js` — 11/11 passed
- `npm test` — 355/355 passed
- `npm run validate:registry` — 0 FAIL, 3 existing WARN
- `node scripts/audit-city-geometry.js --format json` — exits cleanly with setup message while source map is absent

## Research notes

Parallel-agent research and regional/source/license findings were posted to #118. The consensus is to use geometry as advisory build-time QA first, prefer WOF/official sources where possible, and keep OSM/Overture audit-only unless license-reviewed.

Refs #118.