### PR TITLE
Seed city geometry source map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,10 +62,16 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added `scripts/audit-city-geometry.js` and `scripts/lib/geometry-audit.js`,
   a no-network advisory audit path for comparing reviewed cached GeoJSON
   geometries against the shipped city bbox registry.
+- Added `scripts/data/city-geometry-sources.json`, a seed source map for 20
+  high-priority bbox QA rows: Morocco/Habous phase-1 cities plus the current
+  Jerusalem, Brazzaville/Kinshasa, and Basel/Mulhouse validator-warning rows.
 - Added [docs/city-geometry-audit.md](docs/city-geometry-audit.md), documenting
   why raw municipal polygons stay out of the runtime package, which sources are
   safe for audit vs bundled derivation, and which Morocco/current-warning rows
   should be reviewed first.
+- Added CLI coverage for source-map rows with missing local cache files,
+  intentionally blank geometry candidates, cached local GeoJSON, and cache-path
+  escapes.
 - Added focused geometry helper tests covering GeoJSON bbox extraction,
   polygon holes, multipolygons, deterministic grid sampling, and bbox coverage
   metrics.
@@ -101,8 +107,12 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
   a separate PR with cross-source spot checks.
 - The city geometry audit scaffold does not change `detectLocation()`, city
   bboxes, package runtime behavior, or prayer-time calculations. It exits
-  cleanly until `scripts/data/city-geometry-sources.json` is curated with
-  reviewed external IDs and cached geometry.
+  cleanly when a source map is absent, and reports `cache-file-not-found` until
+  reviewed external geometry is fetched into `.cache/city-geometry/`.
+- The seeded city geometry source map stores stable OSM relation IDs and
+  Habous authority IDs only. OSM-derived geometries and bbox edits remain
+  audit-only until explicit license review approves any derived MIT-package
+  data.
 
 ## [1.8.0] — 2026-05-06
 

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -30,7 +30,11 @@ human review. It must not mutate the runtime registry automatically.
 ## Source Map
 
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
-The source map stores metadata and cache pointers only:
+The source map stores metadata and cache pointers only. The current seed covers
+20 high-priority rows: 15 Morocco/Habous phase-1 rows and 5 existing registry
+warning rows. Seventeen rows carry candidate OSM relation IDs; Berrechid,
+Settat, and Jerusalem intentionally remain without geometry candidates until a
+reviewed source or human routing decision is available.
 
 ```json
 {
@@ -65,7 +69,9 @@ The source map stores metadata and cache pointers only:
 
 Use stable provider IDs: WOF IDs/GIDs, OSM relation IDs, Overture GERS IDs, or
 official local authority IDs. Do not store Nominatim `place_id`; it is not a
-stable external identifier.
+stable external identifier. The current OSM relation IDs are audit-only
+candidates, not bundled source data and not approved sources for deriving MIT
+package bboxes without license review.
 
 ## Running
 
@@ -78,8 +84,9 @@ node scripts/audit-city-geometry.js --sources scripts/data/city-geometry-sources
 ```
 
 If `scripts/data/city-geometry-sources.json` is absent, the script exits cleanly
-and prints a setup message. That is intentional while the source map is being
-curated.
+and prints a setup message. If the source map exists but cached GeoJSON is
+absent, the report lists `cache-file-not-found`; that is expected until a
+reviewer fetches raw geometry into `.cache/city-geometry/`.
 
 ## First Audit Targets
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -1,6 +1,6 @@
 # Data Sources
 
-Last refreshed: 2026-05-06
+Last refreshed: 2026-05-08
 
 This page explains what fajr validates against, how each source should be
 trusted, and where the raw source details live. It is not the source of truth
@@ -142,9 +142,9 @@ Raw/source locations:
 - `eval/data/test/morocco-habous.json`
 - `scripts/data/habous-morocco-cities.json`
 - `scripts/data/mawaqit-mosques.json`
-- `scripts/data/city-geometry-sources.json` (planned source map for
-  reviewed external geometry IDs; see
-  [city geometry audit](city-geometry-audit.md))
+- `scripts/data/city-geometry-sources.json` (candidate source map for reviewed
+  external geometry IDs; stores stable IDs and cache pointers only, with raw
+  geometry kept outside git/npm; see [city geometry audit](city-geometry-audit.md))
 - `fixtures/habous-morocco/`
 - `scripts/fetch-morocco-habous.js`
 - `scripts/fetch-habous-morocco-month.js`

--- a/scripts/audit-city-geometry.js
+++ b/scripts/audit-city-geometry.js
@@ -14,9 +14,11 @@
  *         {
  *           "provider": "wof",
  *           "stableId": "whosonfirst:locality:...",
- *           "license": "Who's On First License",
+ *           "licenseUse": "audit-only-until-license-review",
  *           "cacheFile": "MA/rabat.geojson",
- *           "confidence": "candidate"
+ *           "sourceConfidence": "high",
+ *           "matchConfidence": "candidate",
+ *           "reviewStatus": "candidate"
  *         }
  *       ]
  *     }
@@ -64,7 +66,13 @@ for (const entry of sourceMap.cities || []) {
     continue
   }
 
-  for (const source of geometrySourcesForEntry(entry)) {
+  const sources = geometrySourcesForEntry(entry)
+  if (!sources.length) {
+    rows.push(sourceMapEntryRow(city, entry, { status: 'no-geometry-candidates' }))
+    continue
+  }
+
+  for (const source of sources) {
     const cacheFile = source.cacheFile || source.geometryFile
     if (!cacheFile) {
       rows.push(sourceRow(city, source, { status: 'missing-cache-file' }))
@@ -108,6 +116,20 @@ function sourceRow(city, source, result) {
   }
 }
 
+function sourceMapEntryRow(city, entry, result) {
+  return {
+    cityKey: `${city.name}|${city.countryISO}`,
+    city: city.name,
+    countryISO: city.countryISO,
+    priority: entry.priority || [],
+    reviewStatus: entry.review?.status || null,
+    notes: entry.notes || entry.review?.notes || [],
+    provider: null,
+    stableId: null,
+    ...result,
+  }
+}
+
 function report(rows) {
   return {
     version: 1,
@@ -116,10 +138,12 @@ function report(rows) {
     registryPath: 'src/data/cities.json',
     cacheDir: path.relative(ROOT, cacheDir),
     summary: {
-      sourceCandidatesChecked: rows.length,
+      sourceMapCities: (sourceMap.cities || []).length,
+      sourceRowsReported: rows.length,
       checked: rows.filter(row => row.status === 'checked').length,
       missingCacheFiles: rows.filter(row => row.status === 'cache-file-not-found').length,
       missingGeometry: rows.filter(row => row.status === 'missing-geometry').length,
+      noGeometryCandidates: rows.filter(row => row.status === 'no-geometry-candidates').length,
       cityNotFound: rows.filter(row => row.status === 'city-not-found').length,
     },
     rows,

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1,0 +1,402 @@
+{
+  "$schema_doc": "Build-time source map for auditing src/data/cities.json city bboxes. This file stores stable external IDs, review state, authority IDs, and cache pointers only. Raw geometry stays outside git/npm in .cache/city-geometry.",
+  "version": 1,
+  "updated": "2026-05-08",
+  "issue": 118,
+  "cacheRoot": ".cache/city-geometry",
+  "providers": {
+    "osm": {
+      "name": "OpenStreetMap administrative boundary",
+      "stableIdFormat": "osm:relation:{id}",
+      "license": "ODbL",
+      "defaultUse": "audit-only-until-license-review",
+      "notes": [
+        "Store OSM relation IDs only; never store Nominatim place_id.",
+        "Raw OSM geometry and derived bbox edits require license review before shipping in the MIT package."
+      ]
+    },
+    "wof": {
+      "name": "Who's On First / Geocode Earth",
+      "stableIdFormat": "wof:{placetype}:{id}",
+      "license": "Who's On First License with row-level upstream attribution caveats",
+      "defaultUse": "audit-and-reviewed-bbox-proposal"
+    },
+    "official": {
+      "name": "Official local or national boundary source",
+      "stableIdFormat": "provider-specific",
+      "license": "provider-specific",
+      "defaultUse": "preferred-when-license-reviewed"
+    }
+  },
+  "cities": [
+    {
+      "cityKey": "Rabat|MA",
+      "priority": ["phase-1-morocco", "habous", "rabat-metro"],
+      "relatedAuthorityIds": { "habousVilleId": 1, "habousMatch": "direct" },
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": ["Morocco phase-1 row. Habous ID is prayer-time provenance, not geometry."]
+      },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2799215",
+          "ids": { "osmRelationId": 2799215, "adminLevel": 8, "wikidata": "Q3551", "refMAHCP": "04.421.01.0" },
+          "cacheFile": "MA/rabat/osm-relation-2799215.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Sale|MA",
+      "priority": ["phase-1-morocco", "habous", "rabat-metro", "nearest-official-city"],
+      "relatedAuthorityIds": { "habousVilleId": 1, "habousMatch": "nearest-official-city" },
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": ["Habous maps Sale to Rabat; geometry audit should keep the Sale city bbox distinct."]
+      },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2801066",
+          "ids": { "osmRelationId": 2801066, "adminLevel": 8, "wikidata": "Q466046", "refMAHCP": "04.441.01.0" },
+          "cacheFile": "MA/sale/osm-relation-2801066.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Temara|MA",
+      "priority": ["phase-1-morocco", "habous", "rabat-metro", "nearest-official-city"],
+      "relatedAuthorityIds": { "habousVilleId": 1, "habousMatch": "nearest-official-city" },
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": ["Habous maps Temara to Rabat; geometry audit should keep the Temara city bbox distinct."]
+      },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2498868",
+          "ids": { "osmRelationId": 2498868, "adminLevel": 8, "wikidata": "Q1635606", "refMAHCP": "04.501.01.07." },
+          "cacheFile": "MA/temara/osm-relation-2498868.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Agadir|MA",
+      "priority": ["phase-1-morocco", "habous", "agadir-metro"],
+      "relatedAuthorityIds": { "habousVilleId": 117, "habousMatch": "direct" },
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": ["Agadir is the official Habous table used for Inezgane as nearest official city."]
+      },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2529624",
+          "ids": { "osmRelationId": 2529624, "adminLevel": 8, "wikidata": "Q170525", "refMAHCP": "09.001.01.01" },
+          "cacheFile": "MA/agadir/osm-relation-2529624.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Inezgane|MA",
+      "priority": ["phase-1-morocco", "habous", "agadir-metro", "nearest-official-city"],
+      "relatedAuthorityIds": { "habousVilleId": 117, "habousMatch": "nearest-official-city" },
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": ["Habous maps Inezgane to Agadir; geometry audit should keep the Inezgane city bbox distinct."]
+      },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2529625",
+          "ids": { "osmRelationId": 2529625, "adminLevel": 8, "wikidata": "Q2736030", "refMAHCP": "09.273.01.15." },
+          "cacheFile": "MA/inezgane/osm-relation-2529625.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Casablanca|MA",
+      "priority": ["phase-1-morocco", "habous", "large-metro-bbox"],
+      "relatedAuthorityIds": { "habousVilleId": 58, "habousMatch": "direct" },
+      "review": { "status": "candidate", "issue": 118 },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:4072985",
+          "ids": { "osmRelationId": 4072985, "adminLevel": 8, "wikidata": "Q7903", "refMAHCP": "06.141.01.0" },
+          "cacheFile": "MA/casablanca/osm-relation-4072985.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Berrechid|MA",
+      "priority": ["phase-1-morocco", "habous", "casablanca-settat-cluster"],
+      "relatedAuthorityIds": { "habousVilleId": 65, "habousMatch": "direct" },
+      "review": { "status": "unreviewed", "issue": 118 },
+      "geometries": []
+    },
+    {
+      "cityKey": "Settat|MA",
+      "priority": ["phase-1-morocco", "habous", "casablanca-settat-cluster"],
+      "relatedAuthorityIds": { "habousVilleId": 61, "habousMatch": "direct" },
+      "review": { "status": "unreviewed", "issue": 118 },
+      "geometries": []
+    },
+    {
+      "cityKey": "Fes|MA",
+      "priority": ["phase-1-morocco", "habous", "large-metro-bbox"],
+      "relatedAuthorityIds": { "habousVilleId": 81, "habousMatch": "direct" },
+      "review": { "status": "candidate", "issue": 118 },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2799557",
+          "ids": { "osmRelationId": 2799557, "adminLevel": 8, "wikidata": "Q80985", "refMAHCP": "03.231.01.0" },
+          "cacheFile": "MA/fes/osm-relation-2799557.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Sefrou|MA",
+      "priority": ["phase-1-morocco", "habous", "fes-cluster"],
+      "relatedAuthorityIds": { "habousVilleId": 82, "habousMatch": "direct" },
+      "review": { "status": "candidate", "issue": 118 },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2808834",
+          "ids": { "osmRelationId": 2808834, "adminLevel": 8, "wikidata": "Q1009308", "refMAHCP": "03.451.01.09." },
+          "cacheFile": "MA/sefrou/osm-relation-2808834.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Meknes|MA",
+      "priority": ["phase-1-morocco", "habous", "fes-meknes-cluster"],
+      "relatedAuthorityIds": { "habousVilleId": 99, "habousMatch": "direct" },
+      "review": { "status": "candidate", "issue": 118 },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2561177",
+          "ids": { "osmRelationId": 2561177, "adminLevel": 8, "wikidata": "Q178663", "refMAHCP": "03.061.01.01." },
+          "cacheFile": "MA/meknes/osm-relation-2561177.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Tangier|MA",
+      "priority": ["phase-1-morocco", "habous", "north-morocco-border"],
+      "relatedAuthorityIds": { "habousVilleId": 14, "habousMatch": "direct" },
+      "review": { "status": "candidate", "issue": 118 },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2758781",
+          "ids": { "osmRelationId": 2758781, "adminLevel": 8, "wikidata": "Q126148", "refMAHCP": "01.511.01.0" },
+          "cacheFile": "MA/tangier/osm-relation-2758781.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Tetouan|MA",
+      "priority": ["phase-1-morocco", "habous", "north-morocco-border"],
+      "relatedAuthorityIds": { "habousVilleId": 15, "habousMatch": "direct" },
+      "review": { "status": "candidate", "issue": 118 },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2464649",
+          "ids": { "osmRelationId": 2464649, "adminLevel": 8, "wikidata": "Q185157", "refMAHCP": "01.571.01.11." },
+          "cacheFile": "MA/tetouan/osm-relation-2464649.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Nador|MA",
+      "priority": ["phase-1-morocco", "habous", "north-east-morocco-border"],
+      "relatedAuthorityIds": { "habousVilleId": 39, "habousMatch": "direct" },
+      "review": { "status": "candidate", "issue": 118 },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2431056",
+          "ids": { "osmRelationId": 2431056, "adminLevel": 8, "wikidata": "Q824594", "refMAHCP": "02.381.01.05." },
+          "cacheFile": "MA/nador/osm-relation-2431056.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Oujda|MA",
+      "priority": ["phase-1-morocco", "habous", "north-east-morocco-border"],
+      "relatedAuthorityIds": { "habousVilleId": 31, "habousMatch": "direct" },
+      "review": { "status": "candidate", "issue": 118 },
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:2527998",
+          "ids": { "osmRelationId": 2527998, "adminLevel": 8, "wikidata": "Q193802", "refMAHCP": "02.411.01.23." },
+          "cacheFile": "MA/oujda/osm-relation-2527998.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Jerusalem|PS",
+      "priority": ["current-validator-warning", "intentional-routing-anchor", "human-review-required"],
+      "review": {
+        "status": "intentional-routing-anchor",
+        "issue": 118,
+        "notes": [
+          "Current validator WARN: row center is outside bbox by design.",
+          "Do not attach a municipal polygon or change routing semantics without human review."
+        ]
+      },
+      "auditExpectations": [
+        {
+          "kind": "row-center-outside-bbox-allowlisted",
+          "accepted": true
+        }
+      ],
+      "geometries": []
+    },
+    {
+      "cityKey": "Brazzaville|CG",
+      "priority": ["current-validator-warning", "cross-border-overlap", "congo-river"],
+      "review": { "status": "candidate", "issue": 118 },
+      "expectedNeighborWarnings": [
+        { "cityKey": "Kinshasa|CD", "kind": "bbox-overlap-cross-country" }
+      ],
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:16370691",
+          "ids": { "osmRelationId": 16370691, "adminLevel": 5, "wikidata": "Q3844" },
+          "cacheFile": "CG/brazzaville/osm-relation-16370691.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate",
+          "notes": ["OSM candidate is commune/departement level; compare with WOF/official sources before bbox edits."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Kinshasa|CD",
+      "priority": ["current-validator-warning", "cross-border-overlap", "congo-river"],
+      "review": { "status": "candidate", "issue": 118 },
+      "expectedNeighborWarnings": [
+        { "cityKey": "Brazzaville|CG", "kind": "bbox-overlap-cross-country" }
+      ],
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:5646651",
+          "ids": { "osmRelationId": 5646651, "adminLevel": 4, "wikidata": "Q3838" },
+          "cacheFile": "CD/kinshasa/osm-relation-5646651.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate",
+          "notes": ["OSM candidate is province-level; compare with WOF/official sources before bbox edits."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Basel|CH",
+      "priority": ["current-validator-warning", "cross-border-overlap", "europe-p0"],
+      "review": { "status": "candidate", "issue": 118 },
+      "expectedNeighborWarnings": [
+        { "cityKey": "Mulhouse|FR", "kind": "bbox-overlap-cross-country" }
+      ],
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:1683619",
+          "ids": { "osmRelationId": 1683619, "adminLevel": 8, "wikidata": "Q78", "swisstopoBfsNumber": "2701" },
+          "cacheFile": "CH/basel/osm-relation-1683619.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Mulhouse|FR",
+      "priority": ["current-validator-warning", "cross-border-overlap", "europe-p0"],
+      "review": { "status": "candidate", "issue": 118 },
+      "expectedNeighborWarnings": [
+        { "cityKey": "Basel|CH", "kind": "bbox-overlap-cross-country" }
+      ],
+      "geometries": [
+        {
+          "provider": "osm",
+          "stableId": "osm:relation:38246",
+          "ids": { "osmRelationId": 38246, "adminLevel": 8, "wikidata": "Q79815", "refINSEE": "68224" },
+          "cacheFile": "FR/mulhouse/osm-relation-38246.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        }
+      ]
+    }
+  ]
+}

--- a/test/geometryAuditCli.test.js
+++ b/test/geometryAuditCli.test.js
@@ -1,0 +1,157 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const ROOT = process.cwd()
+const SCRIPT = path.join(ROOT, 'scripts/audit-city-geometry.js')
+const tmpDirs = []
+
+describe('city geometry audit CLI', () => {
+  afterEach(() => {
+    while (tmpDirs.length) {
+      fs.rmSync(tmpDirs.pop(), { recursive: true, force: true })
+    }
+  })
+
+  it('prints an advisory and exits 0 when the source map is absent', () => {
+    const dir = tempDir()
+    const missing = path.join(dir, 'missing.json')
+    const out = runCli(['--sources', missing, '--format', 'json'])
+    expect(out).toContain('no source map found')
+    expect(out).toContain('city-geometry-sources.json')
+  })
+
+  it('reports source-map rows without geometry candidates and missing cache files', () => {
+    const dir = tempDir()
+    const sourcePath = path.join(dir, 'sources.json')
+    const cacheDir = path.join(dir, 'cache')
+    fs.mkdirSync(cacheDir)
+    writeJson(sourcePath, {
+      version: 1,
+      cacheRoot: cacheDir,
+      cities: [
+        {
+          cityKey: 'Rabat|MA',
+          review: { status: 'unreviewed' },
+          geometries: [],
+        },
+        {
+          cityKey: 'Sale|MA',
+          geometries: [
+            {
+              provider: 'osm',
+              stableId: 'osm:relation:2801066',
+              cacheFile: 'sale.geojson',
+              reviewStatus: 'candidate',
+            },
+          ],
+        },
+      ],
+    })
+
+    const report = JSON.parse(runCli(['--sources', sourcePath, '--format', 'json']))
+    expect(report.summary.sourceMapCities).toBe(2)
+    expect(report.summary.noGeometryCandidates).toBe(1)
+    expect(report.summary.missingCacheFiles).toBe(1)
+    expect(report.rows.map(row => row.status)).toEqual([
+      'no-geometry-candidates',
+      'cache-file-not-found',
+    ])
+  })
+
+  it('reads cached local GeoJSON and emits checked rows', () => {
+    const dir = tempDir()
+    const sourcePath = path.join(dir, 'sources.json')
+    const cacheDir = path.join(dir, 'cache')
+    fs.mkdirSync(cacheDir)
+    writeJson(path.join(cacheDir, 'rabat.geojson'), squareFeature(-7, 33.5, -6, 34.5))
+    writeJson(sourcePath, {
+      version: 1,
+      cacheRoot: cacheDir,
+      cities: [
+        {
+          cityKey: 'Rabat|MA',
+          geometries: [
+            {
+              provider: 'osm',
+              stableId: 'osm:relation:2799215',
+              cacheFile: 'rabat.geojson',
+              reviewStatus: 'candidate',
+            },
+          ],
+        },
+      ],
+    })
+
+    const report = JSON.parse(runCli(['--sources', sourcePath, '--format', 'json']))
+    expect(report.summary.checked).toBe(1)
+    expect(report.rows[0].status).toBe('checked')
+    expect(report.rows[0].centerInsideGeometry).toBe(true)
+  })
+
+  it('reports cache path escapes instead of reading outside cache dir', () => {
+    const dir = tempDir()
+    const sourcePath = path.join(dir, 'sources.json')
+    const cacheDir = path.join(dir, 'cache')
+    fs.mkdirSync(cacheDir)
+    writeJson(sourcePath, {
+      version: 1,
+      cacheRoot: cacheDir,
+      cities: [
+        {
+          cityKey: 'Rabat|MA',
+          geometries: [
+            {
+              provider: 'osm',
+              stableId: 'osm:relation:2799215',
+              cacheFile: '../outside.geojson',
+              reviewStatus: 'candidate',
+            },
+          ],
+        },
+      ],
+    })
+
+    const report = JSON.parse(runCli(['--sources', sourcePath, '--format', 'json']))
+    expect(report.rows[0].status).toBe('cache-path-outside-cache-dir')
+  })
+})
+
+function tempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fajr-geometry-audit-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+function runCli(args) {
+  return execFileSync(process.execPath, [SCRIPT, ...args], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  })
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, JSON.stringify(value, null, 2))
+}
+
+function squareFeature(west, south, east, north) {
+  return {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'Polygon',
+      coordinates: [[
+        [west, south],
+        [east, south],
+        [east, north],
+        [west, north],
+        [west, south],
+      ]],
+    },
+  }
+}


### PR DESCRIPTION
Refs #118.

## Summary
- Seeds scripts/data/city-geometry-sources.json with 20 prioritized audit rows: 15 Morocco/Habous phase-1 city rows plus 5 current validator-warning rows.
- Updates audit CLI summary/reporting for source-map rows with no geometry candidates and missing local cache files.
- Adds CLI tests for absent source map, missing cache, cached local GeoJSON, and cache path escape handling.
- Updates city geometry/data-source docs and changelog to make clear this is advisory metadata only.

## Verification
- npx vitest run test/geometryAudit.test.js test/geometryAuditCli.test.js
- npm test
- npm run validate:registry
- node scripts/audit-city-geometry.js --format json
- git diff --check

## Notes
No runtime bbox, detectLocation, package files, or prayer-time calculation changes. OSM relation IDs are audit-only until license review; raw geometry remains outside git/npm under .cache/city-geometry.