### PR TITLE
Add WOF city geometry candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added `scripts/data/city-geometry-sources.json`, a seed source map for 20
   high-priority bbox QA rows: Morocco/Habous phase-1 cities plus the current
   Jerusalem, Brazzaville/Kinshasa, and Basel/Mulhouse validator-warning rows.
+- Added WOF candidate IDs for Morocco source-map rows where WOF has a plausible
+  locality or reviewed lower-confidence county geometry, including Berrechid
+  and Settat which previously had no geometry candidate.
 - Added [docs/city-geometry-audit.md](docs/city-geometry-audit.md), documenting
   why raw municipal polygons stay out of the runtime package, which sources are
   safe for audit vs bundled derivation, and which Morocco/current-warning rows

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -32,9 +32,10 @@ human review. It must not mutate the runtime registry automatically.
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
 20 high-priority rows: 15 Morocco/Habous phase-1 rows and 5 existing registry
-warning rows. Seventeen rows carry candidate OSM relation IDs; Berrechid,
-Settat, and Jerusalem intentionally remain without geometry candidates until a
-reviewed source or human routing decision is available.
+warning rows. It carries 17 candidate OSM relation IDs plus 11 WOF candidate
+IDs. Berrechid and Settat now have WOF locality candidates; Jerusalem
+intentionally remains without a geometry candidate until a human routing
+decision is available.
 
 ```json
 {
@@ -71,7 +72,9 @@ Use stable provider IDs: WOF IDs/GIDs, OSM relation IDs, Overture GERS IDs, or
 official local authority IDs. Do not store Nominatim `place_id`; it is not a
 stable external identifier. The current OSM relation IDs are audit-only
 candidates, not bundled source data and not approved sources for deriving MIT
-package bboxes without license review.
+package bboxes without license review. WOF candidates are still candidates:
+locality records are preferred, while county-level WOF records are marked
+medium confidence because their placetype can over-cover the city row.
 
 ## Running
 

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -48,6 +48,16 @@
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
           "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421190103",
+          "ids": { "wofId": 421190103, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "MA/rabat/wof-locality-421190103.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
         }
       ]
     },
@@ -69,6 +79,16 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:1108784811",
+          "ids": { "wofId": 1108784811, "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "MA/sale/wof-county-1108784811.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
           "reviewStatus": "candidate"
         }
       ]
@@ -114,6 +134,16 @@
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
           "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421170495",
+          "ids": { "wofId": 421170495, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "MA/agadir/wof-locality-421170495.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
         }
       ]
     },
@@ -154,6 +184,16 @@
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
           "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:890442533",
+          "ids": { "wofId": 890442533, "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "MA/casablanca/wof-county-890442533.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
         }
       ]
     },
@@ -162,14 +202,36 @@
       "priority": ["phase-1-morocco", "habous", "casablanca-settat-cluster"],
       "relatedAuthorityIds": { "habousVilleId": 65, "habousMatch": "direct" },
       "review": { "status": "unreviewed", "issue": 118 },
-      "geometries": []
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:1125988395",
+          "ids": { "wofId": 1125988395, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "MA/berrechid/wof-locality-1125988395.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
     },
     {
       "cityKey": "Settat|MA",
       "priority": ["phase-1-morocco", "habous", "casablanca-settat-cluster"],
       "relatedAuthorityIds": { "habousVilleId": 61, "habousMatch": "direct" },
       "review": { "status": "unreviewed", "issue": 118 },
-      "geometries": []
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421190099",
+          "ids": { "wofId": 421190099, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "MA/settat/wof-locality-421190099.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
     },
     {
       "cityKey": "Fes|MA",
@@ -185,6 +247,16 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421170491",
+          "ids": { "wofId": 421170491, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 0 },
+          "cacheFile": "MA/fes/wof-locality-421170491.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
           "reviewStatus": "candidate"
         }
       ]
@@ -203,6 +275,16 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421190111",
+          "ids": { "wofId": 421190111, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "MA/sefrou/wof-locality-421190111.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
           "reviewStatus": "candidate"
         }
       ]
@@ -240,6 +322,16 @@
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
           "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421190123",
+          "ids": { "wofId": 421190123, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "MA/tangier/wof-locality-421190123.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
         }
       ]
     },
@@ -276,6 +368,16 @@
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
           "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421190085",
+          "ids": { "wofId": 421190085, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "MA/nador/wof-locality-421190085.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
         }
       ]
     },
@@ -293,6 +395,16 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421200921",
+          "ids": { "wofId": 421200921, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "MA/oujda/wof-locality-421200921.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
           "reviewStatus": "candidate"
         }
       ]

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -1,0 +1,88 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import sourceMap from '../scripts/data/city-geometry-sources.json' with { type: 'json' }
+import cityModule from '../src/data/cities.json' with { type: 'json' }
+
+describe('city geometry source map', () => {
+  const registryKeys = new Set(
+    cityModule.cities.map(city => `${city.name}|${city.countryISO}`)
+  )
+
+  it('references only existing registry city rows', () => {
+    const seen = new Set()
+    for (const entry of sourceMap.cities) {
+      expect(registryKeys.has(entry.cityKey), entry.cityKey).toBe(true)
+      expect(seen.has(entry.cityKey), entry.cityKey).toBe(false)
+      seen.add(entry.cityKey)
+    }
+  })
+
+  it('keeps raw geometry paths inside the expected per-city cache folder', () => {
+    for (const entry of sourceMap.cities) {
+      const [city, iso] = entry.cityKey.split('|')
+      const expectedPrefix = `${iso}/${slug(city)}/`
+      for (const geometry of entry.geometries || []) {
+        expect(geometry.cacheFile, entry.cityKey).toBeTruthy()
+        expect(path.posix.normalize(geometry.cacheFile), geometry.cacheFile)
+          .toBe(geometry.cacheFile)
+        expect(geometry.cacheFile.startsWith(expectedPrefix), `${entry.cityKey} ${geometry.stableId}`)
+          .toBe(true)
+      }
+    }
+  })
+
+  it('keeps OSM audit-only and marks WOF placetype mismatches as lower confidence', () => {
+    for (const entry of sourceMap.cities) {
+      for (const geometry of entry.geometries || []) {
+        if (geometry.provider === 'osm') {
+          expect(geometry.stableId).toMatch(/^osm:relation:\d+$/)
+          expect(geometry.licenseUse).toBe('audit-only-until-license-review')
+        }
+        if (geometry.provider === 'wof') {
+          expect(geometry.stableId).toMatch(/^wof:[a-z]+:\d+$/)
+          expect(geometry.licenseUse).toBe('audit-and-reviewed-bbox-proposal')
+          if (geometry.ids?.placetype !== 'locality') {
+            expect(geometry.sourceConfidence).not.toBe('high')
+            expect(geometry.matchConfidence).toContain('placetype-mismatch')
+          }
+        }
+      }
+    }
+  })
+
+  it('does not store unstable Nominatim place IDs', () => {
+    const forbiddenKeys = []
+    collectForbiddenKeys(sourceMap, forbiddenKeys)
+    expect(forbiddenKeys).toEqual([])
+  })
+
+  it('requires a review reason for rows with no geometry candidates', () => {
+    const blankEntries = sourceMap.cities.filter(entry => !(entry.geometries || []).length)
+    expect(blankEntries.map(entry => entry.cityKey)).toEqual(['Jerusalem|PS'])
+    expect(blankEntries[0].review.status).toBe('intentional-routing-anchor')
+  })
+})
+
+function slug(city) {
+  return city
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+function collectForbiddenKeys(value, out, pathParts = []) {
+  if (!value || typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectForbiddenKeys(item, out, [...pathParts, String(index)]))
+    return
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'place_id' || key === 'placeId') out.push([...pathParts, key].join('.'))
+    collectForbiddenKeys(child, out, [...pathParts, key])
+  }
+}


### PR DESCRIPTION
Refs #118.

## Summary
- Adds 11 Who’s On First candidate geometry IDs to `scripts/data/city-geometry-sources.json` for Morocco source-map rows.
- Promotes Berrechid and Settat from blank geometry rows to WOF locality candidates.
- Marks Sale and Casablanca WOF candidates as medium-confidence county/placetype-mismatch rows rather than city-locality geometry.
- Adds `test/geometrySourceMap.test.js` to guard source-map invariants: registry city keys, per-city cache paths, OSM audit-only license use, WOF placetype-mismatch confidence, no unstable Nominatim place IDs, and explicit review reason for blank rows.
- Updates the geometry audit doc and changelog for the WOF candidate layer.

## Verification
- npx vitest run test/geometrySourceMap.test.js test/geometryAuditCli.test.js
- npm test
- npm run validate:registry
- node scripts/audit-city-geometry.js --format json
- git diff --check

## Local audit note
With local OSM + WOF cache populated, `node scripts/audit-city-geometry.js --format json` reports 28 checked geometries, 0 missing cache files, and Jerusalem as the only intentional no-geometry row. Raw WOF/OSM geometry cache files are not committed.

## Behavior
No runtime bbox, `detectLocation()`, package size, public API, or prayer-time calculation changes.