### PR TITLE
Add WOF geometry cache fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added WOF candidate IDs for Morocco source-map rows where WOF has a plausible
   locality or reviewed lower-confidence county geometry, including Berrechid
   and Settat which previously had no geometry candidate.
+- Added `scripts/fetch-city-geometry-cache.js`, a WOF-only cache hydration
+  helper that fetches reviewed source-map geometry into `.cache/city-geometry/`
+  without committing raw geometry or changing runtime bboxes.
 - Added [docs/city-geometry-audit.md](docs/city-geometry-audit.md), documenting
   why raw municipal polygons stay out of the runtime package, which sources are
   safe for audit vs bundled derivation, and which Morocco/current-warning rows

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -81,6 +81,8 @@ medium confidence because their placetype can over-cover the city row.
 With reviewed IDs and cached GeoJSON present:
 
 ```bash
+node scripts/fetch-city-geometry-cache.js --provider wof --dry-run
+node scripts/fetch-city-geometry-cache.js --provider wof
 node scripts/audit-city-geometry.js
 node scripts/audit-city-geometry.js --format json
 node scripts/audit-city-geometry.js --sources scripts/data/city-geometry-sources.json --cache-dir .cache/city-geometry
@@ -90,6 +92,11 @@ If `scripts/data/city-geometry-sources.json` is absent, the script exits cleanly
 and prints a setup message. If the source map exists but cached GeoJSON is
 absent, the report lists `cache-file-not-found`; that is expected until a
 reviewer fetches raw geometry into `.cache/city-geometry/`.
+
+`fetch-city-geometry-cache.js` currently hydrates WOF candidates only. It uses
+the explicit WOF repository metadata in the source map, writes raw GeoJSON to
+`.cache/city-geometry/`, and leaves OSM/Overture/official fetch paths to
+separate reviewed workflows because their terms and APIs differ.
 
 ## First Audit Targets
 

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -19,7 +19,10 @@
       "name": "Who's On First / Geocode Earth",
       "stableIdFormat": "wof:{placetype}:{id}",
       "license": "Who's On First License with row-level upstream attribution caveats",
-      "defaultUse": "audit-and-reviewed-bbox-proposal"
+      "defaultUse": "audit-and-reviewed-bbox-proposal",
+      "notes": [
+        "Each WOF candidate must store ids.repo so fetch-city-geometry-cache.js can hydrate the local raw-geometry cache deterministically."
+      ]
     },
     "official": {
       "name": "Official local or national boundary source",
@@ -52,7 +55,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:421190103",
-          "ids": { "wofId": 421190103, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "ids": { "wofId": 421190103, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "MA/rabat/wof-locality-421190103.geojson",
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
@@ -84,7 +87,7 @@
         {
           "provider": "wof",
           "stableId": "wof:county:1108784811",
-          "ids": { "wofId": 1108784811, "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "ids": { "wofId": 1108784811, "repo": "whosonfirst-data-admin-ma", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
           "cacheFile": "MA/sale/wof-county-1108784811.geojson",
           "sourceConfidence": "medium",
           "matchConfidence": "placetype-mismatch-candidate",
@@ -138,7 +141,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:421170495",
-          "ids": { "wofId": 421170495, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "ids": { "wofId": 421170495, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "MA/agadir/wof-locality-421170495.geojson",
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
@@ -188,7 +191,7 @@
         {
           "provider": "wof",
           "stableId": "wof:county:890442533",
-          "ids": { "wofId": 890442533, "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "ids": { "wofId": 890442533, "repo": "whosonfirst-data-admin-ma", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
           "cacheFile": "MA/casablanca/wof-county-890442533.geojson",
           "sourceConfidence": "medium",
           "matchConfidence": "placetype-mismatch-candidate",
@@ -206,7 +209,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:1125988395",
-          "ids": { "wofId": 1125988395, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "ids": { "wofId": 1125988395, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "MA/berrechid/wof-locality-1125988395.geojson",
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
@@ -224,7 +227,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:421190099",
-          "ids": { "wofId": 421190099, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "ids": { "wofId": 421190099, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "MA/settat/wof-locality-421190099.geojson",
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
@@ -252,7 +255,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:421170491",
-          "ids": { "wofId": 421170491, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 0 },
+          "ids": { "wofId": 421170491, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 0 },
           "cacheFile": "MA/fes/wof-locality-421170491.geojson",
           "sourceConfidence": "medium",
           "matchConfidence": "candidate",
@@ -280,7 +283,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:421190111",
-          "ids": { "wofId": 421190111, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "ids": { "wofId": 421190111, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "MA/sefrou/wof-locality-421190111.geojson",
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
@@ -326,7 +329,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:421190123",
-          "ids": { "wofId": 421190123, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "ids": { "wofId": 421190123, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "MA/tangier/wof-locality-421190123.geojson",
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
@@ -372,7 +375,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:421190085",
-          "ids": { "wofId": 421190085, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "ids": { "wofId": 421190085, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "MA/nador/wof-locality-421190085.geojson",
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
@@ -400,7 +403,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:421200921",
-          "ids": { "wofId": 421200921, "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "ids": { "wofId": 421200921, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "MA/oujda/wof-locality-421200921.geojson",
           "sourceConfidence": "high",
           "matchConfidence": "candidate",

--- a/scripts/fetch-city-geometry-cache.js
+++ b/scripts/fetch-city-geometry-cache.js
@@ -1,0 +1,146 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Hydrate reviewed build-time geometry cache files from source-map entries.
+ *
+ * This script is intentionally limited to providers whose source-map entries
+ * carry enough license/repository metadata for deterministic fetches. It does
+ * not mutate src/data/cities.json and does not commit raw geometry.
+ *
+ * Usage:
+ *   node scripts/fetch-city-geometry-cache.js --provider wof --dry-run
+ *   node scripts/fetch-city-geometry-cache.js --provider wof --city Rabat
+ *   node scripts/fetch-city-geometry-cache.js --provider wof --format json
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  geometryEntries,
+  safeCachePath,
+  wofRawUrl,
+} from './lib/city-geometry-cache.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, '..')
+
+const args = parseArgs(process.argv.slice(2))
+const sourcePath = path.resolve(ROOT, args.sources || 'scripts/data/city-geometry-sources.json')
+const sourceMap = JSON.parse(fs.readFileSync(sourcePath, 'utf8'))
+const cacheDir = path.resolve(ROOT, args.cacheDir || sourceMap.cacheRoot || '.cache/city-geometry')
+const provider = args.provider || 'wof'
+const branch = args.branch || 'master'
+const format = args.format || 'text'
+const dryRun = Boolean(args.dryRun)
+const overwrite = Boolean(args.overwrite)
+
+if (provider !== 'wof') {
+  console.error('Usage error: only --provider wof is currently supported.')
+  process.exit(2)
+}
+
+const rows = []
+const entries = geometryEntries(sourceMap, { provider, city: args.city })
+for (const { entry, geometry } of entries) {
+  const target = safeCachePath(cacheDir, geometry.cacheFile)
+  const url = wofRawUrl(geometry, { branch })
+  const row = {
+    cityKey: entry.cityKey,
+    provider: geometry.provider,
+    stableId: geometry.stableId,
+    cacheFile: geometry.cacheFile,
+    sourceConfidence: geometry.sourceConfidence || null,
+    matchConfidence: geometry.matchConfidence || null,
+    licenseUse: geometry.licenseUse || null,
+    url,
+  }
+
+  if (fs.existsSync(target) && !overwrite) {
+    rows.push({ ...row, status: 'skipped-existing' })
+    continue
+  }
+  if (dryRun) {
+    rows.push({ ...row, status: 'would-fetch' })
+    continue
+  }
+
+  try {
+    const geojson = await fetchGeojson(url)
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(target, `${JSON.stringify(geojson, null, 2)}\n`)
+    rows.push({ ...row, status: 'fetched' })
+  } catch (err) {
+    rows.push({ ...row, status: 'error', error: err.message })
+  }
+}
+
+const report = {
+  version: 1,
+  generatedAt: new Date().toISOString(),
+  sourcePath: path.relative(ROOT, sourcePath),
+  cacheDir: path.relative(ROOT, cacheDir),
+  provider,
+  dryRun,
+  summary: {
+    rows: rows.length,
+    fetched: rows.filter(row => row.status === 'fetched').length,
+    skippedExisting: rows.filter(row => row.status === 'skipped-existing').length,
+    wouldFetch: rows.filter(row => row.status === 'would-fetch').length,
+    errors: rows.filter(row => row.status === 'error').length,
+  },
+  rows,
+}
+
+if (format === 'json') {
+  console.log(JSON.stringify(report, null, 2))
+} else {
+  printText(report)
+}
+
+if (report.summary.errors) process.exit(1)
+
+async function fetchGeojson(url) {
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': 'fajr-city-geometry-cache/1.0 (https://github.com/tawfeeqmartin/fajr/issues/118)',
+      'Accept': 'application/geo+json, application/json',
+    },
+  })
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`)
+  const geojson = await res.json()
+  if (!geojson || typeof geojson !== 'object' || !geojson.type) {
+    throw new Error(`Invalid GeoJSON from ${url}`)
+  }
+  return geojson
+}
+
+function parseArgs(argv) {
+  const out = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--sources') out.sources = argv[++i]
+    else if (arg === '--cache-dir') out.cacheDir = argv[++i]
+    else if (arg === '--provider') out.provider = argv[++i]
+    else if (arg === '--city') out.city = argv[++i]
+    else if (arg === '--branch') out.branch = argv[++i]
+    else if (arg === '--format') out.format = argv[++i]
+    else if (arg === '--dry-run') out.dryRun = true
+    else if (arg === '--overwrite') out.overwrite = true
+  }
+  return out
+}
+
+function printText(report) {
+  console.log(`# City Geometry Cache Fetch (${report.provider})`)
+  console.log('')
+  console.log(`Source map: ${report.sourcePath}`)
+  console.log(`Cache dir: ${report.cacheDir}`)
+  console.log(`Rows: ${report.summary.rows}`)
+  console.log('')
+  for (const row of report.rows) {
+    const suffix = row.error ? ` (${row.error})` : ''
+    console.log(`- ${row.status}: ${row.cityKey} ${row.stableId} -> ${row.cacheFile}${suffix}`)
+  }
+}

--- a/scripts/lib/city-geometry-cache.js
+++ b/scripts/lib/city-geometry-cache.js
@@ -1,0 +1,59 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Helpers for hydrating build-time city geometry cache files from reviewed
+ * source-map entries. Raw geometry stays outside git/npm in .cache.
+ */
+
+import path from 'node:path'
+
+export function geometryEntries(sourceMap, { provider = null, city = null } = {}) {
+  const cityFilter = city ? normalizeCityFilter(city) : null
+  const out = []
+  for (const entry of sourceMap.cities || []) {
+    if (cityFilter && !matchesCity(entry.cityKey, cityFilter)) continue
+    for (const geometry of entry.geometries || []) {
+      if (provider && geometry.provider !== provider) continue
+      out.push({ entry, geometry })
+    }
+  }
+  return out
+}
+
+export function wofDataPath(wofId) {
+  const id = String(wofId || '')
+  if (!/^\d+$/.test(id)) throw new Error(`Invalid WOF id: ${wofId}`)
+  return id.match(/.{1,3}/g).join('/')
+}
+
+export function wofRawUrl(geometry, { branch = 'master' } = {}) {
+  const wofId = geometry.ids?.wofId || parseWofStableId(geometry.stableId).id
+  const repo = geometry.ids?.repo || geometry.repo
+  if (!repo) throw new Error(`${geometry.stableId || wofId}: missing WOF repo`)
+  return `https://raw.githubusercontent.com/whosonfirst-data/${repo}/${branch}/data/${wofDataPath(wofId)}/${wofId}.geojson`
+}
+
+export function safeCachePath(cacheDir, cacheFile) {
+  if (!cacheFile) throw new Error('Missing cacheFile')
+  const root = path.resolve(cacheDir)
+  const target = path.resolve(root, cacheFile)
+  if (!target.startsWith(root + path.sep) && target !== root) {
+    throw new Error(`cacheFile escapes cache dir: ${cacheFile}`)
+  }
+  return target
+}
+
+export function parseWofStableId(stableId) {
+  const match = /^wof:([a-z]+):(\d+)$/.exec(String(stableId || ''))
+  if (!match) throw new Error(`Invalid WOF stableId: ${stableId}`)
+  return { placetype: match[1], id: match[2] }
+}
+
+function matchesCity(cityKey, filter) {
+  const normalized = normalizeCityFilter(cityKey)
+  return normalized === filter || normalized.startsWith(`${filter}|`)
+}
+
+function normalizeCityFilter(value) {
+  return String(value || '').trim().toLowerCase()
+}

--- a/test/geometryCacheFetcher.test.js
+++ b/test/geometryCacheFetcher.test.js
@@ -1,0 +1,127 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  geometryEntries,
+  safeCachePath,
+  wofDataPath,
+  wofRawUrl,
+} from '../scripts/lib/city-geometry-cache.js'
+
+const ROOT = process.cwd()
+const SCRIPT = path.join(ROOT, 'scripts/fetch-city-geometry-cache.js')
+const tmpDirs = []
+
+describe('city geometry cache fetch helpers', () => {
+  afterEach(() => {
+    while (tmpDirs.length) {
+      fs.rmSync(tmpDirs.pop(), { recursive: true, force: true })
+    }
+  })
+
+  it('builds WOF data paths in repository layout order', () => {
+    expect(wofDataPath(421190103)).toBe('421/190/103')
+    expect(wofDataPath(1108784811)).toBe('110/878/481/1')
+    expect(() => wofDataPath('not-an-id')).toThrow(/Invalid WOF id/)
+  })
+
+  it('builds raw GitHub URLs from explicit WOF repo metadata', () => {
+    expect(wofRawUrl({
+      stableId: 'wof:locality:421190103',
+      ids: { repo: 'whosonfirst-data-admin-ma' },
+    })).toBe('https://raw.githubusercontent.com/whosonfirst-data/whosonfirst-data-admin-ma/master/data/421/190/103/421190103.geojson')
+  })
+
+  it('filters source-map entries by provider and city', () => {
+    const entries = geometryEntries(sampleSourceMap(), { provider: 'wof', city: 'Rabat' })
+    expect(entries).toHaveLength(1)
+    expect(entries[0].entry.cityKey).toBe('Rabat|MA')
+    expect(entries[0].geometry.stableId).toBe('wof:locality:421190103')
+  })
+
+  it('rejects cache paths outside the cache directory', () => {
+    const dir = tempDir()
+    expect(safeCachePath(dir, 'MA/rabat/test.geojson')).toBe(path.join(dir, 'MA/rabat/test.geojson'))
+    expect(() => safeCachePath(dir, '../outside.geojson')).toThrow(/escapes cache dir/)
+  })
+
+  it('prints dry-run JSON without fetching network data', () => {
+    const dir = tempDir()
+    const sourcePath = path.join(dir, 'sources.json')
+    const cacheDir = path.join(dir, 'cache')
+    writeJson(sourcePath, sampleSourceMap())
+
+    const report = JSON.parse(execFileSync(process.execPath, [
+      SCRIPT,
+      '--sources', sourcePath,
+      '--cache-dir', cacheDir,
+      '--provider', 'wof',
+      '--dry-run',
+      '--format', 'json',
+    ], { cwd: ROOT, encoding: 'utf8' }))
+
+    expect(report.summary).toMatchObject({
+      rows: 2,
+      fetched: 0,
+      skippedExisting: 0,
+      wouldFetch: 2,
+      errors: 0,
+    })
+    expect(report.rows[0].url).toContain('/whosonfirst-data-admin-ma/master/data/421/190/103/421190103.geojson')
+    expect(fs.existsSync(cacheDir)).toBe(false)
+  })
+})
+
+function sampleSourceMap() {
+  return {
+    version: 1,
+    cacheRoot: '.cache/city-geometry',
+    cities: [
+      {
+        cityKey: 'Rabat|MA',
+        geometries: [
+          {
+            provider: 'wof',
+            stableId: 'wof:locality:421190103',
+            ids: { wofId: 421190103, repo: 'whosonfirst-data-admin-ma' },
+            cacheFile: 'MA/rabat/wof-locality-421190103.geojson',
+            licenseUse: 'audit-and-reviewed-bbox-proposal',
+          },
+        ],
+      },
+      {
+        cityKey: 'Sale|MA',
+        geometries: [
+          {
+            provider: 'wof',
+            stableId: 'wof:county:1108784811',
+            ids: { wofId: 1108784811, repo: 'whosonfirst-data-admin-ma' },
+            cacheFile: 'MA/sale/wof-county-1108784811.geojson',
+            licenseUse: 'audit-and-reviewed-bbox-proposal',
+          },
+          {
+            provider: 'osm',
+            stableId: 'osm:relation:2801066',
+            cacheFile: 'MA/sale/osm-relation-2801066.geojson',
+            licenseUse: 'audit-only-until-license-review',
+          },
+        ],
+      },
+    ],
+  }
+}
+
+function tempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fajr-geometry-cache-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, JSON.stringify(value, null, 2))
+}

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -43,6 +43,7 @@ describe('city geometry source map', () => {
         }
         if (geometry.provider === 'wof') {
           expect(geometry.stableId).toMatch(/^wof:[a-z]+:\d+$/)
+          expect(geometry.ids?.repo, geometry.stableId).toMatch(/^whosonfirst-data-/)
           expect(geometry.licenseUse).toBe('audit-and-reviewed-bbox-proposal')
           if (geometry.ids?.placetype !== 'locality') {
             expect(geometry.sourceConfidence).not.toBe('high')


### PR DESCRIPTION
Refs #118.

## Summary
- Adds `scripts/fetch-city-geometry-cache.js`, a WOF-only helper that hydrates reviewed source-map geometry into `.cache/city-geometry/` without committing raw geometry.
- Adds `scripts/lib/city-geometry-cache.js` for deterministic WOF path/URL/cache-path helpers.
- Adds explicit `ids.repo` metadata to every WOF source-map candidate so raw GitHub URLs are reproducible.
- Extends source-map tests to require WOF repo metadata and adds cache-fetcher unit/CLI dry-run tests.
- Documents the WOF hydrate + audit workflow in `docs/city-geometry-audit.md` and records it in `CHANGELOG.md`.

## Verification
- npx vitest run test/geometryCacheFetcher.test.js test/geometrySourceMap.test.js
- npm test
- npm run validate:registry
- node scripts/fetch-city-geometry-cache.js --provider wof --dry-run --format json --cache-dir /tmp/fajr-empty-geometry-cache
- rm -rf /tmp/fajr-wof-cache-test && node scripts/fetch-city-geometry-cache.js --provider wof --cache-dir /tmp/fajr-wof-cache-test --format json
- node scripts/audit-city-geometry.js --cache-dir /tmp/fajr-wof-cache-test --format json
- git diff --check

## Behavior
No runtime bbox, `detectLocation()`, package contents, public API, or prayer-time calculation changes. The helper writes raw WOF GeoJSON only to local cache paths; raw geometry remains outside git/npm.