### PR TITLE
Add city geometry audit triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added CLI coverage for source-map rows with missing local cache files,
   intentionally blank geometry candidates, cached local GeoJSON, and cache-path
   escapes.
+- Added automatic geometry-audit triage labels for undercoverage, over-broad
+  bboxes, center mismatches, source-review needs, and low-priority matches.
 - Added focused geometry helper tests covering GeoJSON bbox extraction,
   polygon holes, multipolygons, deterministic grid sampling, and bbox coverage
   metrics.

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -125,6 +125,18 @@ The report should distinguish geometry QA from prayer-time math. A bbox change
 may alter city/source/method provenance, but it is not a WMAE improvement unless
 fixtures prove a calculation change.
 
+Reports include advisory triage labels so reviewers can sort rows before
+opening bbox PRs:
+
+- `undercoverage-review` — reviewed geometry samples fall outside the shipped
+  bbox; potential missed city coverage.
+- `tighten-review` — most shipped bbox samples fall outside reviewed geometry;
+  potential metro/border leakage.
+- `watch` / `low-priority` — visible or minor mismatch, usually not first in
+  line unless the row affects a known source or border problem.
+- `registry-center-review` / `center-geometry-review` — center-point mismatch;
+  treat as high-priority data quality review.
+
 Each row should report at minimum:
 
 - city key and provider stable ID;

--- a/scripts/audit-city-geometry.js
+++ b/scripts/audit-city-geometry.js
@@ -101,6 +101,8 @@ if (format === 'json') {
 }
 
 function sourceRow(city, source, result) {
+  const sourceNeedsReview = source.sourceConfidence !== 'high' ||
+    Boolean(source.matchConfidence && source.matchConfidence !== 'candidate')
   return {
     cityKey: `${city.name}|${city.countryISO}`,
     city: city.name,
@@ -112,6 +114,7 @@ function sourceRow(city, source, result) {
     matchConfidence: source.matchConfidence || null,
     licenseUse: source.licenseUse || null,
     reviewStatus: source.reviewStatus || null,
+    sourceNeedsReview: result.status === 'checked' ? sourceNeedsReview : null,
     ...result,
   }
 }
@@ -145,9 +148,21 @@ function report(rows) {
       missingGeometry: rows.filter(row => row.status === 'missing-geometry').length,
       noGeometryCandidates: rows.filter(row => row.status === 'no-geometry-candidates').length,
       cityNotFound: rows.filter(row => row.status === 'city-not-found').length,
+      sourceNeedsReview: rows.filter(row => row.sourceNeedsReview).length,
+      triage: triageCounts(rows),
     },
     rows,
   }
+}
+
+function triageCounts(rows) {
+  const counts = {}
+  for (const row of rows) {
+    const action = row.triage?.action
+    if (!action) continue
+    counts[action] = (counts[action] || 0) + 1
+  }
+  return counts
 }
 
 function cityKey(name, iso) {
@@ -186,8 +201,8 @@ function printMarkdown(rows) {
   console.log(`Cache dir: ${path.relative(ROOT, cacheDir)}`)
   console.log(`Rows checked: ${rows.length}`)
   console.log('')
-  console.log('| City | ISO | Provider | Stable ID | Status | Review | License use | Center in geometry | Registry outside geom bbox | Geom bbox outside registry |')
-  console.log('|---|---|---|---|---|---|---|---:|---:|---:|')
+  console.log('| City | ISO | Provider | Stable ID | Status | Triage | Source review | License use | Center in geometry | Overcoverage | Undercoverage |')
+  console.log('|---|---|---|---|---|---|---|---|---:|---:|---:|')
   for (const row of rows) {
     console.log([
       row.city,
@@ -195,11 +210,12 @@ function printMarkdown(rows) {
       row.provider || '-',
       row.stableId || '-',
       row.status,
-      row.reviewStatus || '-',
+      row.triage?.action || '-',
+      row.sourceNeedsReview == null ? '-' : String(row.sourceNeedsReview),
       row.licenseUse || '-',
       row.centerInsideGeometry == null ? '-' : String(row.centerInsideGeometry),
-      percent(row.registryBboxOutsideGeometryBboxRatio),
-      percent(row.geometryBboxOutsideRegistryBboxRatio),
+      percent(row.coverage?.overcoverageRatio),
+      percent(row.coverage?.undercoverageRatio),
     ].map(markdownCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'))
   }
 }

--- a/scripts/lib/geometry-audit.js
+++ b/scripts/lib/geometry-audit.js
@@ -86,7 +86,7 @@ export function compareCityBboxToGeojson(city, geojson) {
   const geometryArea = bboxAreaDeg2(geometryBbox)
   const intersectionArea = intersection ? bboxAreaDeg2(intersection) : 0
 
-  return {
+  const result = {
     city: city.name,
     countryISO: city.countryISO,
     status: 'checked',
@@ -101,6 +101,57 @@ export function compareCityBboxToGeojson(city, geojson) {
     registryBboxOutsideGeometryBboxRatio: ratio(registryArea - intersectionArea, registryArea),
     geometryBboxOutsideRegistryBboxRatio: ratio(geometryArea - intersectionArea, geometryArea),
     coverage: sampleCoverage(city.bbox, geojson, geometryBbox),
+  }
+  return {
+    ...result,
+    triage: triageGeometryComparison(result),
+  }
+}
+
+export function triageGeometryComparison(result) {
+  if (!result || result.status !== 'checked') return null
+  if (!result.centerInsideRegistryBbox) {
+    return {
+      action: 'registry-center-review',
+      severity: 'high',
+      reason: 'City center is outside the shipped registry bbox.',
+    }
+  }
+  if (!result.centerInsideGeometry) {
+    return {
+      action: 'center-geometry-review',
+      severity: 'high',
+      reason: 'City center is outside the reviewed external geometry.',
+    }
+  }
+
+  const undercoverage = result.coverage?.undercoverageRatio ?? 0
+  const overcoverage = result.coverage?.overcoverageRatio ?? 0
+  if (undercoverage >= 0.20) {
+    return {
+      action: 'undercoverage-review',
+      severity: 'high',
+      reason: 'External geometry samples fall outside the shipped bbox.',
+    }
+  }
+  if (overcoverage >= 0.70) {
+    return {
+      action: 'tighten-review',
+      severity: 'medium',
+      reason: 'Most shipped bbox samples fall outside the external geometry.',
+    }
+  }
+  if (undercoverage >= 0.05 || overcoverage >= 0.40) {
+    return {
+      action: 'watch',
+      severity: 'low',
+      reason: 'Geometry mismatch is visible but below review thresholds.',
+    }
+  }
+  return {
+    action: 'low-priority',
+    severity: 'info',
+    reason: 'Registry bbox and external geometry broadly agree.',
   }
 }
 

--- a/test/geometryAudit.test.js
+++ b/test/geometryAudit.test.js
@@ -10,6 +10,7 @@ import {
   gridSamplesForBbox,
   gridSideForBbox,
   sampleCoverage,
+  triageGeometryComparison,
 } from '../scripts/lib/geometry-audit.js'
 
 describe('geometry audit helpers', () => {
@@ -108,6 +109,7 @@ describe('geometry audit helpers', () => {
     expect(result.geometryBboxOutsideRegistryBboxRatio).toBe(0.91)
     expect(result.coverage.overcoverageRatio).toBe(0)
     expect(result.coverage.undercoverageRatio).toBeGreaterThan(0.7)
+    expect(result.triage.action).toBe('undercoverage-review')
   })
 
   it('separates center-inside-geometry from center-inside-registry-bbox', () => {
@@ -123,6 +125,7 @@ describe('geometry audit helpers', () => {
     expect(result.centerInsideGeometry).toBe(true)
     expect(result.centerInsideRegistryBbox).toBe(false)
     expect(result.bboxIntersection).toBeNull()
+    expect(result.triage.action).toBe('registry-center-review')
   })
 
   it('reports missing geometry when no usable coordinates exist', () => {
@@ -162,5 +165,22 @@ describe('geometry audit helpers', () => {
     const first = sampleCoverage([0, 3, 0, 3], squareWithHole)
     const second = sampleCoverage([0, 3, 0, 3], squareWithHole)
     expect(second).toEqual(first)
+  })
+
+  it('triages over-broad registry bboxes for tightening review', () => {
+    const city = {
+      name: 'Broad City',
+      countryISO: 'BC',
+      lat: 2,
+      lon: 2,
+      bbox: [-10, 20, -10, 20],
+    }
+    const result = compareCityBboxToGeojson(city, squareWithHole)
+    expect(result.triage.action).toBe('tighten-review')
+    expect(result.triage.severity).toBe('medium')
+  })
+
+  it('returns null triage for unchecked rows', () => {
+    expect(triageGeometryComparison({ status: 'cache-file-not-found' })).toBeNull()
   })
 })

--- a/test/geometryAuditCli.test.js
+++ b/test/geometryAuditCli.test.js
@@ -90,8 +90,10 @@ describe('city geometry audit CLI', () => {
 
     const report = JSON.parse(runCli(['--sources', sourcePath, '--format', 'json']))
     expect(report.summary.checked).toBe(1)
+    expect(report.summary.triage['undercoverage-review']).toBe(1)
     expect(report.rows[0].status).toBe('checked')
     expect(report.rows[0].centerInsideGeometry).toBe(true)
+    expect(report.rows[0].triage.action).toBe('undercoverage-review')
   })
 
   it('reports cache path escapes instead of reading outside cache dir', () => {


### PR DESCRIPTION
Refs #118.

## Summary
- Adds automatic triage labels to geometry audit checked rows: `undercoverage-review`, `tighten-review`, `watch`, `low-priority`, and center mismatch reviews.
- Adds `sourceNeedsReview` and summary counts so medium-confidence or placetype-mismatch sources are visible in JSON reports.
- Updates markdown output to show triage, source-review status, overcoverage, and undercoverage directly.
- Documents the triage labels in `docs/city-geometry-audit.md` and records the change in `CHANGELOG.md`.
- Extends helper and CLI tests for triage behavior.

## Verification
- npx vitest run test/geometryAudit.test.js test/geometryAuditCli.test.js
- npm test
- npm run validate:registry
- node scripts/fetch-city-geometry-cache.js --provider wof --cache-dir /tmp/fajr-wof-cache-test --format json
- node scripts/audit-city-geometry.js --cache-dir /tmp/fajr-wof-cache-test --format json
- git diff --check

## Behavior
No runtime bbox, `detectLocation()`, package contents, public API, or prayer-time calculation changes. This only makes the existing advisory audit output easier to sort and review.