### PR TITLE
Preserve Morocco bbox fixes in registry generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
   locality candidates, clipped to preserve deterministic non-overlap with the
   neighboring Sale/Temara and Inezgane rows. Prayer-time math is unchanged; this
   only affects city/source provenance for coordinates near those bbox edges.
+- Synchronized the city-registry generator overrides so future
+  `scripts/build-city-registry.js` runs preserve the reviewed Rabat/Agadir
+  bboxes.
 
 ### Changed — documentation doctrine cleanup
 

--- a/scripts/build-city-registry.js
+++ b/scripts/build-city-registry.js
@@ -853,14 +853,18 @@ const BBOX_OVERRIDES = {
   'Lahore|PK':          [31.25, 31.85, 74.04, 74.50],
   'Temara|MA':          [33.85, 33.99, -7.00, -6.86],
   'Sale|MA':            [34.04, 34.14, -6.90, -6.78],
-  'Rabat|MA':           [33.97, 34.04, -6.90, -6.78],
+  // v1.8.0 #118/#124: WOF-backed lookup cell, clipped so Rabat does not
+  // steal adjacent Sale/Temara coordinates in detectLocation().
+  'Rabat|MA':           [33.961, 34.035, -6.918, -6.762],
   'Khartoum Bahri|SD':  [15.61, 15.72, 32.50, 32.62],
   'Khartoum|SD':        [15.40, 15.60, 32.50, 32.66],
   'Omdurman|SD':        [15.50, 15.78, 32.30, 32.50],
   'Sharjah|AE':         [25.35, 25.65, 55.42, 55.72],
   'Dubai|AE':           [24.90, 25.35, 55.05, 55.50],
   'Inezgane|MA':        [30.32, 30.39, -9.58, -9.49],
-  'Agadir|MA':          [30.40, 30.58, -9.75, -9.45],
+  // v1.8.0 #118/#124: WOF-backed lookup cell, clipped so Agadir does not
+  // steal adjacent Inezgane coordinates in detectLocation().
+  'Agadir|MA':          [30.391, 30.454, -9.652, -9.454],
   'Zarqa|JO':           [32.05, 32.27, 35.94, 36.24],
   'Amman|JO':           [31.85, 32.00, 35.83, 36.00],
   'Berrechid|MA':       [33.20, 33.34, -7.65, -7.49],


### PR DESCRIPTION
## Summary

- update `scripts/build-city-registry.js` bbox overrides for Rabat and Agadir to match merged PR #124
- document why the WOF-backed lookup cells are clipped around Sale/Temara and Inezgane
- note the generator sync in the changelog

Refs #118 and #124.

## Validation

- npm run validate:registry
- npm test: 372/372

## Note

I ran `node scripts/build-city-registry.js` to verify the generator path. It now preserves the Rabat/Agadir bbox values, but the rebuild also surfaced unrelated pre-existing generator drift in other city fields, so I did not commit regenerated `src/data/cities.json` output in this narrow sync PR. That broader generator drift should be tracked separately.
