### PR TITLE
Guard city registry generator drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Synchronized the city-registry generator overrides so future
   `scripts/build-city-registry.js` runs preserve the reviewed Rabat/Agadir
   bboxes.
+- Added a `scripts/build-city-registry.js --check` guard and reconciled
+  generator inputs for Lisbon, Pattani, and Iraqi override source institutions
+  so the checked-in city registry can no longer drift silently from its source
+  data.
 
 ### Changed — documentation doctrine cleanup
 

--- a/scripts/build-city-registry.js
+++ b/scripts/build-city-registry.js
@@ -47,6 +47,7 @@ import { fileURLToPath } from 'node:url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname  = path.dirname(__filename)
 const ROOT       = path.resolve(__dirname, '..')
+const CHECK_MODE = process.argv.includes('--check')
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Load inputs
@@ -417,7 +418,7 @@ const MUSLIM_POPULATION_CENTERS = [
   { name: 'Brisbane',   countryISO: 'AU', adminRegion: 'Queensland', lat: -27.4698, lon: 153.0251, elevation: 28, timezone: 'Australia/Brisbane', population: 2462000 },
 
   // ─── Multi-method-split / minority-fiqh stress cases ──────────────────────
-  { name: 'Pattani',    nameLocal: 'ปัตตานี', countryISO: 'TH', adminRegion: 'Pattani Province', lat: 6.8682, lon: 101.2497, elevation: 4, timezone: 'Asia/Bangkok', population: 144000 },
+  { name: 'Pattani',    nameLocal: 'ปัตตานี', countryISO: 'TH', adminRegion: 'Pattani Province', lat: 6.8682, lon: 101.2497, elevation: 4, timezone: 'Asia/Bangkok', population: 45000 },
   { name: 'Cotabato',   countryISO: 'PH', adminRegion: 'Maguindanao del Norte / BARMM', lat: 7.2178, lon: 124.2451, elevation: 9, timezone: 'Asia/Manila', population: 325000 },
   { name: 'Marawi',     countryISO: 'PH', adminRegion: 'Lanao del Sur / BARMM', lat: 7.9988, lon: 124.2937, elevation: 730, timezone: 'Asia/Manila', population: 201000 },
   { name: 'Bradford',   countryISO: 'GB', adminRegion: 'West Yorkshire', lat: 53.7960, lon: -1.7594, elevation: 110, timezone: 'Europe/London', population: 358000 },
@@ -917,6 +918,9 @@ const BBOX_OVERRIDES = {
   'Mamoudzou|YT':       [-12.81, -12.74, 45.20, 45.27],
   'Laayoune|EH':        [27.10, 27.20, -13.25, -13.13],
   'Nicosia|CY':         [35.13, 35.24, 33.32, 33.45],
+  // v1.8.0 #126: Pattani's city population is municipal-scale, but the
+  // runtime row intentionally keeps the wider southern Thailand lookup cell.
+  'Pattani|TH':         [6.7182, 7.0182, 101.0997, 101.3997],
 
   // v1.7.8 Tier 4: tighten new-city bboxes to avoid sibling overlaps.
   'Hebron|PS':          [31.50, 31.60, 35.05, 35.16],
@@ -1273,6 +1277,7 @@ for (const [overrideKey, ov] of Object.entries(overrides)) {
   target._methodOverride = ov.methodOverride
   target._altMethods = (ov.altMethods || []).slice()
   target._sourceCitation = ov.citation
+  target._sourceInstitution = ov.sourceInstitution
   target._overrideReasoning = ov.reasoning
 }
 
@@ -1295,7 +1300,7 @@ for (const c of citiesByKey.values()) {
     source = { type: 'mawaqit', slug: c._mawaqitSlug }
   } else if (c._methodOverride) {
     // Override has explicit institutional citation.
-    source = { type: 'national-authority', institution: institutionForMethod(c._methodOverride) || 'See citation' }
+    source = { type: 'national-authority', institution: c._sourceInstitution || institutionForMethod(c._methodOverride) || 'See citation' }
   } else if (c._isCapital) {
     // Capital — institutional national authority owns the timetable.
     const country = c._engineCountry
@@ -1364,11 +1369,18 @@ for (const c of cities) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 const outputDir = path.join(ROOT, 'src/data')
+const outputPath = path.join(outputDir, 'cities.json')
 fs.mkdirSync(outputDir, { recursive: true })
+
+let generatedAt = new Date().toISOString()
+if (CHECK_MODE && fs.existsSync(outputPath)) {
+  const existing = JSON.parse(fs.readFileSync(outputPath, 'utf-8'))
+  if (existing.generated) generatedAt = existing.generated
+}
 
 const output = {
   version:   '1.7.0-alpha.0',
-  generated: new Date().toISOString(),
+  generated: generatedAt,
   license: {
     'world-cities':           'Capital data from UN Statistics Division and Wikipedia (public-domain reference, MIT-aligned)',
     'mawaqit-slugs':          'Curated metadata derived from public Mawaqit profile pages (slugs only)',
@@ -1387,8 +1399,19 @@ const headerObj = { ...output, cities: '__CITIES_PLACEHOLDER__' }
 let serialised = JSON.stringify(headerObj, null, 2)
 const cityLines = cities.map(c => '    ' + JSON.stringify(c)).join(',\n')
 serialised = serialised.replace('"__CITIES_PLACEHOLDER__"', `[\n${cityLines}\n  ]`)
+serialised += '\n'
 
-const outputPath = path.join(outputDir, 'cities.json')
+if (CHECK_MODE) {
+  const existing = fs.readFileSync(outputPath, 'utf-8')
+  if (existing !== serialised) {
+    console.error('[build-city-registry] check failed: src/data/cities.json is out of sync with generator inputs')
+    process.exitCode = 1
+  } else {
+    console.log('[build-city-registry] check passed: src/data/cities.json is in sync')
+  }
+  process.exit()
+}
+
 fs.writeFileSync(outputPath, serialised)
 const stats = fs.statSync(outputPath)
 console.log(`Wrote ${cities.length} cities to ${path.relative(ROOT, outputPath)} (${stats.size} bytes, ${(stats.size / 1024).toFixed(1)} KB)`)

--- a/scripts/data/city-method-overrides.json
+++ b/scripts/data/city-method-overrides.json
@@ -1,6 +1,6 @@
 {
   "_comment": "City-level institutional method overrides for fajr v1.7.0+. Each entry documents an intra-country ikhtilaf where one or more cities follow a different institutional convention than the country default returned by selectMethod(). Citations link to the institutional published source where possible; when no live URL exists the institution and locally-verifiable artefact (e.g. published Imsakiyya, mosque-published timetable, regional council) is named instead so a reviewer can audit. Per CLAUDE.md feedback_aggressive_data_hunt: Wikipedia is not authoritative for fiqh; institutional citations only. Per feedback_surface_disagreement: ALL of these cities also list altMethods (the country default plus any other documented minority) so apps can render the disagreement rather than presenting a single answer.",
-  "_schema": "Record<cityKey, { country, lat, lon, methodOverride, altMethods, citation, reasoning }>. cityKey is the English/Latin transliteration. methodOverride is a string method name resolvable by selectMethod (e.g. 'Karachi', 'Tehran', 'Diyanet', 'Egyptian', 'MoonsightingCommittee'). altMethods entries follow the schema { method, source, populationShare? } where populationShare is omitted when no credible quantitative estimate exists.",
+  "_schema": "Record<cityKey, { country, lat, lon, methodOverride, altMethods, citation, reasoning, sourceInstitution? }>. cityKey is the English/Latin transliteration. methodOverride is a string method name resolvable by selectMethod (e.g. 'Karachi', 'Tehran', 'Diyanet', 'Egyptian', 'MoonsightingCommittee'). altMethods entries follow the schema { method, source, populationShare? } where populationShare is omitted when no credible quantitative estimate exists. sourceInstitution overrides the generic method publisher when the city follows a local institution using that method shape.",
   "_classification_note": "All 16 entries below are 🟢 Established or 🟡→🟢 Approaching established. No 🔴 Novel overrides. Each citation is to a real institutional publisher whose timetables can be verified against the city's Mawaqit / WaktuSolat / equivalent regional registry.",
   "_version": "1.7.2",
 
@@ -24,6 +24,7 @@
     "altMethods": [
       { "method": "Egyptian", "source": "Aladhan world-default for Iraq" }
     ],
+    "sourceInstitution": "Najaf hawza maraji' (Office of Sistani; Astan al-Husayniyya custodial offices) — Tehran-style timing convention",
     "citation": "Office of Grand Ayatollah Sayyid Ali al-Sistani — https://www.sistani.org/ (Najaf hawza published Imsakiyya); cross-referenced with Astan Quds Razavi-style Twelver Shia Imsakiyya conventions",
     "reasoning": "Najaf is the Shia hawza centre — the global Twelver Shia scholarly seat. The maraji' offices (Sistani, Najafi-style) publish Imsakiyya following Tehran-style angles (Fajr 17.7°, Isha 14°, Maghrib +4.5min) consistent with the Jafari fiqh treatment of Maghrib as starting at the disappearance of redness in the eastern sky rather than at sunset itself."
   },
@@ -36,6 +37,7 @@
     "altMethods": [
       { "method": "Egyptian", "source": "Aladhan world-default for Iraq" }
     ],
+    "sourceInstitution": "Najaf hawza maraji' (Office of Sistani; Astan al-Husayniyya custodial offices) — Tehran-style timing convention",
     "citation": "Astan al-Husayniyya / Astan al-Abbasiyya custodial offices, Karbala — https://imamhussain.org/ (Holy Karbala custodial offices publish Imsakiyya for ziyarat); cross-referenced with the Office of Sayyid Sistani Najaf",
     "reasoning": "Karbala is the second principal Shia ziyarat centre; the custodial offices of the Imam Husayn and Abbas shrines publish daily Imsakiyya following Twelver Shia (Tehran-style) timing conventions, identical in shape to Najaf."
   },
@@ -48,6 +50,7 @@
     "altMethods": [
       { "method": "Egyptian", "source": "Aladhan world-default for Iraq" }
     ],
+    "sourceInstitution": "Najaf hawza maraji' (Office of Sistani; Astan al-Husayniyya custodial offices) — Tehran-style timing convention",
     "citation": "Basra-area Twelver Shia mosque-published timetables (Imam Ali, Imam Husayn mosques, Basra) following the Sistani-office Imsakiyya convention",
     "reasoning": "Basra and the southern Iraqi governorates are Shia-majority and follow the Twelver maraji' Imsakiyya. Same Tehran-method dispatch as Najaf/Karbala."
   },

--- a/scripts/data/world-cities.json
+++ b/scripts/data/world-cities.json
@@ -73,7 +73,7 @@
     "NL": { "country": "Netherlands", "capital": "Amsterdam", "latitude": 52.3676, "longitude": 4.9041, "elevation": 2, "timezone": "Europe/Amsterdam", "aladhanMethod": 3, "methodLabel": "MWL" },
     "IT": { "country": "Italy", "capital": "Rome", "latitude": 41.9028, "longitude": 12.4964, "elevation": 21, "timezone": "Europe/Rome", "aladhanMethod": 3, "methodLabel": "MWL" },
     "ES": { "country": "Spain", "capital": "Madrid", "latitude": 40.4168, "longitude": -3.7038, "elevation": 667, "timezone": "Europe/Madrid", "aladhanMethod": 3, "methodLabel": "MWL" },
-    "PT": { "country": "Portugal", "capital": "Lisbon", "latitude": 38.7223, "longitude": -9.1393, "elevation": 2, "timezone": "Europe/Lisbon", "aladhanMethod": 21, "methodLabel": "Lisboa" },
+    "PT": { "country": "Portugal", "capital": "Lisbon", "latitude": 38.7223, "longitude": -9.1393, "elevation": 50, "timezone": "Europe/Lisbon", "aladhanMethod": 21, "methodLabel": "Lisboa" },
     "AT": { "country": "Austria", "capital": "Vienna", "latitude": 48.2082, "longitude": 16.3738, "elevation": 171, "timezone": "Europe/Vienna", "aladhanMethod": 3, "methodLabel": "MWL" },
     "CH": { "country": "Switzerland", "capital": "Bern", "latitude": 46.9480, "longitude": 7.4474, "elevation": 540, "timezone": "Europe/Zurich", "aladhanMethod": 3, "methodLabel": "MWL" },
     "GR": { "country": "Greece", "capital": "Athens", "latitude": 37.9838, "longitude": 23.7275, "elevation": 70, "timezone": "Europe/Athens", "aladhanMethod": 12, "methodLabel": "Diyanet" },

--- a/test/cityRegistryGenerator.test.js
+++ b/test/cityRegistryGenerator.test.js
@@ -1,0 +1,23 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, '..')
+
+describe('city registry generator', () => {
+  it('matches the checked-in runtime registry', () => {
+    const output = execFileSync(
+      process.execPath,
+      ['scripts/build-city-registry.js', '--check'],
+      { cwd: ROOT, encoding: 'utf-8' }
+    )
+
+    expect(output).toContain('check passed')
+  })
+})


### PR DESCRIPTION
## Summary

- add `scripts/build-city-registry.js --check`, a non-mutating check that compares generator output to checked-in `src/data/cities.json` while preserving the existing generated timestamp
- add a Vitest regression so `npm test` fails if the generator drifts from the runtime registry
- reconcile the drift found in #126: Lisbon elevation, Pattani municipal population plus runtime bbox override, and specific Najaf-hawza source institutions for Najaf/Karbala/Basra overrides
- append a trailing newline in generator output so it matches the checked-in registry format

Fixes #126. Refs #118, #124, #125.

## Validation

- node scripts/build-city-registry.js --check
- npm run validate:registry
- npm test: 373/373
- git diff --check
