### PR TITLE
Add WOF candidates for Basel/Mulhouse geometry audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added WOF candidate IDs for Morocco source-map rows where WOF has a plausible
   locality or reviewed lower-confidence county geometry, including Berrechid
   and Settat which previously had no geometry candidate.
+- Added reviewed WOF locality candidates for the Basel/Mulhouse cross-border
+  validator-warning pair, confirming the current issue is over-broad shipped
+  lookup cells rather than missing municipal coverage.
 - Added `scripts/fetch-city-geometry-cache.js`, a WOF-only cache hydration
   helper that fetches reviewed source-map geometry into `.cache/city-geometry/`
   without committing raw geometry or changing runtime bboxes.

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1,7 +1,7 @@
 {
   "$schema_doc": "Build-time source map for auditing src/data/cities.json city bboxes. This file stores stable external IDs, review state, authority IDs, and cache pointers only. Raw geometry stays outside git/npm in .cache/city-geometry.",
   "version": 1,
-  "updated": "2026-05-09",
+  "updated": "2026-05-11",
   "issue": 118,
   "cacheRoot": ".cache/city-geometry",
   "providers": {
@@ -520,6 +520,17 @@
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
           "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101748459",
+          "ids": { "wofId": 101748459, "repo": "whosonfirst-data-admin-ch", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "CH/basel/wof-locality-101748459.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["WOF SQLite admin-ch latest lists this as the current locality row for Basel; bbox aligns with the OSM municipal envelope."]
         }
       ]
     },
@@ -540,6 +551,17 @@
           "matchConfidence": "candidate",
           "licenseUse": "audit-only-until-license-review",
           "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101749573",
+          "ids": { "wofId": 101749573, "repo": "whosonfirst-data-admin-fr", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "FR/mulhouse/wof-locality-101749573.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["WOF SQLite admin-fr latest lists this as the current locality row for Mulhouse; bbox aligns with the OSM municipal envelope."]
         }
       ]
     }

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -65,6 +65,25 @@ describe('city geometry source map', () => {
     expect(blankEntries.map(entry => entry.cityKey)).toEqual(['Jerusalem|PS'])
     expect(blankEntries[0].review.status).toBe('intentional-routing-anchor')
   })
+
+  it('keeps reviewed WOF locality candidates for the Basel/Mulhouse warning pair', () => {
+    const expected = new Map([
+      ['Basel|CH', 'wof:locality:101748459'],
+      ['Mulhouse|FR', 'wof:locality:101749573'],
+    ])
+
+    for (const [cityKey, stableId] of expected) {
+      const entry = sourceMap.cities.find(row => row.cityKey === cityKey)
+      const geometry = entry?.geometries?.find(row => row.stableId === stableId)
+      expect(geometry, cityKey).toBeTruthy()
+      expect(geometry.ids).toMatchObject({
+        placetype: 'locality',
+        mzIsCurrent: 1,
+      })
+      expect(geometry.sourceConfidence).toBe('high')
+      expect(geometry.licenseUse).toBe('audit-and-reviewed-bbox-proposal')
+    }
+  })
 })
 
 function slug(city) {


### PR DESCRIPTION
## Summary
- Add reviewed Who's On First locality candidates for `Basel|CH` and `Mulhouse|FR` in the geometry source map.
- Add a source-map regression test so the current WOF locality IDs stay pinned for the warning pair.
- Update the changelog with the audit finding.

## Research notes
- `whosonfirst-data-admin-ch` current locality: Basel `101748459`.
- `whosonfirst-data-admin-fr` current locality: Mulhouse `101749573`.
- Raw WOF GeoJSON was hydrated only into `.cache/city-geometry/`; no raw geometry is committed or bundled.

## Validation
- `npm test` -> 18 files / 376 tests passed.
- `node scripts/audit-city-geometry.js --format json` -> 31 source rows, 30 checked, 0 missing cache files, 0 missing geometry. Basel/Mulhouse remain `tighten-review` with zero undercoverage against both OSM and WOF.
- `npm pack --dry-run` -> 140.4 kB packed, 515.5 kB unpacked.

Refs #118

## Runtime impact
No shipped bbox, prayer-time math, public API, or package-size impact. This only strengthens the audit evidence for the current Basel/Mulhouse validator-warning pair.