### PR TITLE
Add WOF candidates for Brazzaville/Kinshasa audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added reviewed WOF locality candidates for the Basel/Mulhouse cross-border
   validator-warning pair, confirming the current issue is over-broad shipped
   lookup cells rather than missing municipal coverage.
+- Added reviewed WOF locality candidates for the Brazzaville/Kinshasa
+  cross-border warning pair, documenting that their rectangular envelopes still
+  overlap across the diagonal Congo River boundary.
 - Added `scripts/fetch-city-geometry-cache.js`, a WOF-only cache hydration
   helper that fetches reviewed source-map geometry into `.cache/city-geometry/`
   without committing raw geometry or changing runtime bboxes.

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -479,6 +479,17 @@
           "licenseUse": "audit-only-until-license-review",
           "reviewStatus": "candidate",
           "notes": ["OSM candidate is commune/departement level; compare with WOF/official sources before bbox edits."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421180023",
+          "ids": { "wofId": 421180023, "repo": "whosonfirst-data-admin-cg", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "CG/brazzaville/wof-locality-421180023.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["WOF SQLite admin-cg latest lists this as the current locality row for Brazzaville; envelope still overlaps Kinshasa because the Congo River boundary is diagonal."]
         }
       ]
     },
@@ -500,6 +511,17 @@
           "licenseUse": "audit-only-until-license-review",
           "reviewStatus": "candidate",
           "notes": ["OSM candidate is province-level; compare with WOF/official sources before bbox edits."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421166913",
+          "ids": { "wofId": 421166913, "repo": "whosonfirst-data-admin-cd", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "CD/kinshasa/wof-locality-421166913.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["WOF SQLite admin-cd latest lists this as the current locality row for Kinshasa; envelope still overlaps Brazzaville because the Congo River boundary is diagonal."]
         }
       ]
     },

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -66,10 +66,12 @@ describe('city geometry source map', () => {
     expect(blankEntries[0].review.status).toBe('intentional-routing-anchor')
   })
 
-  it('keeps reviewed WOF locality candidates for the Basel/Mulhouse warning pair', () => {
+  it('keeps reviewed WOF locality candidates for cross-border warning pairs', () => {
     const expected = new Map([
       ['Basel|CH', 'wof:locality:101748459'],
       ['Mulhouse|FR', 'wof:locality:101749573'],
+      ['Brazzaville|CG', 'wof:locality:421180023'],
+      ['Kinshasa|CD', 'wof:locality:421166913'],
     ])
 
     for (const [cityKey, stableId] of expected) {


### PR DESCRIPTION
## Summary
- Add reviewed WOF locality candidates for `Brazzaville|CG` and `Kinshasa|CD` to the geometry source map.
- Extend the source-map regression test so cross-border warning pairs keep their WOF locality IDs pinned.
- Update the changelog with the Congo River finding.

## Research notes
- WOF admin-cg current locality: Brazzaville `421180023`.
- WOF admin-cd current locality: Kinshasa `421166913`.
- Both WOF raw GeoJSON files hydrate successfully into `.cache/city-geometry/`; no raw geometry is committed or bundled.
- Unlike Basel/Mulhouse, these rectangular envelopes still overlap because the Congo River boundary is diagonal, so runtime bbox tightening should be a separate clipping decision, not a direct WOF-envelope copy.

## Validation
- `npm test` -> 18 files / 377 tests passed.
- `node scripts/audit-city-geometry.js --format json` -> 33 source rows, 32 checked, 0 missing cache files, 0 missing geometry.
- Congo rows remain `undercoverage-review`; this PR records evidence only and does not change runtime lookup behavior.
- `npm pack --dry-run` -> 140.5 kB packed, 515.5 kB unpacked, 20 bundled files.

Refs #118

## Runtime impact
None. No `src/data/cities.json`, public API, package contents, or prayer-time math changes.