### PR TITLE
Fix city bbox edge-touch overlap warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Tightened the Basel and Mulhouse lookup cells to reviewed WOF locality
   envelopes, removing that cross-border validator warning while preserving both
   Mawaqit city centers.
+- Fixed the city-registry validator so bboxes that only touch at an edge are
+  not reported as cross-country overlaps; Brazzaville/Kinshasa now stays
+  tracked as a geometry-undercoverage/clipping review item instead of a false
+  runtime overlap warning.
 
 ### Changed — documentation doctrine cleanup
 
@@ -84,8 +88,8 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
   a no-network advisory audit path for comparing reviewed cached GeoJSON
   geometries against the shipped city bbox registry.
 - Added `scripts/data/city-geometry-sources.json`, a seed source map for 20
-  high-priority bbox QA rows: Morocco/Habous phase-1 cities plus the current
-  Jerusalem, Brazzaville/Kinshasa, and Basel/Mulhouse validator-warning rows.
+  high-priority bbox QA rows: Morocco/Habous phase-1 cities plus Jerusalem
+  routing, Congo River clipping, and Basel/Mulhouse resolved-warning rows.
 - Added WOF candidate IDs for Morocco source-map rows where WOF has a plausible
   locality or reviewed lower-confidence county geometry, including Berrechid
   and Settat which previously had no geometry candidate.

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -122,14 +122,17 @@ separate reviewed workflows because their terms and APIs differ.
 
 ## First Audit Targets
 
-Start with rows where geometry quality affects source provenance or existing
-validator warnings:
+Start with rows where geometry quality affects source provenance, existing
+validator warnings, or known clipping gaps:
 
 - Morocco Habous clusters: Rabat/Sale/Temara, Agadir/Inezgane,
   Casablanca/Berrechid/Settat, Fes/Sefrou/Meknes, Tangier/Tetouan/Nador/Oujda.
-- Current registry warnings: Jerusalem PS/IL routing and Brazzaville/Kinshasa.
-  Basel/Mulhouse has reviewed WOF locality evidence and a tightened runtime
-  bbox; keep it as a regression target rather than an open warning.
+- Current registry warning: Jerusalem PS/IL routing.
+- Known geometry clipping gap: Brazzaville/Kinshasa. Their runtime bboxes are
+  edge-adjacent, but WOF locality envelopes still under-cover/overlap across
+  the diagonal Congo River boundary, so this remains a source-review target.
+- Resolved validator-warning regression target: Basel/Mulhouse. It has
+  reviewed WOF locality evidence and a tightened runtime bbox.
 - High-risk metro/border clusters: Cairo/Giza/6th of October,
   Dubai/Sharjah/Ajman, Singapore/Johor Bahru, Kuala Lumpur/Shah Alam,
   Toronto/Mississauga/Laval/Montreal, Lahore/Sialkot/Gujranwala,

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1,7 +1,7 @@
 {
   "$schema_doc": "Build-time source map for auditing src/data/cities.json city bboxes. This file stores stable external IDs, review state, authority IDs, and cache pointers only. Raw geometry stays outside git/npm in .cache/city-geometry.",
   "version": 1,
-  "updated": "2026-05-11",
+  "updated": "2026-05-14",
   "issue": 118,
   "cacheRoot": ".cache/city-geometry",
   "providers": {
@@ -463,10 +463,10 @@
     },
     {
       "cityKey": "Brazzaville|CG",
-      "priority": ["current-validator-warning", "cross-border-overlap", "congo-river"],
-      "review": { "status": "candidate", "issue": 118 },
-      "expectedNeighborWarnings": [
-        { "cityKey": "Kinshasa|CD", "kind": "bbox-overlap-cross-country" }
+      "priority": ["geometry-undercoverage", "edge-adjacent", "congo-river"],
+      "review": { "status": "needs-clipping-review", "issue": 118 },
+      "neighborRelations": [
+        { "cityKey": "Kinshasa|CD", "kind": "bbox-edge-touch", "status": "runtime-adjacent; WOF envelopes still need clipping review" }
       ],
       "geometries": [
         {
@@ -495,10 +495,10 @@
     },
     {
       "cityKey": "Kinshasa|CD",
-      "priority": ["current-validator-warning", "cross-border-overlap", "congo-river"],
-      "review": { "status": "candidate", "issue": 118 },
-      "expectedNeighborWarnings": [
-        { "cityKey": "Brazzaville|CG", "kind": "bbox-overlap-cross-country" }
+      "priority": ["geometry-undercoverage", "edge-adjacent", "congo-river"],
+      "review": { "status": "needs-clipping-review", "issue": 118 },
+      "neighborRelations": [
+        { "cityKey": "Brazzaville|CG", "kind": "bbox-edge-touch", "status": "runtime-adjacent; WOF envelopes still need clipping review" }
       ],
       "geometries": [
         {
@@ -527,10 +527,10 @@
     },
     {
       "cityKey": "Basel|CH",
-      "priority": ["current-validator-warning", "cross-border-overlap", "europe-p0"],
-      "review": { "status": "candidate", "issue": 118 },
-      "expectedNeighborWarnings": [
-        { "cityKey": "Mulhouse|FR", "kind": "bbox-overlap-cross-country" }
+      "priority": ["resolved-validator-warning", "runtime-bbox-shipped", "europe-p0"],
+      "review": { "status": "runtime-bbox-shipped", "issue": 118 },
+      "neighborRelations": [
+        { "cityKey": "Mulhouse|FR", "kind": "resolved-bbox-overlap", "status": "runtime WOF-envelope bbox shipped in #130" }
       ],
       "geometries": [
         {
@@ -558,10 +558,10 @@
     },
     {
       "cityKey": "Mulhouse|FR",
-      "priority": ["current-validator-warning", "cross-border-overlap", "europe-p0"],
-      "review": { "status": "candidate", "issue": 118 },
-      "expectedNeighborWarnings": [
-        { "cityKey": "Basel|CH", "kind": "bbox-overlap-cross-country" }
+      "priority": ["resolved-validator-warning", "runtime-bbox-shipped", "europe-p0"],
+      "review": { "status": "runtime-bbox-shipped", "issue": 118 },
+      "neighborRelations": [
+        { "cityKey": "Basel|CH", "kind": "resolved-bbox-overlap", "status": "runtime WOF-envelope bbox shipped in #130" }
       ],
       "geometries": [
         {

--- a/scripts/validate-city-registry.js
+++ b/scripts/validate-city-registry.js
@@ -32,11 +32,11 @@
  *                        country. A bbox extending across an international
  *                        border is a fail.
  *
- *   6. bbox-overlap:     Pairs of cities whose bboxes intersect are flagged
- *                        as WARN (not fail) — some overlaps are intentional
- *                        (metro + satellite city, where the smaller-bbox sort
- *                        order disambiguates correctly). The list is for
- *                        human review.
+ *   6. bbox-overlap:     Pairs of cities whose bboxes overlap by area are
+ *                        flagged as WARN (not fail) — some overlaps are
+ *                        intentional (metro + satellite city, where the
+ *                        smaller-bbox sort order disambiguates correctly).
+ *                        Edge-touching boxes are not overlaps.
  *
  * Run via: `node scripts/validate-city-registry.js`
  *
@@ -183,8 +183,8 @@ function bboxesIntersect(a, b) {
   // a, b are [latMin, latMax, lonMin, lonMax]. Strict overlap (touching
   // edges only is NOT counted — we use a small epsilon).
   const eps = 1e-9
-  return !(a[1] < b[0] - eps || a[0] > b[1] + eps ||
-           a[3] < b[2] - eps || a[2] > b[3] + eps)
+  return !(a[1] <= b[0] + eps || a[0] >= b[1] - eps ||
+           a[3] <= b[2] + eps || a[2] >= b[3] - eps)
 }
 
 function bboxArea(bbox) {

--- a/test/cityRegistryValidation.test.js
+++ b/test/cityRegistryValidation.test.js
@@ -1,0 +1,29 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, '..')
+
+describe('city registry validator', () => {
+  it('does not report bbox edge-touch as cross-country overlap', () => {
+    const output = execFileSync(
+      process.execPath,
+      ['scripts/validate-city-registry.js'],
+      {
+        cwd: ROOT,
+        encoding: 'utf-8',
+        env: { ...process.env, SHOW_WARNS: '1' },
+      }
+    )
+
+    expect(output).toContain('Validation PASSED: 0 fail-class issues.')
+    expect(output).not.toContain('Brazzaville|CG ∩ Kinshasa|CD')
+    expect(output).not.toContain('bbox-overlap-cross-country')
+  })
+})

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -60,13 +60,19 @@ describe('city geometry source map', () => {
     expect(forbiddenKeys).toEqual([])
   })
 
+  it('uses explicit neighbor relations instead of stale expected warnings', () => {
+    const staleKeys = []
+    collectKeys(sourceMap, 'expectedNeighborWarnings', staleKeys)
+    expect(staleKeys).toEqual([])
+  })
+
   it('requires a review reason for rows with no geometry candidates', () => {
     const blankEntries = sourceMap.cities.filter(entry => !(entry.geometries || []).length)
     expect(blankEntries.map(entry => entry.cityKey)).toEqual(['Jerusalem|PS'])
     expect(blankEntries[0].review.status).toBe('intentional-routing-anchor')
   })
 
-  it('keeps reviewed WOF locality candidates for cross-border warning pairs', () => {
+  it('keeps reviewed WOF locality candidates for audited border pairs', () => {
     const expected = new Map([
       ['Basel|CH', 'wof:locality:101748459'],
       ['Mulhouse|FR', 'wof:locality:101749573'],
@@ -85,6 +91,13 @@ describe('city geometry source map', () => {
       expect(geometry.sourceConfidence).toBe('high')
       expect(geometry.licenseUse).toBe('audit-and-reviewed-bbox-proposal')
     }
+  })
+
+  it('tracks runtime-shipped and needs-clipping geometry outcomes separately', () => {
+    expect(statusFor('Basel|CH')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Mulhouse|FR')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Brazzaville|CG')).toBe('needs-clipping-review')
+    expect(statusFor('Kinshasa|CD')).toBe('needs-clipping-review')
   })
 })
 
@@ -107,4 +120,20 @@ function collectForbiddenKeys(value, out, pathParts = []) {
     if (key === 'place_id' || key === 'placeId') out.push([...pathParts, key].join('.'))
     collectForbiddenKeys(child, out, [...pathParts, key])
   }
+}
+
+function collectKeys(value, targetKey, out, pathParts = []) {
+  if (!value || typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectKeys(item, targetKey, out, [...pathParts, String(index)]))
+    return
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (key === targetKey) out.push([...pathParts, key].join('.'))
+    collectKeys(child, targetKey, out, [...pathParts, key])
+  }
+}
+
+function statusFor(cityKey) {
+  return sourceMap.cities.find(row => row.cityKey === cityKey)?.review?.status
 }


### PR DESCRIPTION
## Summary
- Fix `scripts/validate-city-registry.js` so bboxes that only touch at an edge are not counted as cross-country overlaps.
- Add validator regression coverage for the Brazzaville/Kinshasa edge-touch case.
- Replace stale `expectedNeighborWarnings` geometry-source fields with explicit `neighborRelations` and separate statuses for `runtime-bbox-shipped` vs `needs-clipping-review`.
- Update geometry docs and changelog to reflect that Congo is a clipping/source-review gap, not a live runtime overlap warning.

## Validation
- `npm test` -> 19 files / 380 tests passed.
- `npm run validate:registry` -> 0 fail-class issues; 1 warn-class issue (`Jerusalem|PS` row-center allowlist only).
- `node scripts/audit-city-geometry.js --format json` -> 33 source rows, 32 checked, 0 missing cache files, 0 missing geometry.
- `npm pack --dry-run` -> 140.5 kB packed, 515.5 kB unpacked, 20 bundled files.

Refs #118

## Runtime impact
None. This changes validator semantics and geometry-audit metadata only; no shipped city bbox, public API, or prayer-time math changes.