### PR TITLE
Fix Fes city bbox geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Tightened the Casablanca lookup cell to the reviewed WOF current county
   envelope, which matches the OSM admin-8 city geometry while avoiding WOF's
   deprecated/point-like locality rows.
+- Tightened the Fes lookup cell to WOF current locality `421190143`, which
+  supersedes the older Fes WOF row and matches OSM admin-8 Fes closely enough
+  for the offline city lookup cell.
 
 ### Changed — documentation doctrine cleanup
 

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -1,6 +1,6 @@
 # City Geometry Audit
 
-Last refreshed: 2026-05-09
+Last refreshed: 2026-05-14
 
 `detectLocation()` intentionally ships a compact offline bbox registry rather
 than raw municipal polygons. The bbox layer is fast and small enough for
@@ -35,10 +35,10 @@ human review. It must not mutate the runtime registry automatically.
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
 20 high-priority rows: 15 Morocco/Habous phase-1 rows and 5 existing registry
-warning rows. It carries 17 candidate OSM relation IDs plus 11 WOF candidate
-IDs. Berrechid and Settat now have WOF locality candidates; Jerusalem
-intentionally remains without a geometry candidate until a human routing
-decision is available.
+warning rows. It carries 17 OSM relation rows plus 16 WOF rows across reviewed
+locality/county candidates. Berrechid, Settat, and Fes now have WOF locality
+candidates; Jerusalem intentionally remains without a geometry candidate until
+a human routing decision is available.
 
 ```json
 {
@@ -94,6 +94,12 @@ from neighboring Morocco rows during `detectLocation()`'s smallest-match scan:
   `Oujda|MA`: tightened to reviewed WOF locality envelopes where the previous
   population-radius boxes materially over-covered surrounding areas and no
   adjacent-city clipping was needed.
+- `Casablanca|MA`: tightened to the WOF current county envelope after the WOF
+  locality rows proved deprecated/point-like and the county envelope matched
+  OSM admin-8 Casablanca closely enough for the offline lookup cell.
+- `Fes|MA`: tightened to WOF current locality `421190143`; that row is named
+  Fes-Ville-Nouvelle in WOF but supersedes the older Fes locality row and
+  matches the OSM admin-8 Fes envelope.
 
 These are provenance/routing fixes only. They do not change prayer-time
 calculation math or imply that rectangles now encode municipal boundaries.

--- a/scripts/build-city-registry.js
+++ b/scripts/build-city-registry.js
@@ -904,7 +904,10 @@ const BBOX_OVERRIDES = {
   'Freetown|SL':        [8.39, 8.55, -13.27, -13.13],
   'Podgorica|ME':       [42.40, 42.50, 19.20, 19.40],
   'Detroit|US':         [42.18, 42.46, -83.08, -82.92],
-  'Fes|MA':             [33.94, 34.28, -5.30, -4.85],
+  // v1.8.0 #118: WOF current locality row 421190143 supersedes the older
+  // Fes row and matches the OSM admin-8 envelope; use it to avoid broad
+  // city-provenance leakage around the Fes lookup cell.
+  'Fes|MA':             [33.97125, 34.076345, -5.078619, -4.937726],
   // v1.7.22 #86: keep Shah Alam's own centre lon 101.5183 inside the bbox
   // while still excluding KL CBD at lon ~101.69.
   'Shah Alam|MY':       [2.8731, 3.2731, 101.3183, 101.55],

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -261,7 +261,13 @@
       "cityKey": "Fes|MA",
       "priority": ["phase-1-morocco", "habous", "large-metro-bbox"],
       "relatedAuthorityIds": { "habousVilleId": 81, "habousMatch": "direct" },
-      "review": { "status": "candidate", "issue": 118 },
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": [
+          "2026-05-14: runtime bbox updated to WOF current locality 421190143. WOF names the current row Fes-Ville-Nouvelle, but its spr row supersedes the older Fes locality 421170491 and its envelope matches the OSM admin-8 Fes geometry."
+        ]
+      },
       "geometries": [
         {
           "provider": "osm",
@@ -275,13 +281,25 @@
         },
         {
           "provider": "wof",
+          "stableId": "wof:locality:421190143",
+          "ids": { "wofId": 421190143, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1, "supersedes": [421170491] },
+          "cacheFile": "MA/fes/wof-locality-421190143.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "superseding-current-locality",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["WOF current locality row named Fes-Ville-Nouvelle; accepted because WOF marks it current and its bbox matches the OSM admin-8 Fes envelope."]
+        },
+        {
+          "provider": "wof",
           "stableId": "wof:locality:421170491",
           "ids": { "wofId": 421170491, "repo": "whosonfirst-data-admin-ma", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 0 },
           "cacheFile": "MA/fes/wof-locality-421170491.geojson",
           "sourceConfidence": "medium",
-          "matchConfidence": "candidate",
+          "matchConfidence": "superseded-by-current-locality",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate"
+          "reviewStatus": "superseded-candidate",
+          "notes": ["Retained for audit history; WOF admin-ma latest marks current locality 421190143 as superseding this older Fes row."]
         }
       ]
     },

--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -1,6 +1,6 @@
 {
   "version": "1.7.0-alpha.0",
-  "generated": "2026-05-14T09:46:53.462Z",
+  "generated": "2026-05-14T09:56:40.667Z",
   "license": {
     "world-cities": "Capital data from UN Statistics Division and Wikipedia (public-domain reference, MIT-aligned)",
     "mawaqit-slugs": "Curated metadata derived from public Mawaqit profile pages (slugs only)",
@@ -33,6 +33,7 @@
     {"name":"Beau Bassin-Rose Hill","countryISO":"MU","lat":-20.2289,"lon":57.4683,"bbox":[-20.3,-20.2,57.42,57.55],"timezone":"Indian/Mauritius","population":102000,"elevation":130,"source":{"type":"mawaqit","slug":"hunain-islamic-centre-beau-bassin-rose-hill-71608-mauritius"}},
     {"name":"Khartoum Bahri","countryISO":"SD","lat":15.6333,"lon":32.5333,"bbox":[15.61,15.72,32.5,32.62],"timezone":"Africa/Khartoum","population":700000,"elevation":380,"source":{"type":"mawaqit","slug":"msjd-lkhwjlb-l-tyq-bhry-11111-sudan"}},
     {"name":"Nicosia","countryISO":"CY","lat":35.1856,"lon":33.3823,"bbox":[35.13,35.24,33.32,33.45],"timezone":"Asia/Nicosia","population":326000,"elevation":220,"source":{"type":"inherited","from":"Cyprus"}},
+    {"name":"Fes","countryISO":"MA","lat":34.0331,"lon":-5.0003,"bbox":[33.97125,34.076345,-5.078619,-4.937726],"timezone":"Africa/Casablanca","nameLocal":"فاس","adminRegion":"Fès-Meknès","population":1112000,"elevation":408,"source":{"type":"mawaqit","slug":"masjid-aamrou-bn-laas-fes-30000-morocco-1"}},
     {"name":"Saint-Denis","countryISO":"RE","lat":-20.8823,"lon":55.4504,"bbox":[-20.95,-20.85,55.4,55.55],"timezone":"Indian/Reunion","adminRegion":"Réunion","population":153000,"elevation":20,"source":{"type":"inherited","from":"Reunion"}},
     {"name":"Temara","countryISO":"MA","lat":33.9281,"lon":-6.9067,"bbox":[33.85,33.96,-7,-6.86],"timezone":"Africa/Casablanca","population":313000,"elevation":75,"source":{"type":"mawaqit","slug":"msjd-bd-llh-bn-ysyn-temara-12123-morocco"}},
     {"name":"Luton","countryISO":"GB","lat":51.8787,"lon":-0.42,"bbox":[51.82,51.94,-0.5,-0.36],"timezone":"Europe/London","adminRegion":"Bedfordshire","population":213000,"elevation":122,"source":{"type":"inherited","from":"UK"}},
@@ -288,7 +289,6 @@
     {"name":"Cairo","countryISO":"EG","lat":30.0444,"lon":31.2357,"bbox":[29.84,30.24,31.22,31.56],"timezone":"Africa/Cairo","nameLocal":"القاهرة","population":10100000,"elevation":23,"source":{"type":"mawaqit","slug":"msjd-l-lm-lnf-nouveau-caire-4710001-egypt"}},
     {"name":"Antwerp","countryISO":"BE","lat":51.2194,"lon":4.4025,"bbox":[51.06,51.42,4.2,4.6],"timezone":"Europe/Brussels","adminRegion":"Antwerp Province","population":530000,"elevation":8,"source":{"type":"mawaqit","slug":"iccum-antwerp-2050-belgium"}},
     {"name":"Toronto","countryISO":"CA","lat":43.6532,"lon":-79.3832,"bbox":[43.45,43.85,-79.55,-79.18],"timezone":"America/Toronto","adminRegion":"Ontario","population":2794000,"elevation":76,"source":{"type":"mawaqit","slug":"darussalam-toronto-m9v-3b5-canada"}},
-    {"name":"Fes","countryISO":"MA","lat":34.0331,"lon":-5.0003,"bbox":[33.94,34.28,-5.3,-4.85],"timezone":"Africa/Casablanca","nameLocal":"فاس","adminRegion":"Fès-Meknès","population":1112000,"elevation":408,"source":{"type":"mawaqit","slug":"masjid-aamrou-bn-laas-fes-30000-morocco-1"}},
     {"name":"Boston","countryISO":"US","lat":42.3601,"lon":-71.0589,"bbox":[42.1601,42.5601,-71.2589,-70.8589],"timezone":"America/New_York","adminRegion":"Massachusetts","population":675000,"elevation":43,"source":{"type":"inherited","from":"USA"}},
     {"name":"Padang","countryISO":"ID","lat":-0.9492,"lon":100.3543,"bbox":[-1.1492,-0.7492,100.1543,100.5543],"timezone":"Asia/Jakarta","adminRegion":"West Sumatra","population":909000,"elevation":7,"source":{"type":"inherited","from":"Indonesia"}},
     {"name":"Kochi","countryISO":"IN","lat":9.9312,"lon":76.2673,"bbox":[9.7312,10.1312,76.0673,76.4673],"timezone":"Asia/Kolkata","nameLocal":"കൊച്ചി","adminRegion":"Kerala","population":677000,"elevation":7,"methodOverride":"KarachiShafi","altMethods":[{"method":"Karachi","source":"India country-default (AIMPLB Hanafi-majority via Jamiat Ulema-e-Hind / Deobandi convention) — default Hanafi Asr applies to Hanafi-minority North Indian diaspora communities in Kerala"}],"source":{"type":"national-authority","institution":"University of Islamic Sciences, Karachi (Shafi Asr)"}},

--- a/test/detectLocation.test.js
+++ b/test/detectLocation.test.js
@@ -184,6 +184,7 @@ describe('detectLocation — Mawaqit institutional source', () => {
     const rows = [
       ['Berrechid', 33.2659, -7.5867, 33.21, -7.64],
       ['Casablanca', 33.5731, -7.5898, 33.70, -7.75],
+      ['Fes', 34.0331, -5.0003, 34.20, -5.25],
       ['Settat', 33.0017, -7.6166, 32.90, -7.75],
       ['Sefrou', 33.8311, -4.8294, 33.75, -4.90],
       ['Tangier', 35.7595, -5.8340, 35.60, -6.00],

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -76,6 +76,7 @@ describe('city geometry source map', () => {
     const expected = new Map([
       ['Basel|CH', 'wof:locality:101748459'],
       ['Mulhouse|FR', 'wof:locality:101749573'],
+      ['Fes|MA', 'wof:locality:421190143'],
       ['Brazzaville|CG', 'wof:locality:421180023'],
       ['Kinshasa|CD', 'wof:locality:421166913'],
     ])
@@ -97,6 +98,7 @@ describe('city geometry source map', () => {
     expect(statusFor('Basel|CH')).toBe('runtime-bbox-shipped')
     expect(statusFor('Mulhouse|FR')).toBe('runtime-bbox-shipped')
     expect(statusFor('Casablanca|MA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Fes|MA')).toBe('runtime-bbox-shipped')
     expect(statusFor('Brazzaville|CG')).toBe('needs-clipping-review')
     expect(statusFor('Kinshasa|CD')).toBe('needs-clipping-review')
   })


### PR DESCRIPTION
## Summary
- Tighten `Fes|MA` from the broad population-radius cell `[33.94, 34.28, -5.30, -4.85]` to the reviewed WOF current locality envelope `[33.97125, 34.076345, -5.078619, -4.937726]`.
- Add WOF current locality `421190143` to the geometry source map; it is named Fes-Ville-Nouvelle in WOF but supersedes the older Fes locality `421170491` and matches OSM admin-8 Fes closely.
- Mark Fes as `runtime-bbox-shipped` while retaining the older WOF row as audit history.
- Add regression coverage that the Fes center still resolves to Mawaqit city provenance while an old broad corner no longer resolves to Fes.
- Update the geometry audit doc and changelog.

## Validation
- `npm test` -> 19 files / 380 tests passed.
- `npm run validate:registry` -> 0 fail-class issues; 1 warn-class issue (`Jerusalem|PS` row-center allowlist only).
- `node scripts/build-city-registry.js --check` -> check passed.
- `node scripts/audit-city-geometry.js --format json` -> 20 source cities, 34 source rows, 33 checked, 0 missing cache/geometry. Fes WOF current row is now `low-priority` with exact bbox alignment; Fes OSM row is also `low-priority` with zero undercoverage.
- `npm run build:charts` -> no derived chart/progress diff beyond existing current outputs.
- `npm pack --dry-run` -> 140.5 kB packed, 515.6 kB unpacked, 20 bundled files.

Refs #118

## Position registry
[positions: no-change-required] City bbox/provenance-only update; no region default, method dispatch, confidence grade, or institutional position changes.

## Runtime impact
Only `detectLocation()` / city provenance near the old broad Fes bbox edges changes. Prayer-time math and public API are unchanged.