### PR TITLE
Fix UAE WOF city bbox coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
   geometry, compatible official/commune-level geometry, or should stay an audit
   gap rather than deriving runtime bboxes from OSM alone or broad WOF county
   rows.
+- Added UAE WOF locality source-map rows for Abu Dhabi, Al Ain,
+  Dubai/Sharjah/Ajman; shipped Abu Dhabi and Al Ain runtime bbox updates where
+  the WOF envelopes do not collide, while marking Dubai/Sharjah/Ajman for
+  clipping review.
 
 ### Changed — documentation doctrine cleanup
 

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -34,11 +34,11 @@ human review. It must not mutate the runtime registry automatically.
 
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
-20 high-priority rows: 15 Morocco/Habous phase-1 rows and 5 existing registry
-warning rows. It carries 17 OSM relation rows plus 16 WOF rows across reviewed
-locality/county candidates. Berrechid, Settat, and Fes now have WOF locality
-candidates; Jerusalem intentionally remains without a geometry candidate until
-a human routing decision is available.
+25 high-priority rows: 15 Morocco/Habous phase-1 rows, 5 UAE metro rows, and 5
+existing registry warning rows. It carries 17 OSM relation rows plus 21 WOF
+rows across reviewed locality/county candidates. Berrechid, Settat, and Fes
+now have WOF locality candidates; Jerusalem intentionally remains without a
+geometry candidate until a human routing decision is available.
 
 ```json
 {
@@ -115,6 +115,15 @@ county/prefecture bboxes or OSM alone. Either find a reviewed WOF locality
 polygon, verify an official/commune-level source with compatible licensing, or
 leave the row as a documented audit gap.
 
+The first UAE pass shows a different pattern:
+
+- Abu Dhabi and Al Ain have current WOF locality envelopes that expand the
+  shipped city lookup cells without colliding with neighboring fajr rows, so
+  they are runtime-ready.
+- Dubai, Sharjah, and Ajman also have current WOF locality envelopes, but their
+  rectangular envelopes overlap heavily. They are source-map rows for now and
+  need an explicit clipping rule before runtime bboxes should change.
+
 Reference URLs checked in this pass:
 
 - HDX Morocco COD-AB:
@@ -149,6 +158,9 @@ from neighboring Morocco rows during `detectLocation()`'s smallest-match scan:
 - `Fes|MA`: tightened to WOF current locality `421190143`; that row is named
   Fes-Ville-Nouvelle in WOF but supersedes the older Fes locality row and
   matches the OSM admin-8 Fes envelope.
+- `Abu Dhabi|AE` and `Al Ain|AE`: expanded/tightened to reviewed WOF current
+  locality envelopes. Dubai, Sharjah, and Ajman were added to the source map
+  but intentionally left unchanged at runtime pending clipping review.
 
 These are provenance/routing fixes only. They do not change prayer-time
 calculation math or imply that rectangles now encode municipal boundaries.

--- a/scripts/build-city-registry.js
+++ b/scripts/build-city-registry.js
@@ -981,6 +981,12 @@ const BBOX_OVERRIDES = {
   // Sharjah CBD 25.35, 55.42 → keep lat 25.30-25.40 / lon 55.30-55.55.
   'Sharjah|AE':         [25.30, 25.40, 55.30, 55.55],
 
+  // v1.8.0 #118: WOF current locality envelopes improve UAE city coverage
+  // without colliding with neighboring lookup cells. Dubai/Sharjah/Ajman need
+  // separate clipping review because their WOF envelopes overlap heavily.
+  'Abu Dhabi|AE':       [24.195888, 24.590696, 54.254076, 54.841984],
+  'Al Ain|AE':          [24.013749, 24.414416, 55.464609, 56.018126],
+
   // Dammam SA (1.25M, lat 26.39) vs Khobar SA (626K, lat 26.22). 20 km
   // apart. Tighten Dammam to lat 26.32-26.55 so Khobar (26.22) is outside.
   // Khobar override remains 26.16-26.32.

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -468,6 +468,123 @@
       ]
     },
     {
+      "cityKey": "Abu Dhabi|AE",
+      "priority": ["uae-metro", "wof-locality-runtime-bbox"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox updated to reviewed WOF current locality envelope; no neighboring UAE city bbox collision."]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421179641",
+          "ids": { "wofId": 421179641, "repo": "whosonfirst-data-admin-ae", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "AE/abu-dhabi/wof-locality-421179641.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped"
+        }
+      ]
+    },
+    {
+      "cityKey": "Al Ain|AE",
+      "priority": ["uae-metro", "wof-locality-runtime-bbox"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox updated to reviewed WOF current locality envelope; no neighboring UAE city bbox collision."]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421168687",
+          "ids": { "wofId": 421168687, "repo": "whosonfirst-data-admin-ae", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "AE/al-ain/wof-locality-421168687.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped"
+        }
+      ]
+    },
+    {
+      "cityKey": "Dubai|AE",
+      "priority": ["uae-metro", "needs-clipping-review"],
+      "review": {
+        "status": "needs-clipping-review",
+        "issue": 118,
+        "notes": ["WOF current locality envelope overlaps Sharjah/Ajman envelopes; do not ship as runtime bbox without an explicit clipping rule."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Sharjah|AE", "kind": "bbox-overlap", "status": "WOF locality envelopes overlap; runtime clipping review needed" },
+        { "cityKey": "Ajman|AE", "kind": "bbox-overlap", "status": "WOF locality envelopes overlap; runtime clipping review needed" }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421174961",
+          "ids": { "wofId": 421174961, "repo": "whosonfirst-data-admin-ae", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "AE/dubai/wof-locality-421174961.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Sharjah|AE",
+      "priority": ["uae-metro", "needs-clipping-review"],
+      "review": {
+        "status": "needs-clipping-review",
+        "issue": 118,
+        "notes": ["WOF current locality envelope overlaps Dubai/Ajman envelopes; do not ship as runtime bbox without an explicit clipping rule."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Dubai|AE", "kind": "bbox-overlap", "status": "WOF locality envelopes overlap; runtime clipping review needed" },
+        { "cityKey": "Ajman|AE", "kind": "bbox-overlap", "status": "WOF locality envelopes overlap; runtime clipping review needed" }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421168683",
+          "ids": { "wofId": 421168683, "repo": "whosonfirst-data-admin-ae", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "AE/sharjah/wof-locality-421168683.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Ajman|AE",
+      "priority": ["uae-metro", "needs-clipping-review"],
+      "review": {
+        "status": "needs-clipping-review",
+        "issue": 118,
+        "notes": ["WOF current locality envelope overlaps Dubai/Sharjah envelopes; do not ship as runtime bbox without an explicit clipping rule."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Dubai|AE", "kind": "bbox-overlap", "status": "WOF locality envelopes overlap; runtime clipping review needed" },
+        { "cityKey": "Sharjah|AE", "kind": "bbox-overlap", "status": "WOF locality envelopes overlap; runtime clipping review needed" }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:1126024975",
+          "ids": { "wofId": 1126024975, "repo": "whosonfirst-data-admin-ae", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "AE/ajman/wof-locality-1126024975.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
       "cityKey": "Jerusalem|PS",
       "priority": ["current-validator-warning", "intentional-routing-anchor", "human-review-required"],
       "review": {

--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -1,6 +1,6 @@
 {
   "version": "1.7.0-alpha.0",
-  "generated": "2026-05-14T09:56:40.667Z",
+  "generated": "2026-05-14T10:09:19.903Z",
   "license": {
     "world-cities": "Capital data from UN Statistics Division and Wikipedia (public-domain reference, MIT-aligned)",
     "mawaqit-slugs": "Curated metadata derived from public Mawaqit profile pages (slugs only)",
@@ -129,7 +129,6 @@
     {"name":"Maputo","countryISO":"MZ","lat":-25.9692,"lon":32.5732,"bbox":[-26.0692,-25.8692,32.4732,32.6732],"timezone":"Africa/Maputo","elevation":47,"source":{"type":"national-authority","institution":"Muslim World League"}},
     {"name":"Ramallah","countryISO":"PS","lat":31.9038,"lon":35.2034,"bbox":[31.8038,32.0038,35.1034,35.3034],"timezone":"Asia/Hebron","elevation":854,"source":{"type":"national-authority","institution":"Egyptian General Authority of Survey"}},
     {"name":"Riyadh","countryISO":"SA","lat":24.7136,"lon":46.6753,"bbox":[24.6136,24.8136,46.5753,46.7753],"timezone":"Asia/Riyadh","elevation":612,"source":{"type":"national-authority","institution":"Umm al-Qura University"}},
-    {"name":"Abu Dhabi","countryISO":"AE","lat":24.4539,"lon":54.3773,"bbox":[24.3539,24.5539,54.2773,54.4773],"timezone":"Asia/Dubai","elevation":27,"source":{"type":"national-authority","institution":"Umm al-Qura University"}},
     {"name":"Bern","countryISO":"CH","lat":46.948,"lon":7.4474,"bbox":[46.848,47.048,7.3474,7.5474],"timezone":"Europe/Zurich","elevation":540,"source":{"type":"inherited","from":"Switzerland"}},
     {"name":"Bucharest","countryISO":"RO","lat":44.4268,"lon":26.1025,"bbox":[44.3268,44.5268,26.0025,26.2025],"timezone":"Europe/Bucharest","elevation":96,"source":{"type":"inherited","from":"Romania"}},
     {"name":"Belgrade","countryISO":"RS","lat":44.7866,"lon":20.4489,"bbox":[44.6866,44.8866,20.3489,20.5489],"timezone":"Europe/Belgrade","elevation":117,"source":{"type":"inherited","from":"Serbia"}},
@@ -302,7 +301,6 @@
     {"name":"Bandar Abbas","countryISO":"IR","lat":27.1832,"lon":56.2666,"bbox":[26.9832,27.3832,56.0666,56.4666],"timezone":"Asia/Tehran","nameLocal":"بندرعباس","adminRegion":"Hormozgan","population":526000,"elevation":9,"source":{"type":"inherited","from":"Iran"}},
     {"name":"Kerman","countryISO":"IR","lat":30.2839,"lon":57.0834,"bbox":[30.0839,30.4839,56.8834,57.2834],"timezone":"Asia/Tehran","nameLocal":"کرمان","adminRegion":"Kerman","population":738000,"elevation":1755,"source":{"type":"inherited","from":"Iran"}},
     {"name":"Buraydah","countryISO":"SA","lat":26.326,"lon":43.975,"bbox":[26.126,26.526,43.775,44.175],"timezone":"Asia/Riyadh","nameLocal":"بريدة","adminRegion":"Qassim","population":745000,"elevation":619,"source":{"type":"inherited","from":"SaudiArabia"}},
-    {"name":"Al Ain","countryISO":"AE","lat":24.2075,"lon":55.7447,"bbox":[24.0075,24.4075,55.5447,55.9447],"timezone":"Asia/Dubai","nameLocal":"العين","adminRegion":"Abu Dhabi Emirate","population":766000,"elevation":295,"source":{"type":"inherited","from":"UAE"}},
     {"name":"Port Said","countryISO":"EG","lat":31.2653,"lon":32.3019,"bbox":[31.0653,31.4653,32.1019,32.5019],"timezone":"Africa/Cairo","nameLocal":"بورسعيد","adminRegion":"Port Said","population":760000,"elevation":2,"source":{"type":"inherited","from":"Egypt"}},
     {"name":"Suez","countryISO":"EG","lat":29.9737,"lon":32.5263,"bbox":[29.7737,30.1737,32.3263,32.7263],"timezone":"Africa/Cairo","nameLocal":"السويس","adminRegion":"Suez","population":744000,"elevation":9,"source":{"type":"inherited","from":"Egypt"}},
     {"name":"Mansoura","countryISO":"EG","lat":31.0409,"lon":31.3785,"bbox":[30.8409,31.2409,31.1785,31.5785],"timezone":"Africa/Cairo","nameLocal":"المنصورة","adminRegion":"Dakahlia","population":960000,"elevation":6,"source":{"type":"inherited","from":"Egypt"}},
@@ -362,7 +360,9 @@
     {"name":"Kuala Lumpur","countryISO":"MY","lat":3.139,"lon":101.6869,"bbox":[2.939,3.339,101.55,101.99],"timezone":"Asia/Kuala_Lumpur","population":1809000,"elevation":22,"source":{"type":"mawaqit","slug":"surau-ar-raudhah-islamiah-kuala-lumpur-54200-malaysia-2"}},
     {"name":"Giza","countryISO":"EG","lat":30.0131,"lon":31.2089,"bbox":[29.6131,30.1,30.8089,31.22],"timezone":"Africa/Cairo","nameLocal":"الجيزة","adminRegion":"Giza","population":9200000,"elevation":30,"source":{"type":"inherited","from":"Egypt"}},
     {"name":"Dubai","countryISO":"AE","lat":25.2048,"lon":55.2708,"bbox":[24.9,25.35,55.05,55.5],"timezone":"Asia/Dubai","nameLocal":"دبي","adminRegion":"Dubai Emirate","population":3604000,"elevation":5,"source":{"type":"inherited","from":"UAE"}},
+    {"name":"Al Ain","countryISO":"AE","lat":24.2075,"lon":55.7447,"bbox":[24.013749,24.414416,55.464609,56.018126],"timezone":"Asia/Dubai","nameLocal":"العين","adminRegion":"Abu Dhabi Emirate","population":766000,"elevation":295,"source":{"type":"inherited","from":"UAE"}},
     {"name":"Hong Kong","countryISO":"HK","lat":22.3193,"lon":114.1694,"bbox":[22.16,22.55,113.85,114.43],"timezone":"Asia/Hong_Kong","population":7482000,"elevation":50,"source":{"type":"inherited","from":"HongKong"}},
+    {"name":"Abu Dhabi","countryISO":"AE","lat":24.4539,"lon":54.3773,"bbox":[24.195888,24.590696,54.254076,54.841984],"timezone":"Asia/Dubai","elevation":27,"source":{"type":"national-authority","institution":"Umm al-Qura University"}},
     {"name":"Lahore","countryISO":"PK","lat":31.5497,"lon":74.3436,"bbox":[31.25,31.85,74.04,74.5],"timezone":"Asia/Karachi","nameLocal":"لاہور","adminRegion":"Punjab","population":13096000,"elevation":217,"source":{"type":"mawaqit","slug":"masjid-khatim-ul-nabiyyeen-lahore-54000-pakistan"}},
     {"name":"Osaka","countryISO":"JP","lat":34.6937,"lon":135.5023,"bbox":[34.3937,34.9937,135.2023,135.8023],"timezone":"Asia/Tokyo","adminRegion":"Osaka Prefecture","population":2691000,"elevation":24,"source":{"type":"inherited","from":"JP"}},
     {"name":"Faisalabad","countryISO":"PK","lat":31.4187,"lon":73.0791,"bbox":[31.1187,31.7187,72.7791,73.3791],"timezone":"Asia/Karachi","nameLocal":"فیصل آباد","adminRegion":"Punjab","population":3630000,"elevation":184,"source":{"type":"inherited","from":"Pakistan"}},

--- a/test/detectLocation.test.js
+++ b/test/detectLocation.test.js
@@ -221,6 +221,25 @@ describe('detectLocation — Mawaqit institutional source', () => {
       expect(oldEdge.city?.name, `${name} old overbroad edge should no longer resolve to ${name}`).not.toBe(name)
     }
   })
+
+  it('UAE WOF locality rows expand Abu Dhabi/Al Ain city provenance without touching Dubai/Sharjah/Ajman', () => {
+    const rows = [
+      ['Abu Dhabi', 24.4539, 54.3773, 24.20, 54.80],
+      ['Al Ain', 24.2075, 55.7447, 24.20, 55.50],
+    ]
+
+    for (const [name, centerLat, centerLon, edgeLat, edgeLon] of rows) {
+      const center = detectLocation(centerLat, centerLon)
+      expect(center.city, `${name} center should still resolve`).not.toBeNull()
+      expect(center.city.name).toBe(name)
+      expect(center.country).toBe('UAE')
+
+      const edge = detectLocation(edgeLat, edgeLon)
+      expect(edge.city, `${name} reviewed WOF edge should resolve`).not.toBeNull()
+      expect(edge.city.name).toBe(name)
+      expect(edge.country).toBe('UAE')
+    }
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -77,6 +77,8 @@ describe('city geometry source map', () => {
       ['Basel|CH', 'wof:locality:101748459'],
       ['Mulhouse|FR', 'wof:locality:101749573'],
       ['Fes|MA', 'wof:locality:421190143'],
+      ['Abu Dhabi|AE', 'wof:locality:421179641'],
+      ['Al Ain|AE', 'wof:locality:421168687'],
       ['Brazzaville|CG', 'wof:locality:421180023'],
       ['Kinshasa|CD', 'wof:locality:421166913'],
     ])
@@ -99,6 +101,11 @@ describe('city geometry source map', () => {
     expect(statusFor('Mulhouse|FR')).toBe('runtime-bbox-shipped')
     expect(statusFor('Casablanca|MA')).toBe('runtime-bbox-shipped')
     expect(statusFor('Fes|MA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Abu Dhabi|AE')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Al Ain|AE')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Dubai|AE')).toBe('needs-clipping-review')
+    expect(statusFor('Sharjah|AE')).toBe('needs-clipping-review')
+    expect(statusFor('Ajman|AE')).toBe('needs-clipping-review')
     expect(statusFor('Brazzaville|CG')).toBe('needs-clipping-review')
     expect(statusFor('Kinshasa|CD')).toBe('needs-clipping-review')
   })


### PR DESCRIPTION
## Summary
- Add WOF current locality source-map rows for Abu Dhabi, Al Ain, Dubai, Sharjah, and Ajman.
- Update `Abu Dhabi|AE` and `Al Ain|AE` runtime bboxes to reviewed WOF current locality envelopes where there is no neighboring lookup-cell collision.
- Keep Dubai/Sharjah/Ajman runtime bboxes unchanged and mark them `needs-clipping-review` because their WOF locality envelopes overlap heavily.
- Add `detectLocation()` coverage for Abu Dhabi / Al Ain center and WOF-edge routing.
- Update `docs/city-geometry-audit.md` and changelog with the UAE source posture.

## Validation
- `npm test` -> 19 files / 381 tests passed.
- `npm run validate:registry` -> 0 fail-class issues; 1 warn-class issue (`Jerusalem|PS` row-center allowlist only).
- `node scripts/build-city-registry.js --check` -> check passed.
- `node scripts/audit-city-geometry.js --format json` -> 25 source cities, 39 source rows, 38 checked, 0 missing cache/geometry. Abu Dhabi is `low-priority` with exact WOF bbox alignment; Al Ain is `envelope-aligned`; Dubai/Sharjah/Ajman remain source-map review rows.
- `npm run build:charts` -> refreshed deterministic chart/progress outputs; no resulting chart/progress diff.
- `npm pack --dry-run` -> 140.5 kB packed, 515.6 kB unpacked, 20 bundled files.
- `git diff --check` -> clean.

Refs #118

## Position registry
[positions: no-change-required] City bbox/provenance-only update; no region default, method dispatch, confidence grade, or institutional position changes.

## Runtime impact
`detectLocation()` / city provenance now recognizes reviewed Abu Dhabi and Al Ain edge coordinates that previously fell back to UAE country-level provenance. Dubai, Sharjah, and Ajman behavior is intentionally unchanged pending clipping review. Prayer-time math and public API are unchanged.