### PR TITLE
Fix Geneva border bbox seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added a clipped WOF-backed `Windsor|CA` lookup cell and moved Detroit/Dearborn
   north of the river seam so Windsor coordinates no longer resolve to US city
   provenance.
+- Tightened `Geneva|CH` and added WOF-backed `Annemasse|FR` and
+  `Ferney-Voltaire|FR` lookup cells so adjacent French border towns no longer
+  resolve to Geneva/Switzerland.
 
 ### Changed — documentation doctrine cleanup
 

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -34,9 +34,9 @@ human review. It must not mutate the runtime registry automatically.
 
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
-36 high-priority rows: 15 Morocco/Habous phase-1 rows, 5 UAE metro rows, 10
-Turkey large-city rows, 1 Detroit/Windsor border row, and 5 existing registry
-warning rows. It carries 17 OSM relation rows plus 32 WOF
+39 high-priority rows: 15 Morocco/Habous phase-1 rows, 5 UAE metro rows, 10
+Turkey large-city rows, 1 Detroit/Windsor border row, 3 Geneva border rows, and
+5 existing registry warning rows. It carries 17 OSM relation rows plus 35 WOF
 rows across reviewed locality/county candidates. Berrechid, Settat, and Fes
 now have WOF locality candidates; Jerusalem intentionally remains without a
 geometry candidate until a human routing decision is available.
@@ -143,6 +143,12 @@ The Detroit/Windsor border seam needs clipping rather than direct WOF copying:
   clipped at the river seam while Detroit and Dearborn are clipped north of the
   same seam.
 
+The Geneva/French-border seam is cleaner with WOF locality rows:
+
+- Geneva's old population-radius cell swallowed adjacent French towns. WOF
+  current locality rows let the runtime keep Geneva city provenance while
+  routing Annemasse and Ferney-Voltaire to France.
+
 Reference URLs checked in this pass:
 
 - HDX Morocco COD-AB:
@@ -191,6 +197,9 @@ from neighboring Morocco rows during `detectLocation()`'s smallest-match scan:
 - `Windsor|CA`: added as a clipped WOF-backed lookup cell for the
   Detroit/Windsor seam. `Detroit|US` and `Dearborn|US` now start north of the
   seam, so Windsor no longer resolves to a US city.
+- `Geneva|CH`, `Annemasse|FR`, and `Ferney-Voltaire|FR`: tightened/added from
+  WOF current locality envelopes so French border-town coordinates no longer
+  resolve to Geneva/Switzerland.
 
 These are provenance/routing fixes only. They do not change prayer-time
 calculation math or imply that rectangles now encode municipal boundaries.

--- a/scripts/build-city-registry.js
+++ b/scripts/build-city-registry.js
@@ -386,6 +386,8 @@ const MUSLIM_POPULATION_CENTERS = [
   { name: 'Gothenburg', countryISO: 'SE', adminRegion: 'Västra Götaland County', lat: 57.7089, lon: 11.9746, elevation: 12, timezone: 'Europe/Stockholm', population: 583000 },
   { name: 'Zurich',     countryISO: 'CH', adminRegion: 'Zurich Canton', lat: 47.3769, lon: 8.5417, elevation: 408, timezone: 'Europe/Zurich', population: 421000 },
   { name: 'Geneva',     countryISO: 'CH', adminRegion: 'Geneva Canton', lat: 46.2044, lon: 6.1432, elevation: 375, timezone: 'Europe/Zurich', population: 203000 },
+  { name: 'Annemasse',  countryISO: 'FR', adminRegion: 'Auvergne-Rhône-Alpes', lat: 46.1840, lon: 6.2456, elevation: 435, timezone: 'Europe/Paris', population: 37000 },
+  { name: 'Ferney-Voltaire', countryISO: 'FR', adminRegion: 'Auvergne-Rhône-Alpes', lat: 46.2577, lon: 6.1155, elevation: 430, timezone: 'Europe/Paris', population: 10000 },
   { name: 'Barcelona',  countryISO: 'ES', adminRegion: 'Catalonia', lat: 41.3851, lon: 2.1734, elevation: 12, timezone: 'Europe/Madrid', population: 1620000 },
   { name: 'Milan',      countryISO: 'IT', adminRegion: 'Lombardy', lat: 45.4642, lon: 9.1900, elevation: 120, timezone: 'Europe/Rome', population: 1396000 },
 
@@ -957,7 +959,14 @@ const BBOX_OVERRIDES = {
   'Temara|MA':          [33.85, 33.96, -7.00, -6.86],
 
   // Geneva — formulaic 0.20 bbox extends west of Switzerland's lon 6.0.
-  'Geneva|CH':          [46.10, 46.30, 6.05, 6.25],
+  // v1.8.0 #118: WOF current locality envelope keeps Geneva city provenance
+  // inside Switzerland and stops stealing adjacent French border towns.
+  'Geneva|CH':          [46.177774, 46.234248, 6.110233, 6.175845],
+  // v1.8.0 #118: WOF current locality rows for French towns on the Geneva
+  // border. These are smaller Pass-B cells because detectCountry's broad
+  // Switzerland rectangle sees the first country at these coordinates.
+  'Annemasse|FR':       [46.176411, 46.201967, 6.216619, 6.278294],
+  'Ferney-Voltaire|FR': [46.237488, 46.266135, 6.088144, 6.12439],
 
   // Montevideo — formulaic 0.20 bbox extends south of Uruguay's lat-min.
   'Montevideo|UY':      [-34.95, -34.85, -56.27, -56.05],

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -786,6 +786,79 @@
       ]
     },
     {
+      "cityKey": "Geneva|CH",
+      "priority": ["geneva-border", "wof-locality-runtime-bbox", "europe-p0"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox updated to WOF current locality envelope so adjacent French border towns do not resolve to Geneva."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Annemasse|FR", "kind": "runtime-separated", "status": "Geneva east edge stops west of Annemasse locality bbox" },
+        { "cityKey": "Ferney-Voltaire|FR", "kind": "runtime-separated", "status": "Geneva north edge stops south of Ferney-Voltaire locality bbox" }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101748445",
+          "ids": { "wofId": 101748445, "repo": "whosonfirst-data-admin-ch", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "CH/geneva/wof-locality-101748445.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped"
+        }
+      ]
+    },
+    {
+      "cityKey": "Annemasse|FR",
+      "priority": ["geneva-border", "wof-locality-runtime-bbox", "europe-p0"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox added to stop Annemasse from resolving to Geneva/Switzerland."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Geneva|CH", "kind": "runtime-separated", "status": "Annemasse west edge starts east of Geneva locality bbox" }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101757307",
+          "ids": { "wofId": 101757307, "repo": "whosonfirst-data-admin-fr", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "FR/annemasse/wof-locality-101757307.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped"
+        }
+      ]
+    },
+    {
+      "cityKey": "Ferney-Voltaire|FR",
+      "priority": ["geneva-border", "wof-locality-runtime-bbox", "europe-p0"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox added to stop Ferney-Voltaire from resolving to Geneva/Switzerland."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Geneva|CH", "kind": "runtime-separated", "status": "Ferney-Voltaire south edge starts north of Geneva locality bbox" }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101753277",
+          "ids": { "wofId": 101753277, "repo": "whosonfirst-data-admin-fr", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "FR/ferney-voltaire/wof-locality-101753277.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped"
+        }
+      ]
+    },
+    {
       "cityKey": "Jerusalem|PS",
       "priority": ["current-validator-warning", "intentional-routing-anchor", "human-review-required"],
       "review": {

--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -1,6 +1,6 @@
 {
   "version": "1.7.0-alpha.0",
-  "generated": "2026-05-14T10:43:14.377Z",
+  "generated": "2026-05-14T10:48:16.990Z",
   "license": {
     "world-cities": "Capital data from UN Statistics Division and Wikipedia (public-domain reference, MIT-aligned)",
     "mawaqit-slugs": "Curated metadata derived from public Mawaqit profile pages (slugs only)",
@@ -8,13 +8,16 @@
     "population-centers": "Manual, sourced from UN World Cities + World Population Review 2024-2025"
   },
   "notes": "Cities sorted by bbox area ascending. detectLocation() linear-scans this array and returns the first bbox that contains (lat, lon) — smallest match wins. Each city carries an institutional `source` (mawaqit | national-authority | inherited) so apps can attribute timetable provenance to users. Method overrides are city-level institutional decisions documented in scripts/data/city-method-overrides.json with citation strings.",
-  "total": 478,
+  "total": 480,
   "cities": [
     {"name":"Alburikent (Dagestan)","countryISO":"RU","lat":42.9234,"lon":47.5089,"bbox":[42.92,42.94,47.5,47.52],"timezone":"Europe/Moscow","adminRegion":"Dagestan","population":11000,"elevation":50,"source":{"type":"mawaqit","slug":"alburkent-dzhuma-mechet-alburikent-367026-russia"}},
     {"name":"Isa Town","countryISO":"BH","lat":26.1762,"lon":50.5495,"bbox":[26.16,26.19,50.53,50.56],"timezone":"Asia/Bahrain","population":38000,"elevation":21,"source":{"type":"mawaqit","slug":"masjid-madina-issa-south-810-issa-town-bahrain"}},
+    {"name":"Ferney-Voltaire","countryISO":"FR","lat":46.2577,"lon":6.1155,"bbox":[46.237488,46.266135,6.088144,6.12439],"timezone":"Europe/Paris","adminRegion":"Auvergne-Rhône-Alpes","population":10000,"elevation":430,"source":{"type":"inherited","from":"France"}},
+    {"name":"Annemasse","countryISO":"FR","lat":46.184,"lon":6.2456,"bbox":[46.176411,46.201967,6.216619,6.278294],"timezone":"Europe/Paris","adminRegion":"Auvergne-Rhône-Alpes","population":37000,"elevation":435,"source":{"type":"inherited","from":"France"}},
     {"name":"Sefrou","countryISO":"MA","lat":33.8311,"lon":-4.8294,"bbox":[33.809375,33.844543,-4.853352,-4.804161],"timezone":"Africa/Casablanca","population":79000,"elevation":850,"source":{"type":"mawaqit","slug":"mosquee-ahel-sefrou-sefrou-31000-morocco"}},
     {"name":"Trabzon","countryISO":"TR","lat":41.0027,"lon":39.7168,"bbox":[40.985525,41.013493,39.649901,39.742612],"timezone":"Europe/Istanbul","adminRegion":"Trabzon Province","population":808000,"elevation":39,"source":{"type":"inherited","from":"Turkey"}},
     {"name":"Jerusalem","countryISO":"PS","lat":31.7683,"lon":35.2137,"bbox":[31.74,31.8,35.55,35.6],"timezone":"Asia/Hebron","population":936000,"elevation":754,"source":{"type":"mawaqit","slug":"msjd-lsyd-zynb-jerusalem-97200-palestinian-territories"}},
+    {"name":"Geneva","countryISO":"CH","lat":46.2044,"lon":6.1432,"bbox":[46.177774,46.234248,6.110233,6.175845],"timezone":"Europe/Zurich","adminRegion":"Geneva Canton","population":203000,"elevation":375,"source":{"type":"mawaqit","slug":"fondation-culturelle-islamique-de-geneve-geneve-1209-switzerland"}},
     {"name":"Berrechid","countryISO":"MA","lat":33.2659,"lon":-7.5867,"bbox":[33.230306,33.299095,-7.613623,-7.545455],"timezone":"Africa/Casablanca","population":136000,"elevation":175,"source":{"type":"mawaqit","slug":"mosquee-brahimm-lkhlalil-berrchid-26100-morocco"}},
     {"name":"Mamoudzou","countryISO":"YT","lat":-12.7806,"lon":45.2278,"bbox":[-12.81,-12.74,45.2,45.27],"timezone":"Indian/Mayotte","population":71000,"elevation":14,"source":{"type":"inherited","from":"Mayotte"}},
     {"name":"Mulhouse","countryISO":"FR","lat":47.7508,"lon":7.3359,"bbox":[47.721942,47.783092,7.282525,7.368264],"timezone":"Europe/Paris","population":109000,"elevation":240,"source":{"type":"mawaqit","slug":"association-des-musulmans-des-coteaux-mulhouse"}},
@@ -88,7 +91,6 @@
     {"name":"Akkar","countryISO":"LB","lat":34.5391,"lon":36.1233,"bbox":[34.53,34.69,36.05,36.3],"timezone":"Asia/Beirut","adminRegion":"Akkar Governorate","population":109000,"elevation":35,"source":{"type":"mawaqit","slug":"the-great-prophet-muhammad-mosque-al-baradah-akkar-900001-lebanon"}},
     {"name":"Georgetown","countryISO":"GY","lat":6.8013,"lon":-58.1551,"bbox":[6.7013,6.9013,-58.2551,-58.0551],"timezone":"America/Guyana","elevation":9,"source":{"type":"inherited","from":"GY"}},
     {"name":"Victoria","countryISO":"SC","lat":-4.6191,"lon":55.4513,"bbox":[-4.7191,-4.5191,55.3513,55.5513],"timezone":"Indian/Mahe","elevation":5,"source":{"type":"inherited","from":"Seychelles"}},
-    {"name":"Geneva","countryISO":"CH","lat":46.2044,"lon":6.1432,"bbox":[46.1,46.3,6.05,6.25],"timezone":"Europe/Zurich","adminRegion":"Geneva Canton","population":203000,"elevation":375,"source":{"type":"mawaqit","slug":"fondation-culturelle-islamique-de-geneve-geneve-1209-switzerland"}},
     {"name":"Taourirt","countryISO":"MA","lat":34.4115,"lon":-2.8975,"bbox":[34.3115,34.5115,-2.9975,-2.7975],"timezone":"Africa/Casablanca","population":80000,"elevation":425,"source":{"type":"mawaqit","slug":"jamii-ibrahim-lkhalil-taourirt-65000-morocco-1"}},
     {"name":"Ifrane","countryISO":"MA","lat":33.5228,"lon":-5.1106,"bbox":[33.4228,33.6228,-5.2106,-5.0106],"timezone":"Africa/Casablanca","population":14000,"elevation":1664,"source":{"type":"mawaqit","slug":"mosquee-universite-alakhawayn-ifrane-53000-morocco"}},
     {"name":"Zagreb","countryISO":"HR","lat":45.815,"lon":15.9819,"bbox":[45.715,45.915,15.8819,16.0819],"timezone":"Europe/Zagreb","elevation":122,"source":{"type":"inherited","from":"Croatia"}},

--- a/test/detectLocation.test.js
+++ b/test/detectLocation.test.js
@@ -222,6 +222,28 @@ describe('detectLocation — Mawaqit institutional source', () => {
     }
   })
 
+  it('Geneva border WOF cells keep Geneva while routing French border towns to France', () => {
+    const geneva = detectLocation(46.2044, 6.1432)
+    expect(geneva.city).not.toBeNull()
+    expect(geneva.city.name).toBe('Geneva')
+    expect(geneva.country).toBe('Switzerland')
+    expect(geneva.timezone).toBe('Europe/Zurich')
+
+    const annemasse = detectLocation(46.1944, 6.2377)
+    expect(annemasse.city).not.toBeNull()
+    expect(annemasse.city.name).toBe('Annemasse')
+    expect(annemasse.city.countryISO).toBe('FR')
+    expect(annemasse.country).toBe('France')
+    expect(annemasse.timezone).toBe('Europe/Paris')
+
+    const ferney = detectLocation(46.2558, 6.1081)
+    expect(ferney.city).not.toBeNull()
+    expect(ferney.city.name).toBe('Ferney-Voltaire')
+    expect(ferney.city.countryISO).toBe('FR')
+    expect(ferney.country).toBe('France')
+    expect(ferney.timezone).toBe('Europe/Paris')
+  })
+
   it('UAE WOF locality rows expand Abu Dhabi/Al Ain city provenance without touching Dubai/Sharjah/Ajman', () => {
     const rows = [
       ['Abu Dhabi', 24.4539, 54.3773, 24.20, 54.80],

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -90,6 +90,9 @@ describe('city geometry source map', () => {
       ['Samsun|TR', 'wof:locality:101911033'],
       ['Trabzon|TR', 'wof:locality:101912783'],
       ['Windsor|CA', 'wof:locality:101735855'],
+      ['Geneva|CH', 'wof:locality:101748445'],
+      ['Annemasse|FR', 'wof:locality:101757307'],
+      ['Ferney-Voltaire|FR', 'wof:locality:101753277'],
       ['Brazzaville|CG', 'wof:locality:421180023'],
       ['Kinshasa|CD', 'wof:locality:421166913'],
     ])
@@ -128,6 +131,9 @@ describe('city geometry source map', () => {
     expect(statusFor('Samsun|TR')).toBe('runtime-bbox-shipped')
     expect(statusFor('Trabzon|TR')).toBe('runtime-bbox-shipped')
     expect(statusFor('Windsor|CA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Geneva|CH')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Annemasse|FR')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Ferney-Voltaire|FR')).toBe('runtime-bbox-shipped')
     expect(statusFor('Brazzaville|CG')).toBe('needs-clipping-review')
     expect(statusFor('Kinshasa|CD')).toBe('needs-clipping-review')
   })


### PR DESCRIPTION
## Summary

Refs #118.

This fixes the Geneva/French-border city-provenance seam found during the #118 geometry pass.

Before this patch, adjacent French border-town coordinates such as Annemasse and Ferney-Voltaire resolved to `Geneva|CH`, which changed country, timezone, and method provenance. WOF has clean current locality rows for all three cells, so this PR ships the WOF lookup cells directly.

- Tightens `Geneva|CH` to WOF current locality `101748445`: `[46.177774, 46.234248, 6.110233, 6.175845]`.
- Adds `Annemasse|FR` from WOF current locality `101757307`: `[46.176411, 46.201967, 6.216619, 6.278294]`.
- Adds `Ferney-Voltaire|FR` from WOF current locality `101753277`: `[46.237488, 46.266135, 6.088144, 6.12439]`.
- Adds source-map provenance, routing tests, changelog, and geometry audit docs.

[positions: no-change-required] City bbox/provenance-only update; no region default, method dispatch, confidence grade, or institutional position changes.

## Validation

- `node scripts/fetch-city-geometry-cache.js --provider wof --city Geneva`
- `node scripts/fetch-city-geometry-cache.js --provider wof --city Annemasse`
- `node scripts/fetch-city-geometry-cache.js --provider wof --city Ferney-Voltaire`
- `node scripts/build-city-registry.js`
- local probes:
  - `46.2044, 6.1432` -> `Geneva|CH`, Switzerland, `Europe/Zurich`
  - `46.1944, 6.2377` -> `Annemasse|FR`, France, `Europe/Paris`
  - `46.2558, 6.1081` -> `Ferney-Voltaire|FR`, France, `Europe/Paris`
- `npm run validate:registry` — 480 city centers + 9,600 bbox samples, 0 fail-class issues
- `npx vitest run test/detectLocation.test.js test/geometrySourceMap.test.js` — 64/64
- `node scripts/build-city-registry.js --check`
- `node scripts/audit-city-geometry.js --format json` — 39 source-map cities, 53 source rows, 52 checked, 0 missing caches/geometries
- `npm test` — 385/385
- `npm run build:charts`
- `git diff --check`
- `npm pack --dry-run` — package 140.9 kB, unpacked 516.5 kB

## Notes for reviewers

This is a lookup-cell fix, not a legal municipal boundary claim. Raw WOF geometry remains in `.cache/city-geometry` and outside npm/git.
