### PR TITLE
Fix Strasbourg/Kehl bbox seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Tightened `Geneva|CH` and added WOF-backed `Annemasse|FR` and
   `Ferney-Voltaire|FR` lookup cells so adjacent French border towns no longer
   resolve to Geneva/Switzerland.
+- Separated the `Strasbourg|FR` / `Kehl|DE` Rhine seam with clipped WOF-backed
+  lookup cells so Kehl no longer resolves to Strasbourg/France.
+- Extended Equatorial Guinea's country bbox by 0.01° north so Malabo's own
+  northern city samples remain in Equatorial Guinea instead of falling through
+  to Cameroon.
 
 ### Changed — documentation doctrine cleanup
 

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -34,9 +34,10 @@ human review. It must not mutate the runtime registry automatically.
 
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
-39 high-priority rows: 15 Morocco/Habous phase-1 rows, 5 UAE metro rows, 10
-Turkey large-city rows, 1 Detroit/Windsor border row, 3 Geneva border rows, and
-5 existing registry warning rows. It carries 17 OSM relation rows plus 35 WOF
+41 high-priority rows: 15 Morocco/Habous phase-1 rows, 5 UAE metro rows, 10
+Turkey large-city rows, 1 Detroit/Windsor border row, 3 Geneva border rows, 2
+Strasbourg/Kehl border rows, and 5 existing registry warning rows. It carries
+17 OSM relation rows plus 37 WOF
 rows across reviewed locality/county candidates. Berrechid, Settat, and Fes
 now have WOF locality candidates; Jerusalem intentionally remains without a
 geometry candidate until a human routing decision is available.
@@ -149,6 +150,12 @@ The Geneva/French-border seam is cleaner with WOF locality rows:
   current locality rows let the runtime keep Geneva city provenance while
   routing Annemasse and Ferney-Voltaire to France.
 
+The Strasbourg/Kehl Rhine seam requires a clipped WOF application:
+
+- Both cities have current WOF locality rows, but the raw rectangular
+  envelopes overlap across the Rhine. Strasbourg is clipped just west of
+  Kehl's WOF west edge; Kehl uses its WOF envelope.
+
 Reference URLs checked in this pass:
 
 - HDX Morocco COD-AB:
@@ -200,6 +207,8 @@ from neighboring Morocco rows during `detectLocation()`'s smallest-match scan:
 - `Geneva|CH`, `Annemasse|FR`, and `Ferney-Voltaire|FR`: tightened/added from
   WOF current locality envelopes so French border-town coordinates no longer
   resolve to Geneva/Switzerland.
+- `Strasbourg|FR` and `Kehl|DE`: separated at the Rhine seam so Kehl no
+  longer resolves to Strasbourg/France.
 
 These are provenance/routing fixes only. They do not change prayer-time
 calculation math or imply that rectangles now encode municipal boundaries.

--- a/scripts/build-city-registry.js
+++ b/scripts/build-city-registry.js
@@ -375,6 +375,7 @@ const MUSLIM_POPULATION_CENTERS = [
   { name: 'Lille',      countryISO: 'FR', adminRegion: 'Hauts-de-France', lat: 50.6292, lon: 3.0573, elevation: 21, timezone: 'Europe/Paris', population: 233000 },
   { name: 'Bordeaux',   countryISO: 'FR', adminRegion: 'Nouvelle-Aquitaine', lat: 44.8378, lon: -0.5792, elevation: 22, timezone: 'Europe/Paris', population: 260000 },
   { name: 'Strasbourg', countryISO: 'FR', adminRegion: 'Grand Est', lat: 48.5734, lon: 7.7521, elevation: 142, timezone: 'Europe/Paris', population: 287000 },
+  { name: 'Kehl',       countryISO: 'DE', adminRegion: 'Baden-Württemberg', lat: 48.5838, lon: 7.8125, elevation: 139, timezone: 'Europe/Berlin', population: 37000 },
   { name: 'Hamburg',    countryISO: 'DE', adminRegion: 'Hamburg', lat: 53.5511, lon: 9.9937, elevation: 6, timezone: 'Europe/Berlin', population: 1899000 },
   { name: 'Munich',     countryISO: 'DE', adminRegion: 'Bavaria', lat: 48.1351, lon: 11.5820, elevation: 520, timezone: 'Europe/Berlin', population: 1488000 },
   { name: 'Frankfurt',  countryISO: 'DE', adminRegion: 'Hesse', lat: 50.1109, lon: 8.6821, elevation: 112, timezone: 'Europe/Berlin', population: 763000 },
@@ -967,6 +968,12 @@ const BBOX_OVERRIDES = {
   // Switzerland rectangle sees the first country at these coordinates.
   'Annemasse|FR':       [46.176411, 46.201967, 6.216619, 6.278294],
   'Ferney-Voltaire|FR': [46.237488, 46.266135, 6.088144, 6.12439],
+
+  // v1.8.0 #118: Strasbourg/Kehl Rhine seam. WOF locality rectangles overlap
+  // across the river, so clip Strasbourg's east edge just west of Kehl's WOF
+  // west edge and let Kehl use its reviewed WOF current locality envelope.
+  'Strasbourg|FR':      [48.492024, 48.646236, 7.687934, 7.79],
+  'Kehl|DE':            [48.485236, 48.641269, 7.79153, 7.956431],
 
   // Montevideo — formulaic 0.20 bbox extends south of Uruguay's lat-min.
   'Montevideo|UY':      [-34.95, -34.85, -56.27, -56.05],

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -859,6 +859,55 @@
       ]
     },
     {
+      "cityKey": "Strasbourg|FR",
+      "priority": ["strasbourg-kehl-border", "wof-locality-runtime-bbox", "clipped", "europe-p0"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox updated from WOF current locality row but clipped west of Kehl because the raw WOF rectangles overlap across the Rhine."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Kehl|DE", "kind": "runtime-separated", "status": "Strasbourg east edge stops at lon 7.79; Kehl starts at WOF west edge lon 7.79153" }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101751113",
+          "ids": { "wofId": 101751113, "repo": "whosonfirst-data-admin-fr", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "FR/strasbourg/wof-locality-101751113.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["Full WOF locality bbox extends to lon 7.835923; runtime bbox clips east edge to 7.79 to avoid Kehl."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Kehl|DE",
+      "priority": ["strasbourg-kehl-border", "wof-locality-runtime-bbox", "europe-p0"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox added from WOF current locality row so Kehl no longer resolves to Strasbourg/France."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Strasbourg|FR", "kind": "runtime-separated", "status": "Kehl starts east of Strasbourg's clipped runtime cell" }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101753099",
+          "ids": { "wofId": 101753099, "repo": "whosonfirst-data-admin-de", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "DE/kehl/wof-locality-101753099.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped"
+        }
+      ]
+    },
+    {
       "cityKey": "Jerusalem|PS",
       "priority": ["current-validator-warning", "intentional-routing-anchor", "human-review-required"],
       "review": {

--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -1,6 +1,6 @@
 {
   "version": "1.7.0-alpha.0",
-  "generated": "2026-05-14T10:48:16.990Z",
+  "generated": "2026-05-14T10:52:57.644Z",
   "license": {
     "world-cities": "Capital data from UN Statistics Division and Wikipedia (public-domain reference, MIT-aligned)",
     "mawaqit-slugs": "Curated metadata derived from public Mawaqit profile pages (slugs only)",
@@ -8,7 +8,7 @@
     "population-centers": "Manual, sourced from UN World Cities + World Population Review 2024-2025"
   },
   "notes": "Cities sorted by bbox area ascending. detectLocation() linear-scans this array and returns the first bbox that contains (lat, lon) — smallest match wins. Each city carries an institutional `source` (mawaqit | national-authority | inherited) so apps can attribute timetable provenance to users. Method overrides are city-level institutional decisions documented in scripts/data/city-method-overrides.json with citation strings.",
-  "total": 480,
+  "total": 481,
   "cities": [
     {"name":"Alburikent (Dagestan)","countryISO":"RU","lat":42.9234,"lon":47.5089,"bbox":[42.92,42.94,47.5,47.52],"timezone":"Europe/Moscow","adminRegion":"Dagestan","population":11000,"elevation":50,"source":{"type":"mawaqit","slug":"alburkent-dzhuma-mechet-alburikent-367026-russia"}},
     {"name":"Isa Town","countryISO":"BH","lat":26.1762,"lon":50.5495,"bbox":[26.16,26.19,50.53,50.56],"timezone":"Asia/Bahrain","population":38000,"elevation":21,"source":{"type":"mawaqit","slug":"masjid-madina-issa-south-810-issa-town-bahrain"}},
@@ -42,6 +42,7 @@
     {"name":"Fes","countryISO":"MA","lat":34.0331,"lon":-5.0003,"bbox":[33.97125,34.076345,-5.078619,-4.937726],"timezone":"Africa/Casablanca","nameLocal":"فاس","adminRegion":"Fès-Meknès","population":1112000,"elevation":408,"source":{"type":"mawaqit","slug":"masjid-aamrou-bn-laas-fes-30000-morocco-1"}},
     {"name":"Saint-Denis","countryISO":"RE","lat":-20.8823,"lon":55.4504,"bbox":[-20.95,-20.85,55.4,55.55],"timezone":"Indian/Reunion","adminRegion":"Réunion","population":153000,"elevation":20,"source":{"type":"inherited","from":"Reunion"}},
     {"name":"Temara","countryISO":"MA","lat":33.9281,"lon":-6.9067,"bbox":[33.85,33.96,-7,-6.86],"timezone":"Africa/Casablanca","population":313000,"elevation":75,"source":{"type":"mawaqit","slug":"msjd-bd-llh-bn-ysyn-temara-12123-morocco"}},
+    {"name":"Strasbourg","countryISO":"FR","lat":48.5734,"lon":7.7521,"bbox":[48.492024,48.646236,7.687934,7.79],"timezone":"Europe/Paris","adminRegion":"Grand Est","population":287000,"elevation":142,"source":{"type":"mawaqit","slug":"mosquee-quba-neudorf-strasbourg-67100-france"}},
     {"name":"Dearborn","countryISO":"US","lat":42.3223,"lon":-83.1763,"bbox":[42.32,42.4,-83.28,-83.08],"timezone":"America/Detroit","adminRegion":"Michigan","population":109000,"elevation":184,"methodOverride":"ISNA","altMethods":[{"method":"Tehran","source":"Iraqi-Lebanese Shia diaspora — Islamic Center of America (Dearborn) and other Najaf-Karbala diaspora institutions follow Tehran-style timing for the Twelver Shia community"}],"source":{"type":"national-authority","institution":"Islamic Society of North America"}},
     {"name":"Luton","countryISO":"GB","lat":51.8787,"lon":-0.42,"bbox":[51.82,51.94,-0.5,-0.36],"timezone":"Europe/London","adminRegion":"Bedfordshire","population":213000,"elevation":122,"source":{"type":"inherited","from":"UK"}},
     {"name":"Bursa","countryISO":"TR","lat":40.1885,"lon":29.061,"bbox":[40.16606,40.253447,28.996355,29.20099],"timezone":"Europe/Istanbul","adminRegion":"Bursa Province","population":3139000,"elevation":100,"source":{"type":"inherited","from":"Turkey"}},
@@ -58,6 +59,7 @@
     {"name":"Gaziantep","countryISO":"TR","lat":37.0662,"lon":37.3833,"bbox":[37.005549,37.125921,37.275644,37.464959],"timezone":"Europe/Istanbul","nameLocal":"Gaziantep","adminRegion":"Gaziantep Province","population":2070000,"elevation":855,"source":{"type":"inherited","from":"Turkey"}},
     {"name":"Tangier","countryISO":"MA","lat":35.7595,"lon":-5.834,"bbox":[35.708029,35.820327,-5.942508,-5.733967],"timezone":"Africa/Casablanca","nameLocal":"طنجة","adminRegion":"Tanger-Tétouan-Al Hoceima","population":947000,"elevation":18,"source":{"type":"inherited","from":"Morocco"}},
     {"name":"Amman","countryISO":"JO","lat":31.9454,"lon":35.9284,"bbox":[31.85,32,35.83,36],"timezone":"Asia/Amman","elevation":757,"source":{"type":"national-authority","institution":"Jordan Ministry of Awqaf, Islamic Affairs and Holy Places"}},
+    {"name":"Kehl","countryISO":"DE","lat":48.5838,"lon":7.8125,"bbox":[48.485236,48.641269,7.79153,7.956431],"timezone":"Europe/Berlin","adminRegion":"Baden-Württemberg","population":37000,"elevation":139,"source":{"type":"inherited","from":"Germany"}},
     {"name":"Jerusalem","countryISO":"IL","lat":31.7683,"lon":35.2137,"bbox":[31.6683,31.8,35.1137,35.3137],"timezone":"Asia/Jerusalem","elevation":754,"source":{"type":"inherited","from":"Israel"}},
     {"name":"Khobar","countryISO":"SA","lat":26.2172,"lon":50.1971,"bbox":[26.16,26.3,50.1,50.3],"timezone":"Asia/Riyadh","nameLocal":"الخبر","adminRegion":"Eastern Province","population":626000,"elevation":8,"source":{"type":"inherited","from":"SaudiArabia"}},
     {"name":"Port Louis","countryISO":"MU","lat":-20.1609,"lon":57.5012,"bbox":[-20.2,-20.06,57.4,57.6],"timezone":"Indian/Mauritius","population":149000,"elevation":6,"source":{"type":"mawaqit","slug":"umar-bin-al-khattan-r-a-port-louis-11817-mauritius"}},
@@ -223,7 +225,6 @@
     {"name":"Baalbek","countryISO":"LB","lat":34.0058,"lon":36.2181,"bbox":[33.8558,34.1558,36.0681,36.3681],"timezone":"Asia/Beirut","adminRegion":"Baalbek-Hermel","population":105000,"elevation":1170,"source":{"type":"mawaqit","slug":"msjd-lmlk-fysl-al-s-wd-msjd-lmqsd-baalbeck-1801-lebanon"}},
     {"name":"Thies","countryISO":"SN","lat":14.7886,"lon":-16.9359,"bbox":[14.6386,14.9386,-17.0859,-16.7859],"timezone":"Africa/Dakar","population":320000,"elevation":78,"source":{"type":"mawaqit","slug":"mosquee-abou-darda-thies-23000-senegal"}},
     {"name":"Kota Kinabalu","countryISO":"MY","lat":5.9804,"lon":116.0735,"bbox":[5.8304,6.1304,115.9235,116.2235],"timezone":"Asia/Kuching","adminRegion":"Sabah","population":458000,"elevation":3,"source":{"type":"inherited","from":"Malaysia"}},
-    {"name":"Strasbourg","countryISO":"FR","lat":48.5734,"lon":7.7521,"bbox":[48.4234,48.7234,7.6021,7.9021],"timezone":"Europe/Paris","adminRegion":"Grand Est","population":287000,"elevation":142,"source":{"type":"mawaqit","slug":"mosquee-quba-neudorf-strasbourg-67100-france"}},
     {"name":"Pattani","countryISO":"TH","lat":6.8682,"lon":101.2497,"bbox":[6.7182,7.0182,101.0997,101.3997],"timezone":"Asia/Bangkok","nameLocal":"ปัตตานี","adminRegion":"Pattani Province","population":45000,"elevation":4,"source":{"type":"inherited","from":"Thailand"}},
     {"name":"Cotabato","countryISO":"PH","lat":7.2178,"lon":124.2451,"bbox":[7.0678,7.3678,124.0951,124.3951],"timezone":"Asia/Manila","adminRegion":"Maguindanao del Norte / BARMM","population":325000,"elevation":9,"methodOverride":"MWL","altMethods":[{"method":"ISNA","source":"Some Bangsamoro diaspora apps (Muslim Pro defaults via NCMF Manila offices) use ISNA-aligned 15°/15° as a North America-influenced compromise; minority practice."}],"source":{"type":"national-authority","institution":"Muslim World League"}},
     {"name":"Bilbao","countryISO":"ES","lat":43.263,"lon":-2.935,"bbox":[43.113,43.413,-3.085,-2.785],"timezone":"Europe/Madrid","adminRegion":"Basque Country","population":346000,"elevation":19,"source":{"type":"inherited","from":"ES"}},

--- a/src/engine.js
+++ b/src/engine.js
@@ -411,9 +411,9 @@ function detectCountry(lat, lon) {
   // territory (lat 3.75). Cameroon's bbox 1.7-13.1 / 8.5-16.2 catches
   // Malabo's (3.75, 8.77). EquatorialGuinea was listed first but its
   // northern lat was 2.35 — Malabo 3.75 was OUTSIDE. Expand
-  // EquatorialGuinea to 3.85 (covers Malabo) or restructure. Malabo's
-  // territory IS GQ — extend GQ.
-  if (lat >= 0.92 && lat <= 3.85 && lon >= 5.62 && lon <= 11.34) return 'EquatorialGuinea'
+  // EquatorialGuinea to 3.86 (covers Malabo's northern validation samples) or
+  // restructure. Malabo's territory IS GQ — extend GQ.
+  if (lat >= 0.92 && lat <= 3.86 && lon >= 5.62 && lon <= 11.34) return 'EquatorialGuinea'
   if (lat >= -3.96 && lat <= 2.32 && lon >= 8.70 && lon <= 14.50) return 'Gabon'
   // v1.7.5: DRCongo BEFORE RepublicOfTheCongo — Kinshasa CD (-4.44, 15.27)
   // and Luanda AO (-8.84, 13.29) — Luanda was matched by DRCongo's bbox
@@ -829,6 +829,7 @@ const COUNTRY_BBOX_TABLE = {
   Senegal:      [[12.3, 16.04, -17.6, -11.3]],
   Nigeria:      [[3.9, 14, 2.7, 14.7]],
   Cameroon:     [[1.7, 13.1, 8.5, 16.2]],
+  EquatorialGuinea: [[0.92, 3.86, 5.62, 11.34]],
   Brazil:       [[-33.75, 5.27, -73.99, -34.79]],
   Argentina:    [[-55.06, -21.78, -73.57, -53.65]],
   Paraguay:     [[-27.61, -19.29, -62.65, -54.26]],

--- a/test/detectLocation.test.js
+++ b/test/detectLocation.test.js
@@ -244,6 +244,22 @@ describe('detectLocation — Mawaqit institutional source', () => {
     expect(ferney.timezone).toBe('Europe/Paris')
   })
 
+  it('Strasbourg/Kehl Rhine seam keeps each city on its own country side', () => {
+    const strasbourg = detectLocation(48.5734, 7.7521)
+    expect(strasbourg.city).not.toBeNull()
+    expect(strasbourg.city.name).toBe('Strasbourg')
+    expect(strasbourg.city.countryISO).toBe('FR')
+    expect(strasbourg.country).toBe('France')
+    expect(strasbourg.timezone).toBe('Europe/Paris')
+
+    const kehl = detectLocation(48.5722, 7.8156)
+    expect(kehl.city).not.toBeNull()
+    expect(kehl.city.name).toBe('Kehl')
+    expect(kehl.city.countryISO).toBe('DE')
+    expect(kehl.country).toBe('Germany')
+    expect(kehl.timezone).toBe('Europe/Berlin')
+  })
+
   it('UAE WOF locality rows expand Abu Dhabi/Al Ain city provenance without touching Dubai/Sharjah/Ajman', () => {
     const rows = [
       ['Abu Dhabi', 24.4539, 54.3773, 24.20, 54.80],
@@ -512,6 +528,13 @@ describe('detectLocation — issue #47 regression', () => {
   it('Hanoi VN → country=Vietnam (was Laos)', () => {
     const loc = detectLocation(21.03, 105.85)
     expect(loc.country).toBe('Vietnam')
+  })
+
+  it('Malabo northern bbox sample → city=Malabo, country=EquatorialGuinea', () => {
+    const loc = detectLocation(3.8519, 8.7786)
+    expect(loc.city?.name).toBe('Malabo')
+    expect(loc.city?.countryISO).toBe('GQ')
+    expect(loc.country).toBe('EquatorialGuinea')
   })
 
   it('Asunción PY → country=Paraguay (was Argentina)', () => {

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -93,6 +93,8 @@ describe('city geometry source map', () => {
       ['Geneva|CH', 'wof:locality:101748445'],
       ['Annemasse|FR', 'wof:locality:101757307'],
       ['Ferney-Voltaire|FR', 'wof:locality:101753277'],
+      ['Strasbourg|FR', 'wof:locality:101751113'],
+      ['Kehl|DE', 'wof:locality:101753099'],
       ['Brazzaville|CG', 'wof:locality:421180023'],
       ['Kinshasa|CD', 'wof:locality:421166913'],
     ])
@@ -134,6 +136,8 @@ describe('city geometry source map', () => {
     expect(statusFor('Geneva|CH')).toBe('runtime-bbox-shipped')
     expect(statusFor('Annemasse|FR')).toBe('runtime-bbox-shipped')
     expect(statusFor('Ferney-Voltaire|FR')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Strasbourg|FR')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Kehl|DE')).toBe('runtime-bbox-shipped')
     expect(statusFor('Brazzaville|CG')).toBe('needs-clipping-review')
     expect(statusFor('Kinshasa|CD')).toBe('needs-clipping-review')
   })


### PR DESCRIPTION
## Summary
- Add `Kehl|DE` with a reviewed WOF locality bbox and clip `Strasbourg|FR` east of the Rhine overlap so Kehl coordinates no longer resolve to Strasbourg/France.
- Record the WOF source-map provenance for both Strasbourg and Kehl and add regression coverage for the cross-border seam.
- Extend Equatorial Guinea country bbox coverage to include Malabo northern validation samples exposed by the wider registry validator.

[positions: no-change-required] City bbox/provenance-only update; no region default, method dispatch, confidence grade, or institutional position changes.

Refs #118

## Validation
- `node scripts/build-city-registry.js`
- `npm run validate:registry` — 481 cities, 4,810 internal samples, 4,810 external samples, 0 fail-class issues
- `npx vitest run test/detectLocation.test.js test/geometrySourceMap.test.js` — 66/66
- `npm test` — 387/387
- `node scripts/audit-city-geometry.js --format json` — 41 source-map cities, 55 reported rows, 54 checked, 0 missing cache/geometry
- `npm run build:charts`
- `git diff --check`
- `npm pack --dry-run` — 140.9 kB packed / 516.8 kB unpacked
