### PR TITLE
Align Morocco geometry source statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Tightened the `Brazzaville|CG` / `Kinshasa|CD` Congo River seam with
   WOF-backed runtime cells so each capital's edge samples keep their own
   country/timezone without filling the river gap.
+- Aligned Morocco WOF-backed geometry source-map statuses with shipped runtime
+  bboxes, leaving OSM-only rows as audit candidates pending license review.
 
 ### Changed — documentation doctrine cleanup
 

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -38,9 +38,10 @@ The source map stores metadata and cache pointers only. The current seed covers
 Turkey large-city rows, 1 Detroit/Windsor border row, 3 Geneva border rows, 2
 Strasbourg/Kehl border rows, and 5 existing registry warning rows. It carries
 17 OSM relation rows plus 37 WOF
-rows across reviewed locality/county candidates. Berrechid, Settat, and Fes
-now have WOF locality candidates; Jerusalem intentionally remains without a
-geometry candidate until a human routing decision is available.
+rows across reviewed locality/county candidates. Morocco rows with WOF-backed
+runtime status are separated from OSM-only audit candidates; Jerusalem
+intentionally remains without a geometry candidate until a human routing
+decision is available.
 
 ```json
 {
@@ -218,6 +219,10 @@ from neighboring Morocco rows during `detectLocation()`'s smallest-match scan:
 - `Brazzaville|CG` and `Kinshasa|CD`: separated across the Congo River seam so
   Brazzaville's east edge and Kinshasa's south/east edges resolve to their own
   countries/timezones without filling the river gap.
+- Morocco WOF-backed runtime rows now have source-map status aligned with the
+  shipped registry bboxes: Rabat, Agadir, Berrechid, Settat, Fes, Sefrou,
+  Tangier, Nador, and Oujda. OSM-only rows remain audit candidates pending
+  license review.
 
 These are provenance/routing fixes only. They do not change prayer-time
 calculation math or imply that rectangles now encode municipal boundaries.

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -37,7 +37,7 @@
       "priority": ["phase-1-morocco", "habous", "rabat-metro"],
       "relatedAuthorityIds": { "habousVilleId": 1, "habousMatch": "direct" },
       "review": {
-        "status": "candidate",
+        "status": "runtime-bbox-shipped",
         "issue": 118,
         "notes": [
           "Morocco phase-1 row. Habous ID is prayer-time provenance, not geometry.",
@@ -63,7 +63,8 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate"
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["Runtime uses a clipped WOF-backed bbox to preserve distinct Rabat/Sale/Temara lookup cells."]
         }
       ]
     },
@@ -126,7 +127,7 @@
       "priority": ["phase-1-morocco", "habous", "agadir-metro"],
       "relatedAuthorityIds": { "habousVilleId": 117, "habousMatch": "direct" },
       "review": {
-        "status": "candidate",
+        "status": "runtime-bbox-shipped",
         "issue": 118,
         "notes": [
           "Agadir is the official Habous table used for Inezgane as nearest official city.",
@@ -152,7 +153,8 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate"
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["Runtime uses a clipped WOF-backed bbox to preserve distinct Agadir/Inezgane lookup cells."]
         }
       ]
     },
@@ -218,7 +220,7 @@
       "priority": ["phase-1-morocco", "habous", "casablanca-settat-cluster"],
       "relatedAuthorityIds": { "habousVilleId": 65, "habousMatch": "direct" },
       "review": {
-        "status": "candidate",
+        "status": "runtime-bbox-shipped",
         "issue": 118,
         "notes": ["2026-05-09: runtime bbox updated to reviewed WOF locality envelope."]
       },
@@ -231,7 +233,7 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate"
+          "reviewStatus": "runtime-bbox-shipped"
         }
       ]
     },
@@ -240,7 +242,7 @@
       "priority": ["phase-1-morocco", "habous", "casablanca-settat-cluster"],
       "relatedAuthorityIds": { "habousVilleId": 61, "habousMatch": "direct" },
       "review": {
-        "status": "candidate",
+        "status": "runtime-bbox-shipped",
         "issue": 118,
         "notes": ["2026-05-09: runtime bbox updated to reviewed WOF locality envelope."]
       },
@@ -253,7 +255,7 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate"
+          "reviewStatus": "runtime-bbox-shipped"
         }
       ]
     },
@@ -308,7 +310,7 @@
       "priority": ["phase-1-morocco", "habous", "fes-cluster"],
       "relatedAuthorityIds": { "habousVilleId": 82, "habousMatch": "direct" },
       "review": {
-        "status": "candidate",
+        "status": "runtime-bbox-shipped",
         "issue": 118,
         "notes": ["2026-05-09: runtime bbox updated to reviewed WOF locality envelope."]
       },
@@ -331,7 +333,7 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate"
+          "reviewStatus": "runtime-bbox-shipped"
         }
       ]
     },
@@ -358,7 +360,7 @@
       "priority": ["phase-1-morocco", "habous", "north-morocco-border"],
       "relatedAuthorityIds": { "habousVilleId": 14, "habousMatch": "direct" },
       "review": {
-        "status": "candidate",
+        "status": "runtime-bbox-shipped",
         "issue": 118,
         "notes": ["2026-05-09: runtime bbox updated to reviewed WOF locality envelope."]
       },
@@ -381,7 +383,7 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate"
+          "reviewStatus": "runtime-bbox-shipped"
         }
       ]
     },
@@ -408,7 +410,7 @@
       "priority": ["phase-1-morocco", "habous", "north-east-morocco-border"],
       "relatedAuthorityIds": { "habousVilleId": 39, "habousMatch": "direct" },
       "review": {
-        "status": "candidate",
+        "status": "runtime-bbox-shipped",
         "issue": 118,
         "notes": ["2026-05-09: runtime bbox updated to reviewed WOF locality envelope."]
       },
@@ -431,7 +433,7 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate"
+          "reviewStatus": "runtime-bbox-shipped"
         }
       ]
     },
@@ -440,7 +442,7 @@
       "priority": ["phase-1-morocco", "habous", "north-east-morocco-border"],
       "relatedAuthorityIds": { "habousVilleId": 31, "habousMatch": "direct" },
       "review": {
-        "status": "candidate",
+        "status": "runtime-bbox-shipped",
         "issue": 118,
         "notes": ["2026-05-09: runtime bbox updated to reviewed WOF locality envelope."]
       },
@@ -463,7 +465,7 @@
           "sourceConfidence": "high",
           "matchConfidence": "candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate"
+          "reviewStatus": "runtime-bbox-shipped"
         }
       ]
     },

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -76,7 +76,15 @@ describe('city geometry source map', () => {
     const expected = new Map([
       ['Basel|CH', 'wof:locality:101748459'],
       ['Mulhouse|FR', 'wof:locality:101749573'],
+      ['Rabat|MA', 'wof:locality:421190103'],
+      ['Agadir|MA', 'wof:locality:421170495'],
+      ['Berrechid|MA', 'wof:locality:1125988395'],
+      ['Settat|MA', 'wof:locality:421190099'],
       ['Fes|MA', 'wof:locality:421190143'],
+      ['Sefrou|MA', 'wof:locality:421190111'],
+      ['Tangier|MA', 'wof:locality:421190123'],
+      ['Nador|MA', 'wof:locality:421190085'],
+      ['Oujda|MA', 'wof:locality:421200921'],
       ['Abu Dhabi|AE', 'wof:locality:421179641'],
       ['Al Ain|AE', 'wof:locality:421168687'],
       ['Istanbul|TR', 'wof:locality:890460455'],
@@ -115,8 +123,16 @@ describe('city geometry source map', () => {
   it('tracks runtime-shipped and needs-clipping geometry outcomes separately', () => {
     expect(statusFor('Basel|CH')).toBe('runtime-bbox-shipped')
     expect(statusFor('Mulhouse|FR')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Rabat|MA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Agadir|MA')).toBe('runtime-bbox-shipped')
     expect(statusFor('Casablanca|MA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Berrechid|MA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Settat|MA')).toBe('runtime-bbox-shipped')
     expect(statusFor('Fes|MA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Sefrou|MA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Tangier|MA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Nador|MA')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Oujda|MA')).toBe('runtime-bbox-shipped')
     expect(statusFor('Abu Dhabi|AE')).toBe('runtime-bbox-shipped')
     expect(statusFor('Al Ain|AE')).toBe('runtime-bbox-shipped')
     expect(statusFor('Dubai|AE')).toBe('runtime-bbox-shipped')


### PR DESCRIPTION
## Summary
- Mark Morocco rows that already use reviewed WOF-backed runtime bboxes as `runtime-bbox-shipped` in the geometry source map.
- Keep OSM-only Morocco rows as `candidate` because OSM geometry remains audit-only pending license review.
- Extend source-map tests so shipped WOF Morocco rows are not silently downgraded again.

[positions: no-change-required] Geometry source-map/provenance-only update; no runtime bbox, region default, method dispatch, confidence grade, or institutional position changes.

Refs #118

## Validation
- `npx vitest run test/geometrySourceMap.test.js` — 8/8
- `npm test` — 388/388
- `node scripts/audit-city-geometry.js --format json` — 41 source-map cities, 55 reported rows, 54 checked, 0 missing cache/geometry
- `git diff --check`
- `npm pack --dry-run` — 141.2 kB packed / 517.4 kB unpacked
