### PR TITLE
docs(wiki): Gulf cluster + Egypt region-page cleanup (fajr#88)

### DIFF
--- a/knowledge/wiki/regions/bahrain.md
+++ b/knowledge/wiki/regions/bahrain.md
@@ -1,0 +1,56 @@
+# Bahrain — prayer-time conventions
+
+## Institutional reference bodies
+
+Bahrain is unusual in maintaining **two parallel awqaf administrations** along the sectarian Sunni/Shia divide — a structure documented in Bahraini law that recognises and serves both communities institutionally:
+
+- **Sunni Endowments Directorate (الإدارة العامة للأوقاف السنية)** — administers Sunni mosques and publishes the Sunni Awqaf Imsakiyya. URL: https://www.sunniaffairs.gov.bh
+- **Jaafari Endowments Directorate (الإدارة العامة للأوقاف الجعفرية)** — administers Twelver Shia mosques and ḥusayniyat, publishes the Jaafari Imsakiyya. URL: https://www.jawf.gov.bh
+- **Ministry of Justice, Islamic Affairs and Awqaf (وزارة العدل والشؤون الإسلامية والأوقاف)** — umbrella institutional reference. URL: https://www.moj.gov.bh
+
+**Population served:** ~1.1M Muslims (~73% of Bahrain's ~1.5M total). **Twelver Shia majority among nationals** (~60-70% of Bahraini citizens), Sunni minority among nationals (~30%); the overall Muslim breakdown is closer to 50/50 when expat Sunni population is included. Citation: Pew 2015, Bahraini government census reporting, Toby Matthiesen.
+
+**Madhab:** Multi-tradition. Twelver Shia Jaafari (citizen-majority) + Sunni Maliki/Hanbali (citizen-minority + expat-majority). Asr convention is Standard (1× shadow) institutionally across both, though Twelver Shia jurisprudence on Fajr/Maghrib waiting boundaries differs from Sunni convention.
+
+## Calculation method (as implemented in fajr)
+
+- **adhan.js method:** dispatches to `Kuwait` (`CalculationMethod.Kuwait()`) via fall-through in `selectMethod()` — corresponds to **Aladhan API method 8**
+- **Fajr angle:** 18° (Kuwait Awqaf institutional default; matches Bahrain's Sunni Awqaf publication closely)
+- **Isha angle:** 17.5° (Kuwait Awqaf default; Bahrain's Sunni Awqaf does not publish a distinct angle pair)
+- **Asr school:** Standard (1× shadow)
+- **Method offsets:** none
+- **Classification:** 🟡→🟢 (Approaching established — preset is regional-cluster default; bahrain-specific institutional verification against Sunni + Jaafari Awqaf publications is open follow-up)
+
+## Why this method
+
+Bahrain has no canonical national prayer-time methodology distinct from the lower-Gulf cluster. fajr's dispatch follows the Kuwait Ministry of Awqaf preset (18°/17.5°/Standard) which is the **empirical Gulf default for lower-Gulf countries without their own national preset**. UAE and Qatar override with their own institutional presets; Bahrain, Oman, and Yemen fall through to the Kuwait preset.
+
+The **Asr school choice** uses the v1.7.22 metadata split:
+- `location.asrConvention` returns `'standard'` (both Sunni Maliki/Hanbali and Twelver Shia Jaafari communities use Standard 1× shadow Asr)
+- `applied.asrSchool` returns `'standard'`
+
+Convention and applied formula align — no override needed for typical Bahraini users.
+
+## Known points of ikhtilaf within the country
+
+- **Sectarian Jaafari/Sunni split is the defining ikhtilaf** — Bahrain is one of the few states where the institutional Awqaf is explicitly structured along this divide, with separate Sunni and Jaafari Imsakiyya publications. Numerically, both communities use Standard Asr; the Twelver Shia Jaafari convention treats Maghrib boundary slightly differently (later, by ~5-10 min, to ensure full sunset) and Fajr boundary slightly differently (the Sistani-aligned Jaafari Imsakiyya). fajr does not currently surface this as per-city `altMethods` for Bahraini coordinates — open follow-up given the institutional ground-truth split.
+- **The Kuwait dispatch is a Sunni-aligned proxy.** Twelver Shia users in Bahrain who follow Jaafari Imsakiyya may want a Tehran/Sistani-aligned dispatch instead. Override pattern: `method: 'Tehran'` returns the Tehran 17.7°/14° preset, which is closer to Sistani convention than the Kuwait fall-through.
+
+## City-level overrides
+
+None at city level. Manama, Riffa, Muharraq, Hamad Town, Isa Town, and all major Bahraini coordinates use the Kuwait fall-through.
+
+## Open questions / outstanding work
+
+- **Bahrain Sunni Awqaf live fixture** — fajr currently has no Bahrain-specific institutional fixture; an empirical fetcher targeting https://www.sunniaffairs.gov.bh Imsakiyya or a single-day Sunni Awqaf scrape would confirm the Kuwait dispatch matches Bahrain's published Sunni Awqaf publication to within fajr's tolerance bands.
+- **Bahrain Jaafari Awqaf live fixture** — separate fetcher for https://www.jawf.gov.bh would surface the Twelver Shia Jaafari convention as a real second-source ground truth, enabling per-community ground-truth for Bahrain — the only country in fajr's coverage where both Sunni and Shia institutional awqaf publish at official-state level.
+- **Per-community `altMethods`** — once both fixtures are available, Bahraini coordinates could surface both Sunni and Jaafari as `altMethods` chips in `notes[]`, matching the institutional ground-truth structure.
+
+## Sources
+
+- Bahrain Sunni Endowments Directorate: https://www.sunniaffairs.gov.bh
+- Bahrain Jaafari Endowments Directorate: https://www.jawf.gov.bh
+- Bahrain Ministry of Justice, Islamic Affairs and Awqaf: https://www.moj.gov.bh
+- Aladhan method 8 (Kuwait — applied to Bahrain via dispatch fall-through): https://aladhan.com/calculation-methods
+- Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1266)
+- Demographic citations: Pew 2015, Matthiesen "The Other Saudis: Shiism, Dissent and Sectarianism" (2014), Bahraini government 2010 census

--- a/knowledge/wiki/regions/bahrain.md
+++ b/knowledge/wiki/regions/bahrain.md
@@ -10,31 +10,31 @@ Bahrain is unusual in maintaining **two parallel awqaf administrations** along t
 
 **Population served:** ~1.1M Muslims (~73% of Bahrain's ~1.5M total). **Twelver Shia majority among nationals** (~60-70% of Bahraini citizens), Sunni minority among nationals (~30%); the overall Muslim breakdown is closer to 50/50 when expat Sunni population is included. Citation: Pew 2015, Bahraini government census reporting, Toby Matthiesen.
 
-**Madhab:** Multi-tradition. Twelver Shia Jaafari (citizen-majority) + Sunni Maliki/Hanbali (citizen-minority + expat-majority). Asr convention is Standard (1× shadow) institutionally across both, though Twelver Shia jurisprudence on Fajr/Maghrib waiting boundaries differs from Sunni convention.
+**Madhab:** Multi-tradition. Twelver Shia Jaafari (citizen-majority) + Sunni Maliki/Hanbali (citizen-minority + expat-majority). Institutional publications use Standard (1× shadow) Asr; this is an Asr-convention statement, not a claim that all communities share one legal madhhab. Twelver Shia jurisprudence on Fajr/Maghrib waiting boundaries differs from Sunni convention.
 
 ## Calculation method (as implemented in fajr)
 
-- **adhan.js method:** dispatches to `Kuwait` (`CalculationMethod.Kuwait()`) via fall-through in `selectMethod()` — corresponds to **Aladhan API method 8**
-- **Fajr angle:** 18° (Kuwait Awqaf institutional default; matches Bahrain's Sunni Awqaf publication closely)
+- **adhan.js method:** dispatches to `Kuwait` (`CalculationMethod.Kuwait()`) via fall-through in `selectMethod()` — corresponds to **Aladhan API method 9**
+- **Fajr angle:** 18° (Kuwait Awqaf institutional default; used as a hypothesised proxy pending a Bahrain Sunni Awqaf fixture)
 - **Isha angle:** 17.5° (Kuwait Awqaf default; Bahrain's Sunni Awqaf does not publish a distinct angle pair)
 - **Asr school:** Standard (1× shadow)
 - **Method offsets:** none
-- **Classification:** 🟡→🟢 (Approaching established — preset is regional-cluster default; bahrain-specific institutional verification against Sunni + Jaafari Awqaf publications is open follow-up)
+- **Classification:** 🟡 Limited precedent — current fajr dispatch uses the Kuwait institutional preset as a regional proxy; Bahrain-specific institutional fixtures are still required before treating this as approaching established.
 
 ## Why this method
 
-Bahrain has no canonical national prayer-time methodology distinct from the lower-Gulf cluster. fajr's dispatch follows the Kuwait Ministry of Awqaf preset (18°/17.5°/Standard) which is the **empirical Gulf default for lower-Gulf countries without their own national preset**. UAE and Qatar override with their own institutional presets; Bahrain, Oman, and Yemen fall through to the Kuwait preset.
+Bahrain has no verified national prayer-time fixture in fajr yet. The current dispatch follows the Kuwait Ministry of Awqaf preset (18°/17.5°/Standard) as a **regional fallback pending country-specific institutional validation**. UAE and Qatar override with their own institutional presets; Bahrain, Oman, and Yemen fall through to the Kuwait preset.
 
 The **Asr school choice** uses the v1.7.22 metadata split:
-- `location.asrConvention` returns `'standard'` (both Sunni Maliki/Hanbali and Twelver Shia Jaafari communities use Standard 1× shadow Asr)
+- `location.asrConvention` returns `'standard'` (the current country publication/default metadata uses Standard 1× shadow Asr)
 - `applied.asrSchool` returns `'standard'`
 
-Convention and applied formula align — no override needed for typical Bahraini users.
+Convention and applied formula align for the current country-default dispatch. Users following a different local publication should use an explicit override once their source is identified.
 
 ## Known points of ikhtilaf within the country
 
 - **Sectarian Jaafari/Sunni split is the defining ikhtilaf** — Bahrain is one of the few states where the institutional Awqaf is explicitly structured along this divide, with separate Sunni and Jaafari Imsakiyya publications. Numerically, both communities use Standard Asr; the Twelver Shia Jaafari convention treats Maghrib boundary slightly differently (later, by ~5-10 min, to ensure full sunset) and Fajr boundary slightly differently (the Sistani-aligned Jaafari Imsakiyya). fajr does not currently surface this as per-city `altMethods` for Bahraini coordinates — open follow-up given the institutional ground-truth split.
-- **The Kuwait dispatch is a Sunni-aligned proxy.** Twelver Shia users in Bahrain who follow Jaafari Imsakiyya may want a Tehran/Sistani-aligned dispatch instead. Override pattern: `method: 'Tehran'` returns the Tehran 17.7°/14° preset, which is closer to Sistani convention than the Kuwait fall-through.
+- **The Kuwait dispatch is a Sunni-aligned proxy.** Pending a Bahrain Jaafari Awqaf fixture, Tehran/Sistani-style methods are only a user-selected proxy for some Jaafari practice, not an established Bahraini institutional mapping.
 
 ## City-level overrides
 
@@ -42,7 +42,7 @@ None at city level. Manama, Riffa, Muharraq, Hamad Town, Isa Town, and all major
 
 ## Open questions / outstanding work
 
-- **Bahrain Sunni Awqaf live fixture** — fajr currently has no Bahrain-specific institutional fixture; an empirical fetcher targeting https://www.sunniaffairs.gov.bh Imsakiyya or a single-day Sunni Awqaf scrape would confirm the Kuwait dispatch matches Bahrain's published Sunni Awqaf publication to within fajr's tolerance bands.
+- **Bahrain Sunni Awqaf live fixture** — fajr currently has no Bahrain-specific institutional fixture; an empirical fetcher targeting https://www.sunniaffairs.gov.bh Imsakiyya or a single-day Sunni Awqaf scrape would compare the Kuwait dispatch against Bahrain's published Sunni Awqaf publication.
 - **Bahrain Jaafari Awqaf live fixture** — separate fetcher for https://www.jawf.gov.bh would surface the Twelver Shia Jaafari convention as a real second-source ground truth, enabling per-community ground-truth for Bahrain — the only country in fajr's coverage where both Sunni and Shia institutional awqaf publish at official-state level.
 - **Per-community `altMethods`** — once both fixtures are available, Bahraini coordinates could surface both Sunni and Jaafari as `altMethods` chips in `notes[]`, matching the institutional ground-truth structure.
 
@@ -51,6 +51,6 @@ None at city level. Manama, Riffa, Muharraq, Hamad Town, Isa Town, and all major
 - Bahrain Sunni Endowments Directorate: https://www.sunniaffairs.gov.bh
 - Bahrain Jaafari Endowments Directorate: https://www.jawf.gov.bh
 - Bahrain Ministry of Justice, Islamic Affairs and Awqaf: https://www.moj.gov.bh
-- Aladhan method 8 (Kuwait — applied to Bahrain via dispatch fall-through): https://aladhan.com/calculation-methods
+- Aladhan method 9 (Kuwait — applied to Bahrain via dispatch fall-through): https://aladhan.com/calculation-methods
 - Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1266)
 - Demographic citations: Pew 2015, Matthiesen "The Other Saudis: Shiism, Dissent and Sectarianism" (2014), Bahraini government 2010 census

--- a/knowledge/wiki/regions/egypt.md
+++ b/knowledge/wiki/regions/egypt.md
@@ -6,14 +6,14 @@
 - **Secondary authority:** Dar al-Ifta al-Misriyya (دار الإفتاء المصرية) — the state fatwa body — and the Ministry of Awqaf (وزارة الأوقاف) for prayer-time governance.
 - **URL:** EGSA: https://www.esa.gov.eg/ ; Dar al-Ifta: https://www.dar-alifta.org/ ; Awqaf: https://www.awkaf.gov.eg/
 - **Population served:** ~98M Muslims (~94% of Egypt's ~104M total — Sunni-majority with a Coptic Christian minority; Egypt is a religiously identifying-Muslim state with Islam as the state religion per Article 2 of the constitution).
-- **Madhab:** Sunni Shafi'i historically dominant; Hanafi institutionally dominant since the Ottoman period (Al-Azhar's official madhab in administration, though Al-Azhar teaches all four Sunni madhabs); Maliki and Hanbali minorities present.
+- **Madhab:** Sunni Shafi'i historically dominant; Hanafi institutionally dominant since the Ottoman period (Al-Azhar's official madhhab in administration, though Al-Azhar teaches all four Sunni madhhabs); Maliki and Hanbali minorities present.
 
 ## Calculation method (as implemented in fajr)
 
 - **adhan.js method:** `Egyptian` (`CalculationMethod.Egyptian()`) — corresponds to **Aladhan API method 5**
 - **Fajr angle:** 19.5°
 - **Isha angle:** 17.5°
-- **Asr school:** Standard (Shafi'i — 1× shadow)
+- **Asr school:** Standard (1× shadow)
 - **Special offsets:** none
 - **Classification:** 🟢 Established (institutional preset; EGSA is the named originating authority of the angle pair globally adopted as the "Egyptian" convention)
 
@@ -22,10 +22,10 @@
 The 19.5°/17.5° pair is the **EGSA convention**, adopted from Egypt's national surveying authority and used historically by EGSA's published *Taqwim* (calendar) and the Egyptian Awqaf Ministry's official timetables. The angle pair is named "Egyptian" in adhan.js, Aladhan, and PrayTimes.org because EGSA is the originating institution — making the alignment between fajr's dispatch and Egypt's published reality direct.
 
 The **Asr school choice** uses the v1.7.22 metadata split:
-- `location.asrConvention` returns `'standard'` (Egyptian Awqaf Ministry timetables historically use Shafi'i / 1× shadow; the institutional convention is Standard despite Al-Azhar's administrative Hanafi affiliation)
+- `location.asrConvention` returns `'standard'` (Egyptian institutional publications use Standard / 1× shadow Asr despite Al-Azhar's administrative Hanafi history)
 - `applied.asrSchool` returns `'standard'`
 
-The Asr-school choice — Shafi'i (Standard, 1× shadow) — is the historical Egyptian Awqaf institutional convention, reflecting the broader Shafi'i-historical population pattern. Al-Azhar's administrative madhab is Hanafi, but Al-Azhar teaches all four Sunni madhabs and its Awqaf-Ministry-published timetables use Standard Asr. Hanafi-observant individuals who want 2× shadow Asr override explicitly via `madhab: 'hanafi'`. The country-default `asrConvention` correctly surfaces "Egypt is institutionally Shafi'i-Standard for prayer-time publication" without silently mutating the calculation.
+The Asr-school choice — Standard (1× shadow) — is the Egyptian institutional publication convention. Al-Azhar's administrative madhhab is Hanafi, but Al-Azhar teaches all four Sunni madhhabs and Awqaf-Ministry-published timetables use Standard Asr. Hanafi-observant individuals who want 2× shadow Asr override explicitly via `override.asrConvention: 'hanafi'`. The country-default `asrConvention` should be read as Asr shadow-factor metadata, not as a full legal-madhhab label.
 
 ## Institutional ground truth in fajr's eval corpus
 
@@ -34,11 +34,11 @@ The Asr-school choice — Shafi'i (Standard, 1× shadow) — is the historical E
 - **Coverage:** 15 cities × 1 day (initial single-day snapshot; daily snapshots accumulating via `.github/workflows/egypt-esa-snapshot.yml`)
 - **Agreement:** fajr matches the ESA institutional publication at **WMAE 0.68 min** across Fajr/Shuruq/Dhuhr/Asr/Maghrib/Isha — sub-minute agreement validates the `Egyptian` preset dispatch.
 
-This makes Egypt one of the few countries with **institutional-direct ground truth** in fajr's eval corpus (alongside Diyanet for Türkiye, KEMENAG for Indonesia, JAKIM for Malaysia, MUIS for Singapore, Habous for Morocco). Per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria), this lifts Egypt's confidence grade.
+This makes Egypt one of the few countries with **institutional-direct ground truth** in fajr's eval corpus (alongside Diyanet for Türkiye, KEMENAG for Indonesia, JAKIM for Malaysia, MUIS for Singapore, Habous for Morocco). Per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria), this supports future confidence promotion once multi-day evidence accumulates and `docs/positions.md` / promotion logs are updated.
 
 ## Known points of ikhtilaf within the country
 
-- **Asr school: Shafi'i vs Hanafi.** Egypt's Awqaf Ministry timetables use Shafi'i (1× shadow). Hanafi-administered institutions (some Al-Azhar-affiliated functions, Hanafi-affiliated mosques in Cairo's older quarters) may use Hanafi (2× shadow) in their internal scheduling. Differences run ~30–60 min in Asr. fajr's default is Shafi'i (Standard); Hanafi users override with `madhab: 'hanafi'`.
+- **Asr convention: Standard vs Hanafi.** Egypt's Awqaf Ministry timetables use Standard (1× shadow). Hanafi-administered institutions (some Al-Azhar-affiliated functions, Hanafi-affiliated mosques in Cairo's older quarters) may use Hanafi (2× shadow) in their internal scheduling. Differences run ~30–60 min in Asr. fajr's default is Standard; Hanafi users override with `override.asrConvention: 'hanafi'`.
 - **No Egyptian Sufi or Shia internal differences** at the institutional-publishing level — Egypt is institutionally monolithic on prayer-time methodology.
 - **EGSA vs Awqaf Ministry vs Dar al-Ifta:** all three Egyptian institutions converge on the 19.5°/17.5° angle pair + Standard Asr; the institutional-precedent for the convention is therefore strongly multi-source institutional, not merely calendrical.
 
@@ -48,9 +48,9 @@ None at city level for Egypt. The country-default `Egyptian` dispatch handles Ca
 
 ## Open questions / outstanding work
 
-- **Daily ESA snapshots accumulating** — `.github/workflows/egypt-esa-snapshot.yml` captures fresh ESA times daily into `fixtures/egypt-esa/daily/` via review PRs. Once accumulated to ≥30 days × 15 cities (~450 rows), promotion from single-day to multi-day institutional fixture lifts Egypt's confidence grade from B → A per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
+- **Daily ESA snapshots accumulating** — `.github/workflows/egypt-esa-snapshot.yml` captures fresh ESA times daily into `fixtures/egypt-esa/daily/` via review PRs. Once accumulated to ≥30 days × 15 cities (~450 rows), the multi-day institutional fixture would support future promotion per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria) after the position registry and promotion log are updated.
 - **Provincial granularity** — Egypt's 27 governorates may publish slight per-governorate adjustments via the Awqaf Ministry's regional structures. ESA's single 15-city fixture covers the major governorate capitals; per-governorate variation is not yet surfaced.
-- **Hanafi-Asr `notes[]` advisory** — for Egyptian coordinates, a `notes[]` advisory could surface the Shafi'i-vs-Hanafi Asr ikhtilaf with the explicit recommendation that Hanafi users override. Open follow-up; analogous to the Türkiye Hanafi-Asr metadata pattern.
+- **Asr-convention `notes[]` advisory** — for Egyptian coordinates, a `notes[]` advisory could surface the Standard-vs-Hanafi Asr ikhtilaf with the explicit recommendation that Hanafi users override. Open follow-up; analogous to the Türkiye Hanafi-Asr metadata pattern.
 - **Pre-2014 EGSA tables vs post-2014 administrative restructuring** — the EGSA convention is empirically stable but the institutional structure of the Awqaf Ministry has shifted post-2014; documenting the institutional continuity is open follow-up.
 
 ## Sources

--- a/knowledge/wiki/regions/egypt.md
+++ b/knowledge/wiki/regions/egypt.md
@@ -1,6 +1,7 @@
 # Egypt — prayer-time conventions
 
 ## Institutional reference body
+
 - **Name:** Egyptian General Authority of Survey (EGSA / Hay'at al-Misaha al-Misriyya, الهيئة المصرية العامة للمساحة)
 - **Secondary authority:** Dar al-Ifta al-Misriyya (دار الإفتاء المصرية) — the state fatwa body — and the Ministry of Awqaf (وزارة الأوقاف) for prayer-time governance.
 - **URL:** EGSA: https://www.esa.gov.eg/ ; Dar al-Ifta: https://www.dar-alifta.org/ ; Awqaf: https://www.awkaf.gov.eg/
@@ -8,6 +9,7 @@
 - **Madhab:** Sunni Shafi'i historically dominant; Hanafi institutionally dominant since the Ottoman period (Al-Azhar's official madhab in administration, though Al-Azhar teaches all four Sunni madhabs); Maliki and Hanbali minorities present.
 
 ## Calculation method (as implemented in fajr)
+
 - **adhan.js method:** `Egyptian` (`CalculationMethod.Egyptian()`) — corresponds to **Aladhan API method 5**
 - **Fajr angle:** 19.5°
 - **Isha angle:** 17.5°
@@ -16,20 +18,53 @@
 - **Classification:** 🟢 Established (institutional preset; EGSA is the named originating authority of the angle pair globally adopted as the "Egyptian" convention)
 
 ## Why this method
+
 The 19.5°/17.5° pair is the **EGSA convention**, adopted from Egypt's national surveying authority and used historically by EGSA's published *Taqwim* (calendar) and the Egyptian Awqaf Ministry's official timetables. The angle pair is named "Egyptian" in adhan.js, Aladhan, and PrayTimes.org because EGSA is the originating institution — making the alignment between fajr's dispatch and Egypt's published reality direct.
 
-The Asr school choice is **Shafi'i (Standard)** — although Al-Azhar's administrative madhab is Hanafi, the Egyptian Awqaf Ministry's published timetables historically use Shafi'i (Standard) Asr (1× shadow), reflecting the broader Shafi'i-historical population pattern. This is an open point of internal review; some Egyptian community-level publications use Hanafi Asr (e.g. for Hanafi-affiliated mosques in Cairo's older quarters). For now fajr follows the institutional convention of EGSA + Awqaf Ministry timetables.
+The **Asr school choice** uses the v1.7.22 metadata split:
+- `location.asrConvention` returns `'standard'` (Egyptian Awqaf Ministry timetables historically use Shafi'i / 1× shadow; the institutional convention is Standard despite Al-Azhar's administrative Hanafi affiliation)
+- `applied.asrSchool` returns `'standard'`
+
+The Asr-school choice — Shafi'i (Standard, 1× shadow) — is the historical Egyptian Awqaf institutional convention, reflecting the broader Shafi'i-historical population pattern. Al-Azhar's administrative madhab is Hanafi, but Al-Azhar teaches all four Sunni madhabs and its Awqaf-Ministry-published timetables use Standard Asr. Hanafi-observant individuals who want 2× shadow Asr override explicitly via `madhab: 'hanafi'`. The country-default `asrConvention` correctly surfaces "Egypt is institutionally Shafi'i-Standard for prayer-time publication" without silently mutating the calculation.
+
+## Institutional ground truth in fajr's eval corpus
+
+**v1.8.1 update (2026-05-14):** fajr now has a **real Egyptian General Authority of Survey institutional fixture** in the eval corpus, captured directly from https://www.esa.gov.eg/ via the server-side-rendered prayer-time portal. The fetcher is at `scripts/fetch-egypt-esa.js`; the fixture at `eval/data/test/egypt-esa.json`.
+
+- **Coverage:** 15 cities × 1 day (initial single-day snapshot; daily snapshots accumulating via `.github/workflows/egypt-esa-snapshot.yml`)
+- **Agreement:** fajr matches the ESA institutional publication at **WMAE 0.68 min** across Fajr/Shuruq/Dhuhr/Asr/Maghrib/Isha — sub-minute agreement validates the `Egyptian` preset dispatch.
+
+This makes Egypt one of the few countries with **institutional-direct ground truth** in fajr's eval corpus (alongside Diyanet for Türkiye, KEMENAG for Indonesia, JAKIM for Malaysia, MUIS for Singapore, Habous for Morocco). Per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria), this lifts Egypt's confidence grade.
 
 ## Known points of ikhtilaf within the country
-- **Asr school: Shafi'i vs Hanafi.** Egypt's Awqaf Ministry timetables use Shafi'i (1× shadow). Hanafi-administered institutions (some Al-Azhar-affiliated functions) may use Hanafi (2× shadow) in their internal scheduling. Differences run ~30–60 min in Asr. fajr's default is Shafi'i; Hanafi users can override with `madhab: 'hanafi'`.
-- **No Egyptian Sufi or Shia internal differences** at the institutional-publishing level.
+
+- **Asr school: Shafi'i vs Hanafi.** Egypt's Awqaf Ministry timetables use Shafi'i (1× shadow). Hanafi-administered institutions (some Al-Azhar-affiliated functions, Hanafi-affiliated mosques in Cairo's older quarters) may use Hanafi (2× shadow) in their internal scheduling. Differences run ~30–60 min in Asr. fajr's default is Shafi'i (Standard); Hanafi users override with `madhab: 'hanafi'`.
+- **No Egyptian Sufi or Shia internal differences** at the institutional-publishing level — Egypt is institutionally monolithic on prayer-time methodology.
+- **EGSA vs Awqaf Ministry vs Dar al-Ifta:** all three Egyptian institutions converge on the 19.5°/17.5° angle pair + Standard Asr; the institutional-precedent for the convention is therefore strongly multi-source institutional, not merely calendrical.
+
+## City-level overrides
+
+None at city level for Egypt. The country-default `Egyptian` dispatch handles Cairo, Alexandria, Giza, Shubra El-Kheima, Port Said, Suez, Mansoura, Tanta, and all major Egyptian coordinates correctly per the v1.8.1 ESA fixture's 15-city agreement.
+
+## Open questions / outstanding work
+
+- **Daily ESA snapshots accumulating** — `.github/workflows/egypt-esa-snapshot.yml` captures fresh ESA times daily into `fixtures/egypt-esa/daily/` via review PRs. Once accumulated to ≥30 days × 15 cities (~450 rows), promotion from single-day to multi-day institutional fixture lifts Egypt's confidence grade from B → A per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
+- **Provincial granularity** — Egypt's 27 governorates may publish slight per-governorate adjustments via the Awqaf Ministry's regional structures. ESA's single 15-city fixture covers the major governorate capitals; per-governorate variation is not yet surfaced.
+- **Hanafi-Asr `notes[]` advisory** — for Egyptian coordinates, a `notes[]` advisory could surface the Shafi'i-vs-Hanafi Asr ikhtilaf with the explicit recommendation that Hanafi users override. Open follow-up; analogous to the Türkiye Hanafi-Asr metadata pattern.
+- **Pre-2014 EGSA tables vs post-2014 administrative restructuring** — the EGSA convention is empirically stable but the institutional structure of the Awqaf Ministry has shifted post-2014; documenting the institutional continuity is open follow-up.
 
 ## Sources
+
 - Egyptian General Authority of Survey: https://www.esa.gov.eg/
 - Dar al-Ifta al-Misriyya: https://www.dar-alifta.org/
 - Egyptian Ministry of Awqaf: https://www.awkaf.gov.eg/
 - Aladhan API method 5 (`Egyptian`): https://aladhan.com/calculation-methods
 - adhan.js `CalculationMethod.Egyptian()` source
+- ESA institutional fixture (v1.8.1): `eval/data/test/egypt-esa.json`
+- Daily ESA snapshot workflow: `.github/workflows/egypt-esa-snapshot.yml`
+- ESA fetcher (v1.8.1): `scripts/fetch-egypt-esa.js`
 
 ## Last reviewed
+
+- 2026-05-14 by fajr-claude (deepening + v1.8.1 ESA institutional fixture annotation)
 - 2026-05-03 by fajr-agent (initial creation per v1.7.9 docs regen sweep — closing the gap flagged in #57 audit)

--- a/knowledge/wiki/regions/kuwait.md
+++ b/knowledge/wiki/regions/kuwait.md
@@ -5,28 +5,28 @@
 - **Name:** Ministry of Awqaf and Islamic Affairs (وزارة الأوقاف والشؤون الإسلامية)
 - **URL:** https://www.awqaf.gov.kw ; published prayer times via Kuwait Awqaf timetables; data feed channels include the al-Mosaller (المصلي) public app
 - **Population served:** ~3M Muslims (~75% of Kuwait's ~4M total — Kuwait's heavy expat population is largely Muslim too, particularly South Asian Sunni, Egyptian/Syrian Sunni, and Iranian/Iraqi Shia)
-- **Madhab:** Kuwait is Sunni-majority overall (~70% of citizens; Maliki + Hanafi + Shafi'i + Hanbali represented institutionally without one dominant), with a substantial Twelver Shia minority (~30% of citizens, concentrated in Kuwait City and Ahmadi). Awqaf is structured as Sunni-administered; Shia communities run their own ḥusayniyat and madrasas. Asr convention is Standard (1× shadow) across both populations institutionally.
+- **Madhab:** Kuwait is Sunni-majority overall (~70% of citizens; Maliki + Hanafi + Shafi'i + Hanbali represented institutionally without one dominant), with a substantial Twelver Shia minority (~30% of citizens, concentrated in Kuwait City and Ahmadi). Awqaf is structured as Sunni-administered; Shia communities run their own husayniyat and madrasas. The state publication uses Standard (1× shadow) Asr; that is an institutional timetable convention, not a claim that every Kuwaiti legal-madhhab community follows Standard Asr privately.
 
 ## Calculation method (as implemented in fajr)
 
-- **adhan.js method:** `Kuwait` (`CalculationMethod.Kuwait()`) — corresponds to **Aladhan API method 8**
+- **adhan.js method:** `Kuwait` (`CalculationMethod.Kuwait()`) — corresponds to **Aladhan API method 9**
 - **Fajr angle:** 18° (Kuwait Awqaf institutional convention)
 - **Isha angle:** 17.5° (Kuwait Awqaf institutional convention)
-- **Asr school:** Standard (1× shadow) — matches both Sunni (Maliki/Shafi'i/Hanbali) and Twelver Shia conventions; only Hanafi calls for 2× shadow and Kuwait's Hanafi citizenry follows the institutional Standard publication.
-- **Method offsets:** none institutional; the adhan.js Kuwait preset matches Kuwait Awqaf's published times within fajr's tolerance bands.
+- **Asr school:** Standard (1× shadow) — matches the institutional timetable publication. Hanafi users who follow 2× shadow Asr should override explicitly.
+- **Method offsets:** none in the preset. fajr does not yet carry a Kuwait Awqaf fixture, so this is an institutional-preset dispatch rather than an empirical fixture-backed claim.
 - **Classification:** 🟢 Established (institutional preset; Kuwait Awqaf is the named originating institution; the preset is widely deployed across the lower Gulf as the regional default)
 
 ## Why this method
 
-The 18°/17.5° angle pair is the **Kuwait Ministry of Awqaf institutional convention**, used in Kuwait's published Imsakiyya and the al-Mosaller official app data. The Aladhan API's method 8 is named "Kuwait" because Awqaf is the named originating institution.
+The 18°/17.5° angle pair is the **Kuwait Ministry of Awqaf institutional convention**, used in Kuwait's published Imsakiyya and the al-Mosaller official app data. The Aladhan API's method 9 is named "Kuwait" because Awqaf is the named originating institution.
 
-The Kuwait preset is also the **regional default for Bahrain, Oman, and Yemen** in fajr (via fall-through in `selectMethod()`), reflecting the empirical observation that the lower Gulf countries without their own national preset follow Kuwait's published angle pair closely enough to share the dispatch. UAE and Qatar have their own institutional presets (Umm al-Qura and Qatar Calendar House respectively) and override the fall-through.
+The Kuwait preset is also the **current proxy default for Bahrain, Oman, and Yemen** in fajr (via fall-through in `selectMethod()`). This is a conservative lower-Gulf fallback where country-specific fixtures are not yet present, not a claim of country-specific empirical validation for those states. UAE and Qatar have their own institutional presets (Umm al-Qura and Qatar Calendar House respectively) and override the fall-through.
 
 The **Asr school choice** uses the v1.7.22 metadata split:
-- `location.asrConvention` returns `'standard'` (Kuwait's institutional Sunni + Shia conventions both use Standard Asr)
+- `location.asrConvention` returns `'standard'` (Kuwait's institutional publication uses Standard Asr)
 - `applied.asrSchool` returns `'standard'`
 
-Convention and applied formula align — no override needed for typical Kuwaiti users. Hanafi users who want 2× shadow Asr override explicitly via `madhab: 'hanafi'`.
+Convention and applied formula align for the state-published timetable. Hanafi users who want 2× shadow Asr override explicitly via `override.asrConvention: 'hanafi'`.
 
 ## Known points of ikhtilaf within the country
 
@@ -40,12 +40,12 @@ None at city level for Kuwait. The country-default Kuwait dispatch handles Kuwai
 
 ## Open questions / outstanding work
 
-- **Live Awqaf fixture** — fajr currently has no Kuwait-specific institutional fixture in the eval corpus. Acquiring an Awqaf-direct fetcher (al-Mosaller API or scraped daily Imsakiyya from awqaf.gov.kw) would lift Kuwait from 🟡→🟢 to 🟢 with empirical backing and grade B → A per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
+- **Live Awqaf fixture** — fajr currently has no Kuwait-specific institutional fixture in the eval corpus. Acquiring an Awqaf-direct fetcher (al-Mosaller API or scraped daily Imsakiyya from awqaf.gov.kw) would turn the current institutional-preset dispatch into an institutionally verified, empirical grade-A candidate per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
 - **Shia altMethods surfacing** — Sistani-aligned Imsakiyya for the ~30% Twelver Shia citizenry could be exposed as a `notes[]` chip for Kuwait City coordinates, analogous to the Saudi Eastern Province pattern.
 
 ## Sources
 
 - Kuwait Ministry of Awqaf and Islamic Affairs: https://www.awqaf.gov.kw
-- Aladhan method 8 (Kuwait): https://aladhan.com/calculation-methods
+- Aladhan method 9 (Kuwait): https://aladhan.com/calculation-methods
 - adhan.js Kuwait preset: https://github.com/batoulapps/adhan-js
 - Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1265)

--- a/knowledge/wiki/regions/kuwait.md
+++ b/knowledge/wiki/regions/kuwait.md
@@ -1,0 +1,51 @@
+# Kuwait — prayer-time conventions
+
+## Institutional reference body
+
+- **Name:** Ministry of Awqaf and Islamic Affairs (وزارة الأوقاف والشؤون الإسلامية)
+- **URL:** https://www.awqaf.gov.kw ; published prayer times via Kuwait Awqaf timetables; data feed channels include the al-Mosaller (المصلي) public app
+- **Population served:** ~3M Muslims (~75% of Kuwait's ~4M total — Kuwait's heavy expat population is largely Muslim too, particularly South Asian Sunni, Egyptian/Syrian Sunni, and Iranian/Iraqi Shia)
+- **Madhab:** Kuwait is Sunni-majority overall (~70% of citizens; Maliki + Hanafi + Shafi'i + Hanbali represented institutionally without one dominant), with a substantial Twelver Shia minority (~30% of citizens, concentrated in Kuwait City and Ahmadi). Awqaf is structured as Sunni-administered; Shia communities run their own ḥusayniyat and madrasas. Asr convention is Standard (1× shadow) across both populations institutionally.
+
+## Calculation method (as implemented in fajr)
+
+- **adhan.js method:** `Kuwait` (`CalculationMethod.Kuwait()`) — corresponds to **Aladhan API method 8**
+- **Fajr angle:** 18° (Kuwait Awqaf institutional convention)
+- **Isha angle:** 17.5° (Kuwait Awqaf institutional convention)
+- **Asr school:** Standard (1× shadow) — matches both Sunni (Maliki/Shafi'i/Hanbali) and Twelver Shia conventions; only Hanafi calls for 2× shadow and Kuwait's Hanafi citizenry follows the institutional Standard publication.
+- **Method offsets:** none institutional; the adhan.js Kuwait preset matches Kuwait Awqaf's published times within fajr's tolerance bands.
+- **Classification:** 🟢 Established (institutional preset; Kuwait Awqaf is the named originating institution; the preset is widely deployed across the lower Gulf as the regional default)
+
+## Why this method
+
+The 18°/17.5° angle pair is the **Kuwait Ministry of Awqaf institutional convention**, used in Kuwait's published Imsakiyya and the al-Mosaller official app data. The Aladhan API's method 8 is named "Kuwait" because Awqaf is the named originating institution.
+
+The Kuwait preset is also the **regional default for Bahrain, Oman, and Yemen** in fajr (via fall-through in `selectMethod()`), reflecting the empirical observation that the lower Gulf countries without their own national preset follow Kuwait's published angle pair closely enough to share the dispatch. UAE and Qatar have their own institutional presets (Umm al-Qura and Qatar Calendar House respectively) and override the fall-through.
+
+The **Asr school choice** uses the v1.7.22 metadata split:
+- `location.asrConvention` returns `'standard'` (Kuwait's institutional Sunni + Shia conventions both use Standard Asr)
+- `applied.asrSchool` returns `'standard'`
+
+Convention and applied formula align — no override needed for typical Kuwaiti users. Hanafi users who want 2× shadow Asr override explicitly via `madhab: 'hanafi'`.
+
+## Known points of ikhtilaf within the country
+
+- **Twelver Shia ~30% of citizens** primarily follow Sistani-aligned Imsakiyya in their religious-publishing practice; numerically this matches Kuwait Awqaf's institutional convention closely on Standard Asr but differs on Fajr/Maghrib waiting periods. Not currently surfaced via per-city `altMethods`.
+- **Hanafi expatriate population** (Pakistani-Bangladeshi-Indian) in Kuwait City + Salmiya may publish via mosque-level Hanafi-published times that use 2× shadow Asr. fajr's `applied.asrSchool` defaults to Standard; Hanafi users override explicitly.
+- **Iranian-expatriate Shia** in Kuwait may follow Tehran/Sistani convention rather than the Kuwait default; like the UAE pattern, geography-based override is less clean than the citizen-population-based Saudi case.
+
+## City-level overrides
+
+None at city level for Kuwait. The country-default Kuwait dispatch handles Kuwait City, Hawalli, Salmiya, Ahmadi, Jahra, and all major Kuwaiti coordinates correctly.
+
+## Open questions / outstanding work
+
+- **Live Awqaf fixture** — fajr currently has no Kuwait-specific institutional fixture in the eval corpus. Acquiring an Awqaf-direct fetcher (al-Mosaller API or scraped daily Imsakiyya from awqaf.gov.kw) would lift Kuwait from 🟡→🟢 to 🟢 with empirical backing and grade B → A per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
+- **Shia altMethods surfacing** — Sistani-aligned Imsakiyya for the ~30% Twelver Shia citizenry could be exposed as a `notes[]` chip for Kuwait City coordinates, analogous to the Saudi Eastern Province pattern.
+
+## Sources
+
+- Kuwait Ministry of Awqaf and Islamic Affairs: https://www.awqaf.gov.kw
+- Aladhan method 8 (Kuwait): https://aladhan.com/calculation-methods
+- adhan.js Kuwait preset: https://github.com/batoulapps/adhan-js
+- Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1265)

--- a/knowledge/wiki/regions/oman.md
+++ b/knowledge/wiki/regions/oman.md
@@ -1,0 +1,56 @@
+# Oman — prayer-time conventions
+
+## Institutional reference body
+
+- **Name:** Ministry of Awqaf and Religious Affairs (وزارة الأوقاف والشؤون الدينية)
+- **URL:** https://www.mara.gov.om
+- **Population served:** ~3.5M Muslims (~85% of Oman's ~4M total — the rest are predominantly Hindu/Christian South Asian expatriate workforce)
+- **Madhab:** Oman is the world's **only Ibadi-majority country**, a distinction that gives it a unique institutional position in Islamic jurisprudence. Demographics among Muslim Omanis (citizens + Muslim expatriates):
+  - **Ibadi (~45-50% of citizens)** — official state madhhab; distinct school of Islam from both Sunni and Shia, tracing intellectual lineage to the early Kharijite movement but with substantially different theology and practice; Imam-led; uses 1× shadow Asr (Standard) institutionally
+  - **Sunni Shafi'i + Hanafi (~45% of citizens, primarily Dhofari Shafi'i + expatriate Hanafi)** — both use Standard Asr
+  - **Twelver Shia minority (~5%)** — primarily Iranian-origin Lawatiya merchants in Muttrah/Muscat
+- All three Omani traditions converge on **Standard 1× shadow Asr** as the institutional convention.
+
+## Calculation method (as implemented in fajr)
+
+- **adhan.js method:** dispatches to `Kuwait` (`CalculationMethod.Kuwait()`) via fall-through in `selectMethod()` — corresponds to **Aladhan API method 8**
+- **Fajr angle:** 18° (Kuwait Awqaf institutional default)
+- **Isha angle:** 17.5° (Kuwait Awqaf institutional default)
+- **Asr school:** Standard (1× shadow) — matches Ibadi + Sunni Shafi'i/Hanbali + Twelver Shia conventions in Oman uniformly. Only Hanafi calls for 2× shadow and Oman's Hanafi expatriate citizens follow the institutional Standard publication.
+- **Method offsets:** none
+- **Classification:** 🟡→🟢 (Approaching established — preset is regional-cluster default; Oman-specific institutional verification against MARA Awqaf publication is open follow-up)
+
+## Why this method
+
+Oman has no canonical national prayer-time methodology distinct from the lower-Gulf cluster. fajr's dispatch follows the Kuwait Ministry of Awqaf preset (18°/17.5°/Standard) which is the empirical Gulf default for lower-Gulf countries without their own national preset. UAE and Qatar override; Bahrain, Oman, and Yemen fall through to the Kuwait preset.
+
+The **Ibadi institutional position on prayer-time astronomy** is consistent with Sunni convention — Ibadi jurisprudence accepts the 18°/17.5° twilight-angle pair and Standard Asr without dispute; the practice-level differences between Ibadi and Sunni prayer observance (slightly different qunoot recitation; folded vs. opened hands during qiyam) do not change the *time-boundary* definitions that fajr's engine calculates.
+
+The **Asr school choice** uses the v1.7.22 metadata split:
+- `location.asrConvention` returns `'standard'` (Ibadi + Sunni Shafi'i/Hanbali + Twelver Shia all use Standard 1× shadow Asr in Oman)
+- `applied.asrSchool` returns `'standard'`
+
+Convention and applied formula align — no override needed for typical Omani users.
+
+## Known points of ikhtilaf within the country
+
+- **Ibadi vs. Sunni Shafi'i practice differences** are devotional/jurisprudential (qunoot, gesture conventions, niyyah recitation) but **not time-boundary differences**. fajr's prayer times serve both Ibadi and Sunni-Shafi'i Omanis correctly — the per-prayer time calculation is identical for both traditions.
+- **Lawatiya Twelver Shia minority** in Muttrah/Muscat (~5% of citizens; Iranian-origin merchant community with distinct ḥusayniyat) follows Sistani-aligned Imsakiyya which differs from the Kuwait dispatch on Fajr/Maghrib waiting periods. Not currently surfaced via per-city `altMethods` for Omani coordinates.
+- **Dhofari Shafi'i practice** (southern Oman, Salalah region) may differ subtly from northern Ibadi-administered mosque-published times due to historical Hadhramawti links, but this falls within fajr's tolerance bands for the Kuwait dispatch.
+
+## City-level overrides
+
+None at city level. Muscat, Salalah, Sohar, Nizwa, Sur, and all major Omani coordinates use the Kuwait fall-through.
+
+## Open questions / outstanding work
+
+- **Live MARA Awqaf fixture** — fajr currently has no Oman-specific institutional fixture; a fetcher targeting https://www.mara.gov.om Imsakiyya would confirm the Kuwait dispatch matches Oman's published times. Grade B → A per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria) requires this empirical anchor.
+- **Ibadi-specific scholarly grounding** — the wiki currently does not have a dedicated `knowledge/wiki/methods/ibadi.md` or `knowledge/wiki/fiqh/ibadi-prayer-times.md`. Because Ibadi converges with Sunni on time-boundary calculations, no separate method is needed, but a wiki page documenting why-it-converges would close the documentation gap for the world's only Ibadi-majority country.
+- **Lawatiya Shia altMethods** — Sistani-aligned dispatch for Muscat/Muttrah coordinates could be exposed via `notes[]`. Open follow-up.
+
+## Sources
+
+- Oman Ministry of Awqaf and Religious Affairs: https://www.mara.gov.om
+- Aladhan method 8 (Kuwait — applied to Oman via dispatch fall-through): https://aladhan.com/calculation-methods
+- Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1267)
+- Ibadi tradition background: Hoffman, Valerie J. (2012) "The Essentials of Ibāḍī Islam" (Syracuse UP); Wilkinson, John C. (2010) "Ibâdism: Origins and Early Development in Oman" (Oxford UP)

--- a/knowledge/wiki/regions/oman.md
+++ b/knowledge/wiki/regions/oman.md
@@ -6,37 +6,37 @@
 - **URL:** https://www.mara.gov.om
 - **Population served:** ~3.5M Muslims (~85% of Oman's ~4M total — the rest are predominantly Hindu/Christian South Asian expatriate workforce)
 - **Madhab:** Oman is the world's **only Ibadi-majority country**, a distinction that gives it a unique institutional position in Islamic jurisprudence. Demographics among Muslim Omanis (citizens + Muslim expatriates):
-  - **Ibadi (~45-50% of citizens)** — official state madhhab; distinct school of Islam from both Sunni and Shia, tracing intellectual lineage to the early Kharijite movement but with substantially different theology and practice; Imam-led; uses 1× shadow Asr (Standard) institutionally
-  - **Sunni Shafi'i + Hanafi (~45% of citizens, primarily Dhofari Shafi'i + expatriate Hanafi)** — both use Standard Asr
+  - **Ibadi (~45-50% of citizens)** — official state madhhab; distinct school of Islam from both Sunni and Shia, tracing intellectual lineage to the early Kharijite movement but with substantially different theology and practice; Imam-led; represented by the state publication's Standard 1× Asr convention
+  - **Sunni Shafi'i + Hanafi (~45% of citizens, primarily Dhofari Shafi'i + expatriate Hanafi)** — the state publication uses Standard Asr; Hanafi users who follow 2× shadow Asr should override explicitly
   - **Twelver Shia minority (~5%)** — primarily Iranian-origin Lawatiya merchants in Muttrah/Muscat
-- All three Omani traditions converge on **Standard 1× shadow Asr** as the institutional convention.
+- The current country-default metadata is **Standard 1× shadow Asr** as an institutional publication convention, not a full legal-madhhab taxonomy.
 
 ## Calculation method (as implemented in fajr)
 
-- **adhan.js method:** dispatches to `Kuwait` (`CalculationMethod.Kuwait()`) via fall-through in `selectMethod()` — corresponds to **Aladhan API method 8**
+- **adhan.js method:** dispatches to `Kuwait` (`CalculationMethod.Kuwait()`) via fall-through in `selectMethod()` — corresponds to **Aladhan API method 9**
 - **Fajr angle:** 18° (Kuwait Awqaf institutional default)
 - **Isha angle:** 17.5° (Kuwait Awqaf institutional default)
-- **Asr school:** Standard (1× shadow) — matches Ibadi + Sunni Shafi'i/Hanbali + Twelver Shia conventions in Oman uniformly. Only Hanafi calls for 2× shadow and Oman's Hanafi expatriate citizens follow the institutional Standard publication.
+- **Asr school:** Standard (1× shadow) — matches the current institutional publication/default. This does not imply all Hanafi individuals treat Standard as their madhhab rule; Hanafi users may override to 2× Asr.
 - **Method offsets:** none
-- **Classification:** 🟡→🟢 (Approaching established — preset is regional-cluster default; Oman-specific institutional verification against MARA Awqaf publication is open follow-up)
+- **Classification:** 🟡 Limited precedent — current fajr dispatch uses the Kuwait institutional preset as a regional proxy; Oman-specific institutional fixtures are still required before treating this as approaching established.
 
 ## Why this method
 
-Oman has no canonical national prayer-time methodology distinct from the lower-Gulf cluster. fajr's dispatch follows the Kuwait Ministry of Awqaf preset (18°/17.5°/Standard) which is the empirical Gulf default for lower-Gulf countries without their own national preset. UAE and Qatar override; Bahrain, Oman, and Yemen fall through to the Kuwait preset.
+Oman has no verified national prayer-time fixture in fajr yet. The current dispatch follows the Kuwait Ministry of Awqaf preset (18°/17.5°/Standard) as a regional fallback pending country-specific institutional validation. UAE and Qatar override; Bahrain, Oman, and Yemen fall through to the Kuwait preset.
 
-The **Ibadi institutional position on prayer-time astronomy** is consistent with Sunni convention — Ibadi jurisprudence accepts the 18°/17.5° twilight-angle pair and Standard Asr without dispute; the practice-level differences between Ibadi and Sunni prayer observance (slightly different qunoot recitation; folded vs. opened hands during qiyam) do not change the *time-boundary* definitions that fajr's engine calculates.
+No separate Ibadi calculation method is currently implemented. Available institutional practice appears to converge with the lower-Gulf Standard-Asr publication model, but a MARA fixture is still needed before fajr should call this country-specific validation.
 
 The **Asr school choice** uses the v1.7.22 metadata split:
-- `location.asrConvention` returns `'standard'` (Ibadi + Sunni Shafi'i/Hanbali + Twelver Shia all use Standard 1× shadow Asr in Oman)
+- `location.asrConvention` returns `'standard'` (the current country publication/default metadata uses Standard 1× shadow Asr)
 - `applied.asrSchool` returns `'standard'`
 
-Convention and applied formula align — no override needed for typical Omani users.
+Convention and applied formula align for the current country-default dispatch. Hanafi users who follow 2× shadow Asr override explicitly via `override.asrConvention: 'hanafi'`.
 
 ## Known points of ikhtilaf within the country
 
-- **Ibadi vs. Sunni Shafi'i practice differences** are devotional/jurisprudential (qunoot, gesture conventions, niyyah recitation) but **not time-boundary differences**. fajr's prayer times serve both Ibadi and Sunni-Shafi'i Omanis correctly — the per-prayer time calculation is identical for both traditions.
+- **Ibadi vs. Sunni Shafi'i practice differences** are devotional/jurisprudential (qunoot, gesture conventions, niyyah recitation) rather than an implemented separate fajr method. A direct MARA fixture should remain the arbiter before claiming full country-specific agreement.
 - **Lawatiya Twelver Shia minority** in Muttrah/Muscat (~5% of citizens; Iranian-origin merchant community with distinct ḥusayniyat) follows Sistani-aligned Imsakiyya which differs from the Kuwait dispatch on Fajr/Maghrib waiting periods. Not currently surfaced via per-city `altMethods` for Omani coordinates.
-- **Dhofari Shafi'i practice** (southern Oman, Salalah region) may differ subtly from northern Ibadi-administered mosque-published times due to historical Hadhramawti links, but this falls within fajr's tolerance bands for the Kuwait dispatch.
+- **Dhofari Shafi'i practice** (southern Oman, Salalah region) may differ subtly from northern Ibadi-administered mosque-published times due to historical Hadhramawti links. This needs fixture evidence before any tolerance-band claim.
 
 ## City-level overrides
 
@@ -44,13 +44,13 @@ None at city level. Muscat, Salalah, Sohar, Nizwa, Sur, and all major Omani coor
 
 ## Open questions / outstanding work
 
-- **Live MARA Awqaf fixture** — fajr currently has no Oman-specific institutional fixture; a fetcher targeting https://www.mara.gov.om Imsakiyya would confirm the Kuwait dispatch matches Oman's published times. Grade B → A per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria) requires this empirical anchor.
+- **Live MARA Awqaf fixture** — fajr currently has no Oman-specific institutional fixture; a fetcher targeting https://www.mara.gov.om Imsakiyya would test whether the Kuwait dispatch matches Oman's published times. Promotion per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria) requires this empirical anchor plus a position-registry update.
 - **Ibadi-specific scholarly grounding** — the wiki currently does not have a dedicated `knowledge/wiki/methods/ibadi.md` or `knowledge/wiki/fiqh/ibadi-prayer-times.md`. Because Ibadi converges with Sunni on time-boundary calculations, no separate method is needed, but a wiki page documenting why-it-converges would close the documentation gap for the world's only Ibadi-majority country.
 - **Lawatiya Shia altMethods** — Sistani-aligned dispatch for Muscat/Muttrah coordinates could be exposed via `notes[]`. Open follow-up.
 
 ## Sources
 
 - Oman Ministry of Awqaf and Religious Affairs: https://www.mara.gov.om
-- Aladhan method 8 (Kuwait — applied to Oman via dispatch fall-through): https://aladhan.com/calculation-methods
+- Aladhan method 9 (Kuwait — applied to Oman via dispatch fall-through): https://aladhan.com/calculation-methods
 - Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1267)
 - Ibadi tradition background: Hoffman, Valerie J. (2012) "The Essentials of Ibāḍī Islam" (Syracuse UP); Wilkinson, John C. (2010) "Ibâdism: Origins and Early Development in Oman" (Oxford UP)

--- a/knowledge/wiki/regions/qatar.md
+++ b/knowledge/wiki/regions/qatar.md
@@ -5,32 +5,32 @@
 - **Name:** Qatar Calendar House (دار التقويم القطري) under the Ministry of Endowments and Islamic Affairs (وزارة الأوقاف والشؤون الإسلامية)
 - **URL:** https://www.qch.gov.qa (Qatar Calendar House) ; https://www.awqaf.gov.qa (parent ministry)
 - **Population served:** ~2.5M Muslims (~67% of Qatar's ~3M total — the lower share reflects Qatar's heavy non-Muslim expat workforce, primarily Hindu/Christian South Asian and Filipino)
-- **Madhab:** Qatar's citizen population (~12-15% of total residents) is institutionally Sunni Hanbali, aligned with Saudi Arabia's institutional madhab. Muslim expatriate composition is multi-madhab — Pakistani-Bangladeshi-Indian Hanafi, Egyptian-Sudanese Shafi'i/Hanbali, Iranian Twelver Shia — but the institutional preset reflects the Hanbali-aligned Awqaf publication. Asr convention is Standard (1× shadow) institutionally.
+- **Madhab:** Qatar's citizen population (~12-15% of total residents) is institutionally Sunni Hanbali, aligned with Saudi Arabia's institutional madhhab. Muslim expatriate composition is multi-madhhab — Pakistani-Bangladeshi-Indian Hanafi, Egyptian-Sudanese Shafi'i/Hanbali, Iranian Twelver Shia — but the institutional preset reflects the Hanbali-aligned Awqaf publication. The state publication uses Standard (1× shadow) Asr; Hanafi users may follow a different Asr convention privately.
 
 ## Calculation method (as implemented in fajr)
 
-- **adhan.js method:** `Qatar` (`CalculationMethod.Qatar()`) — corresponds to **Aladhan API method 9**
+- **adhan.js method:** `Qatar` (`CalculationMethod.Qatar()`) — corresponds to **Aladhan API method 10**
 - **Fajr angle:** 18° (Qatar Calendar House institutional convention)
 - **Isha angle:** N/A — uses **90 min interval after Maghrib** (identical Isha convention to UmmAlQura; this is the institutional Gulf pattern for fixed-interval Isha)
-- **Asr school:** Standard (1× shadow). Institutional Hanbali + the Sunni expatriate majority both use Standard Asr.
-- **Method offsets:** none institutional; the adhan.js Qatar preset matches Qatar Calendar House publication.
-- **Classification:** 🟢 Established (institutional preset; Qatar Calendar House is the named originating institution; the 18° + 90-min-interval pair is empirically validated against Awqaf publications)
+- **Asr school:** Standard (1× shadow) as the institutional publication convention. Hanafi users who follow 2× shadow Asr should override explicitly.
+- **Method offsets:** none in the preset. fajr does not yet carry a Qatar Calendar House fixture, so this is an institutional-preset dispatch rather than an empirical fixture-backed claim.
+- **Classification:** 🟢 Established (institutional preset; Qatar Calendar House is the named originating institution for the 18° + 90-min-interval pair)
 
 ## Why this method
 
-The 18° Fajr + 90-minute Isha interval is the **Qatar Calendar House institutional convention**, the published Qatari official Imsakiyya. The Aladhan API's method 9 is named "Qatar" because Qatar Calendar House is the named originating institution.
+The 18° Fajr + 90-minute Isha interval is the **Qatar Calendar House institutional convention**, the published Qatari official Imsakiyya. The Aladhan API's method 10 is named "Qatar" because Qatar Calendar House is the named originating institution.
 
 **Note vs. UmmAlQura:** Qatar shares the 90-minute Isha interval with UmmAlQura (Saudi Arabia) but differs on Fajr angle (Qatar: 18°; UmmAlQura: 18.5°). This is a real institutional disagreement on Fajr boundary, not a unification onto a single Gulf preset. fajr respects this by dispatching Qatar coordinates to the Qatar preset, not the UmmAlQura preset.
 
 The **Asr school choice** uses the v1.7.22 metadata split:
-- `location.asrConvention` returns `'standard'` (Qatar institutional Hanbali + Sunni majority both use Standard Asr)
+- `location.asrConvention` returns `'standard'` (Qatar's institutional publication uses Standard Asr)
 - `applied.asrSchool` returns `'standard'`
 
-Convention and applied formula align — no override needed for typical Qatari users. Hanafi users override explicitly.
+Convention and applied formula align for the state-published timetable. Hanafi users who follow 2× shadow Asr override explicitly via `override.asrConvention: 'hanafi'`.
 
 ## Known points of ikhtilaf within the country
 
-- **Multi-madhab expatriate composition** (similar to UAE): Pakistani-Bangladeshi Hanafi mosques in Doha may publish Hanafi 2× Asr; Egyptian Shafi'i mosques publish 1× Asr (no formula difference, same Standard). The country-default `applied.asrSchool` defaults to Standard; Hanafi users override explicitly via `madhab: 'hanafi'`.
+- **Multi-madhhab expatriate composition** (similar to UAE): Pakistani-Bangladeshi Hanafi mosques in Doha may publish Hanafi 2× Asr; Egyptian Shafi'i mosques publish 1× Asr (no formula difference, same Standard). The country-default `applied.asrSchool` defaults to Standard; Hanafi users override explicitly.
 - **Iranian-expatriate Twelver Shia minority** (small but present) follow Sistani-aligned Imsakiyya. Not currently surfaced via per-city `altMethods` for Qatari coordinates.
 - **Ramadan administrative adjustments**: Qatar Calendar House may publish Ramadan-specific Isha (later than 90-min-default) per administrative convention. fajr does not auto-switch Ramadan Isha — apps should be aware during Ramadan that the institutional publication may be later than fajr's standard-Isha calc.
 
@@ -40,13 +40,13 @@ None at city level for Qatar. The country-default Qatar dispatch handles Doha, A
 
 ## Open questions / outstanding work
 
-- **Live Qatar Calendar House fixture** — fajr currently has no Qatar-specific institutional fixture in the eval corpus. Acquiring a QCH-direct fetcher would lift Qatar from 🟢 institutional-baseline to 🟢 institutional + empirical-corroboration, grade B → A per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
+- **Live Qatar Calendar House fixture** — fajr currently has no Qatar-specific institutional fixture in the eval corpus. Acquiring a QCH-direct fetcher would turn the current institutional-preset dispatch into an institutionally verified, empirical grade-A candidate per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
 - **Ramadan-aware Isha** — Qatar's administrative Ramadan-Isha convention (similar to UmmAlQura's 120-min Ramadan default) is not currently surfaced via `notes[]`. Open follow-up.
 
 ## Sources
 
 - Qatar Calendar House: https://www.qch.gov.qa
 - Qatar Ministry of Endowments and Islamic Affairs: https://www.awqaf.gov.qa
-- Aladhan method 9 (Qatar): https://aladhan.com/calculation-methods
+- Aladhan method 10 (Qatar): https://aladhan.com/calculation-methods
 - adhan.js Qatar preset: https://github.com/batoulapps/adhan-js
 - Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1261)

--- a/knowledge/wiki/regions/qatar.md
+++ b/knowledge/wiki/regions/qatar.md
@@ -1,0 +1,52 @@
+# Qatar — prayer-time conventions
+
+## Institutional reference body
+
+- **Name:** Qatar Calendar House (دار التقويم القطري) under the Ministry of Endowments and Islamic Affairs (وزارة الأوقاف والشؤون الإسلامية)
+- **URL:** https://www.qch.gov.qa (Qatar Calendar House) ; https://www.awqaf.gov.qa (parent ministry)
+- **Population served:** ~2.5M Muslims (~67% of Qatar's ~3M total — the lower share reflects Qatar's heavy non-Muslim expat workforce, primarily Hindu/Christian South Asian and Filipino)
+- **Madhab:** Qatar's citizen population (~12-15% of total residents) is institutionally Sunni Hanbali, aligned with Saudi Arabia's institutional madhab. Muslim expatriate composition is multi-madhab — Pakistani-Bangladeshi-Indian Hanafi, Egyptian-Sudanese Shafi'i/Hanbali, Iranian Twelver Shia — but the institutional preset reflects the Hanbali-aligned Awqaf publication. Asr convention is Standard (1× shadow) institutionally.
+
+## Calculation method (as implemented in fajr)
+
+- **adhan.js method:** `Qatar` (`CalculationMethod.Qatar()`) — corresponds to **Aladhan API method 9**
+- **Fajr angle:** 18° (Qatar Calendar House institutional convention)
+- **Isha angle:** N/A — uses **90 min interval after Maghrib** (identical Isha convention to UmmAlQura; this is the institutional Gulf pattern for fixed-interval Isha)
+- **Asr school:** Standard (1× shadow). Institutional Hanbali + the Sunni expatriate majority both use Standard Asr.
+- **Method offsets:** none institutional; the adhan.js Qatar preset matches Qatar Calendar House publication.
+- **Classification:** 🟢 Established (institutional preset; Qatar Calendar House is the named originating institution; the 18° + 90-min-interval pair is empirically validated against Awqaf publications)
+
+## Why this method
+
+The 18° Fajr + 90-minute Isha interval is the **Qatar Calendar House institutional convention**, the published Qatari official Imsakiyya. The Aladhan API's method 9 is named "Qatar" because Qatar Calendar House is the named originating institution.
+
+**Note vs. UmmAlQura:** Qatar shares the 90-minute Isha interval with UmmAlQura (Saudi Arabia) but differs on Fajr angle (Qatar: 18°; UmmAlQura: 18.5°). This is a real institutional disagreement on Fajr boundary, not a unification onto a single Gulf preset. fajr respects this by dispatching Qatar coordinates to the Qatar preset, not the UmmAlQura preset.
+
+The **Asr school choice** uses the v1.7.22 metadata split:
+- `location.asrConvention` returns `'standard'` (Qatar institutional Hanbali + Sunni majority both use Standard Asr)
+- `applied.asrSchool` returns `'standard'`
+
+Convention and applied formula align — no override needed for typical Qatari users. Hanafi users override explicitly.
+
+## Known points of ikhtilaf within the country
+
+- **Multi-madhab expatriate composition** (similar to UAE): Pakistani-Bangladeshi Hanafi mosques in Doha may publish Hanafi 2× Asr; Egyptian Shafi'i mosques publish 1× Asr (no formula difference, same Standard). The country-default `applied.asrSchool` defaults to Standard; Hanafi users override explicitly via `madhab: 'hanafi'`.
+- **Iranian-expatriate Twelver Shia minority** (small but present) follow Sistani-aligned Imsakiyya. Not currently surfaced via per-city `altMethods` for Qatari coordinates.
+- **Ramadan administrative adjustments**: Qatar Calendar House may publish Ramadan-specific Isha (later than 90-min-default) per administrative convention. fajr does not auto-switch Ramadan Isha — apps should be aware during Ramadan that the institutional publication may be later than fajr's standard-Isha calc.
+
+## City-level overrides
+
+None at city level for Qatar. The country-default Qatar dispatch handles Doha, Al Rayyan, Al Wakrah, Al Khor, and all major Qatari coordinates correctly.
+
+## Open questions / outstanding work
+
+- **Live Qatar Calendar House fixture** — fajr currently has no Qatar-specific institutional fixture in the eval corpus. Acquiring a QCH-direct fetcher would lift Qatar from 🟢 institutional-baseline to 🟢 institutional + empirical-corroboration, grade B → A per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
+- **Ramadan-aware Isha** — Qatar's administrative Ramadan-Isha convention (similar to UmmAlQura's 120-min Ramadan default) is not currently surfaced via `notes[]`. Open follow-up.
+
+## Sources
+
+- Qatar Calendar House: https://www.qch.gov.qa
+- Qatar Ministry of Endowments and Islamic Affairs: https://www.awqaf.gov.qa
+- Aladhan method 9 (Qatar): https://aladhan.com/calculation-methods
+- adhan.js Qatar preset: https://github.com/batoulapps/adhan-js
+- Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1261)

--- a/knowledge/wiki/regions/yemen.md
+++ b/knowledge/wiki/regions/yemen.md
@@ -11,22 +11,22 @@ Yemen is partitioned politically and ecclesiastically since 2014, with **two dis
 **Population served:** ~32M Muslims (~99% of Yemen's ~32M total). Demographic breakdown:
 - **Sunni Shafi'i (~65%)** — concentrated in southern and central Yemen (Aden, Taiz, Hadhramaut, Mukalla, Ibb); Shafi'i institutional tradition with strong Hadhrami scholarly lineage
 - **Zaydi (~35%)** — concentrated in northern highlands (Sana'a, Saada, Hajjah, Sa'dah governorates); Zaydi-Hadawi tradition, theologically Shia in lineage but jurisprudentially closer to Sunni Shafi'i than to Twelver Shia
-- **Twelver Shia (~1-2%)** — small minority, primarily in Saada governorate's Ismaili pockets
+- **Ismaili minority pockets** — primarily in northern Yemen; distinct from both Zaydi and Twelver Shia traditions
 
 **Madhab:** Both Shafi'i and Zaydi populations use **Standard 1× shadow Asr** institutionally; the wider Zaydi Imsakiyya differs from Shafi'i on Fajr/Maghrib boundary treatment but converges on Asr shadow-factor.
 
 ## Calculation method (as implemented in fajr)
 
-- **adhan.js method:** dispatches to `Kuwait` (`CalculationMethod.Kuwait()`) via fall-through in `selectMethod()` — corresponds to **Aladhan API method 8**
+- **adhan.js method:** dispatches to `Kuwait` (`CalculationMethod.Kuwait()`) via fall-through in `selectMethod()` — corresponds to **Aladhan API method 9**
 - **Fajr angle:** 18° (Kuwait Awqaf institutional default)
 - **Isha angle:** 17.5° (Kuwait Awqaf institutional default)
 - **Asr school:** Standard (1× shadow) — shadow-correct for both Shafi'i and Zaydi populations
 - **Method offsets:** none
-- **Classification:** 🟡→🟢 (Approaching established — preset is regional-cluster default; Yemen-specific institutional verification against either Aden Shafi'i or Sana'a Zaydi awqaf is open follow-up, complicated by the political-administrative partition)
+- **Classification:** 🟡 Limited precedent — current fajr dispatch uses the Kuwait institutional preset as a regional proxy; Yemen-specific institutional fixtures are still required before treating this as approaching established.
 
 ## Why this method
 
-Yemen has no canonical post-2014-partition national prayer-time methodology distinct from the lower-Gulf cluster. fajr's dispatch follows the Kuwait Ministry of Awqaf preset (18°/17.5°/Standard) which is the empirical Gulf default for lower-Gulf countries without their own national preset. UAE and Qatar override with their own institutional presets; Bahrain, Oman, and Yemen fall through.
+Yemen has no verified post-2014-partition national prayer-time fixture in fajr yet. The current dispatch follows the Kuwait Ministry of Awqaf preset (18°/17.5°/Standard) as a regional fallback pending country-specific institutional validation. UAE and Qatar override with their own institutional presets; Bahrain, Oman, and Yemen fall through.
 
 **v1.7.5 bbox tightening note:** Yemen's western longitude was tightened from 42 to 42.5 to prevent the bbox from swallowing Muhayil Asir (18.54, 42.05), which lies inside Saudi Arabia's southern 'Asir region. Hodeidah YE is at 42.95, so Yemen still covers correctly. This is documented in `src/engine.js:62-64`.
 
@@ -34,13 +34,13 @@ The **Asr school choice** uses the v1.7.22 metadata split:
 - `location.asrConvention` returns `'standard'` (both Shafi'i and Zaydi populations use Standard 1× shadow Asr; both are explicitly enumerated in the `countryDefaults` block in `src/engine.js`)
 - `applied.asrSchool` returns `'standard'`
 
-Convention and applied formula align — no override needed for typical Yemeni users.
+Convention and applied formula align for the current country-default dispatch. Users following a local Aden, Sana'a, or community-specific publication should use an explicit override once their source is identified.
 
 ## Known points of ikhtilaf within the country
 
-- **Sunni Shafi'i vs. Zaydi tradition** — the defining ikhtilaf in Yemen. Both use Standard 1× shadow Asr (so fajr's default is shadow-correct for both), but the wider Zaydi Imsakiyya treats Fajr (slightly later, per Hadawi convention) and Maghrib (slightly later, ensuring sunset completion) differently from the Shafi'i Aden-mufti publication. The Kuwait preset's 18°/17.5° is closer to the Shafi'i Aden convention than the Zaydi Sana'a convention.
-- **Houthi-Aden administrative divergence** — post-2014, the two governments publish different Ramadan-calendar conventions and may publish slightly different daily Imsakiyya. This is a **future #40 caller-override candidate**, not a country-default split — fajr ships one country-default and surfaces the alternative via opt-in.
-- **Hadhrami scholarly tradition** in eastern Yemen (Tarim, Mukalla) carries significant influence on Shafi'i practice across the broader Indian Ocean (Southeast Asia, East Africa); the Tarim-published Imsakiyya may differ from the Aden Awqaf publication by 1-2 minutes, within fajr's tolerance bands.
+- **Sunni Shafi'i vs. Zaydi tradition** — the defining ikhtilaf in Yemen. Both are represented as Standard 1× shadow Asr in the current metadata, but wider Zaydi Imsakiyya practice may treat Fajr and Maghrib differently from the Shafi'i Aden-mufti publication. Which source is closer to the Kuwait fall-through is a fixture question, not yet established.
+- **Houthi-Aden administrative divergence** — post-2014, the two governments publish different Ramadan-calendar conventions and may publish slightly different daily Imsakiyya. This is a v1.9.0 caller-override candidate, not a country-default split — fajr ships one country-default and can surface alternatives via opt-in once fixtures exist.
+- **Hadhrami scholarly tradition** in eastern Yemen (Tarim, Mukalla) carries significant influence on Shafi'i practice across the broader Indian Ocean (Southeast Asia, East Africa); fixture evidence is needed before asserting how closely Tarim-published times match the Aden Awqaf publication.
 
 ## City-level overrides
 
@@ -48,14 +48,14 @@ None at city level. Sana'a, Aden, Taiz, Hodeidah, Mukalla, and all major Yemeni 
 
 ## Open questions / outstanding work
 
-- **Aden Shafi'i Awqaf live fixture** — fetcher targeting https://www.endowments.gov.ye Imsakiyya would confirm the Kuwait dispatch matches the Shafi'i Aden publication. Currently the live status of the endowments.gov.ye portal is unverified (Yemen's civil-war administrative disruption may have affected uptime).
+- **Aden Shafi'i Awqaf live fixture** — fetcher targeting https://www.endowments.gov.ye Imsakiyya would test whether the Kuwait dispatch matches the Shafi'i Aden publication. Currently the live status of the endowments.gov.ye portal is unverified (Yemen's civil-war administrative disruption may have affected uptime).
 - **Sana'a Zaydi Imsakiyya capture** — a Houthi-administered awqaf Imsakiyya fixture would surface the Zaydi-Hadawi convention as a real second-source ground truth. Politically sensitive but academically valuable for documenting the only Zaydi-majority population's prayer-time convention.
 - **Per-tradition `altMethods`** — once both fixtures are available, Sana'a coordinates could surface Zaydi as the country-default and Shafi'i as an opt-in alternative; Aden/southern coordinates could invert the priority. This matches the institutional structure on the ground without making fajr take a side on the political partition.
 
 ## Sources
 
 - Yemen (recognised government) Ministry of Endowments and Religious Affairs: https://www.endowments.gov.ye (uptime variable due to civil-war disruption)
-- Aladhan method 8 (Kuwait — applied to Yemen via dispatch fall-through): https://aladhan.com/calculation-methods
+- Aladhan method 9 (Kuwait — applied to Yemen via dispatch fall-through): https://aladhan.com/calculation-methods
 - Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1268)
 - Engine bbox tightening note (v1.7.5, Muhayil Asir carve-out): see [`src/engine.js`](../../../src/engine.js#L62-64)
 - Engine `countryDefaults` note on Yemen Shafi'i + Zaydi convergence on Standard Asr: see [`src/engine.js`](../../../src/engine.js#L965-971)

--- a/knowledge/wiki/regions/yemen.md
+++ b/knowledge/wiki/regions/yemen.md
@@ -1,0 +1,63 @@
+# Yemen — prayer-time conventions
+
+## Institutional reference bodies
+
+Yemen is partitioned politically and ecclesiastically since 2014, with **two distinct institutional administrations** publishing prayer-time conventions:
+
+- **Sana'a — Houthi-administered north (de facto control over ~80% of the population):** the Zaydi-Hadawi tradition's awqaf-administration publishes via the Houthi-run Ministry of Awqaf and Religious Guidance. The published Imsakiyya reflects Zaydi-Hadawi convention.
+- **Aden — internationally-recognised government, south (Yemeni Republic):** the Aden-based mufti and the recognised government's Ministry of Endowments and Religious Affairs publish the Shafi'i-aligned Sunni Imsakiyya. URL: https://www.endowments.gov.ye
+- **Pre-2014 unified reference:** the Yemeni Ministry of Endowments and Religious Affairs (وزارة الأوقاف والإرشاد) — historically the unified state institution before the political split.
+
+**Population served:** ~32M Muslims (~99% of Yemen's ~32M total). Demographic breakdown:
+- **Sunni Shafi'i (~65%)** — concentrated in southern and central Yemen (Aden, Taiz, Hadhramaut, Mukalla, Ibb); Shafi'i institutional tradition with strong Hadhrami scholarly lineage
+- **Zaydi (~35%)** — concentrated in northern highlands (Sana'a, Saada, Hajjah, Sa'dah governorates); Zaydi-Hadawi tradition, theologically Shia in lineage but jurisprudentially closer to Sunni Shafi'i than to Twelver Shia
+- **Twelver Shia (~1-2%)** — small minority, primarily in Saada governorate's Ismaili pockets
+
+**Madhab:** Both Shafi'i and Zaydi populations use **Standard 1× shadow Asr** institutionally; the wider Zaydi Imsakiyya differs from Shafi'i on Fajr/Maghrib boundary treatment but converges on Asr shadow-factor.
+
+## Calculation method (as implemented in fajr)
+
+- **adhan.js method:** dispatches to `Kuwait` (`CalculationMethod.Kuwait()`) via fall-through in `selectMethod()` — corresponds to **Aladhan API method 8**
+- **Fajr angle:** 18° (Kuwait Awqaf institutional default)
+- **Isha angle:** 17.5° (Kuwait Awqaf institutional default)
+- **Asr school:** Standard (1× shadow) — shadow-correct for both Shafi'i and Zaydi populations
+- **Method offsets:** none
+- **Classification:** 🟡→🟢 (Approaching established — preset is regional-cluster default; Yemen-specific institutional verification against either Aden Shafi'i or Sana'a Zaydi awqaf is open follow-up, complicated by the political-administrative partition)
+
+## Why this method
+
+Yemen has no canonical post-2014-partition national prayer-time methodology distinct from the lower-Gulf cluster. fajr's dispatch follows the Kuwait Ministry of Awqaf preset (18°/17.5°/Standard) which is the empirical Gulf default for lower-Gulf countries without their own national preset. UAE and Qatar override with their own institutional presets; Bahrain, Oman, and Yemen fall through.
+
+**v1.7.5 bbox tightening note:** Yemen's western longitude was tightened from 42 to 42.5 to prevent the bbox from swallowing Muhayil Asir (18.54, 42.05), which lies inside Saudi Arabia's southern 'Asir region. Hodeidah YE is at 42.95, so Yemen still covers correctly. This is documented in `src/engine.js:62-64`.
+
+The **Asr school choice** uses the v1.7.22 metadata split:
+- `location.asrConvention` returns `'standard'` (both Shafi'i and Zaydi populations use Standard 1× shadow Asr; both are explicitly enumerated in the `countryDefaults` block in `src/engine.js`)
+- `applied.asrSchool` returns `'standard'`
+
+Convention and applied formula align — no override needed for typical Yemeni users.
+
+## Known points of ikhtilaf within the country
+
+- **Sunni Shafi'i vs. Zaydi tradition** — the defining ikhtilaf in Yemen. Both use Standard 1× shadow Asr (so fajr's default is shadow-correct for both), but the wider Zaydi Imsakiyya treats Fajr (slightly later, per Hadawi convention) and Maghrib (slightly later, ensuring sunset completion) differently from the Shafi'i Aden-mufti publication. The Kuwait preset's 18°/17.5° is closer to the Shafi'i Aden convention than the Zaydi Sana'a convention.
+- **Houthi-Aden administrative divergence** — post-2014, the two governments publish different Ramadan-calendar conventions and may publish slightly different daily Imsakiyya. This is a **future #40 caller-override candidate**, not a country-default split — fajr ships one country-default and surfaces the alternative via opt-in.
+- **Hadhrami scholarly tradition** in eastern Yemen (Tarim, Mukalla) carries significant influence on Shafi'i practice across the broader Indian Ocean (Southeast Asia, East Africa); the Tarim-published Imsakiyya may differ from the Aden Awqaf publication by 1-2 minutes, within fajr's tolerance bands.
+
+## City-level overrides
+
+None at city level. Sana'a, Aden, Taiz, Hodeidah, Mukalla, and all major Yemeni coordinates use the Kuwait fall-through.
+
+## Open questions / outstanding work
+
+- **Aden Shafi'i Awqaf live fixture** — fetcher targeting https://www.endowments.gov.ye Imsakiyya would confirm the Kuwait dispatch matches the Shafi'i Aden publication. Currently the live status of the endowments.gov.ye portal is unverified (Yemen's civil-war administrative disruption may have affected uptime).
+- **Sana'a Zaydi Imsakiyya capture** — a Houthi-administered awqaf Imsakiyya fixture would surface the Zaydi-Hadawi convention as a real second-source ground truth. Politically sensitive but academically valuable for documenting the only Zaydi-majority population's prayer-time convention.
+- **Per-tradition `altMethods`** — once both fixtures are available, Sana'a coordinates could surface Zaydi as the country-default and Shafi'i as an opt-in alternative; Aden/southern coordinates could invert the priority. This matches the institutional structure on the ground without making fajr take a side on the political partition.
+
+## Sources
+
+- Yemen (recognised government) Ministry of Endowments and Religious Affairs: https://www.endowments.gov.ye (uptime variable due to civil-war disruption)
+- Aladhan method 8 (Kuwait — applied to Yemen via dispatch fall-through): https://aladhan.com/calculation-methods
+- Engine `selectMethod()` dispatch: see [`src/engine.js`](../../../src/engine.js#L1268)
+- Engine bbox tightening note (v1.7.5, Muhayil Asir carve-out): see [`src/engine.js`](../../../src/engine.js#L62-64)
+- Engine `countryDefaults` note on Yemen Shafi'i + Zaydi convergence on Standard Asr: see [`src/engine.js`](../../../src/engine.js#L965-971)
+- Zaydi tradition background: Haykel, Bernard (2003) "Revival and Reform in Islam: The Legacy of Muhammad al-Shawkani" (Cambridge UP)
+- Yemen sectarian breakdown: Pew Research Center "Mapping the Global Muslim Population" (2009); CIA World Factbook Yemen entry


### PR DESCRIPTION
## Summary

Backfills the high-traffic Gulf-cluster country wikis remaining after the v1.8.1 backfills and deepens the Egypt page with the v1.8.1 ESA fixture context. This is wiki/documentation only: no `src/*`, eval harness, or calculation behavior changes.

Human-process note: `knowledge/wiki/` is normally Loop 1 human-compile scope. Tawfeeq explicitly approved this cleanup as a maintainer-directed wiki backfill, so this PR records that exception rather than treating it as an autoresearch engine run.

### Scope

- Adds Gulf-cluster pages for Kuwait, Qatar, Bahrain, Oman, Yemen.
- Deepens Egypt with ESA institutional fixture context.
- Corrects the v1.7.22+ Asr terminology split: `location.asrConvention` / `applied.asrSchool` are Asr shadow-factor fields, not full legal-madhhab taxonomy.
- Keeps all fall-through countries honest about evidence level: Bahrain/Oman/Yemen use Kuwait as a regional proxy pending country-specific fixtures.

### Engine dispatch context surfaced

| Country | adhan.js preset | Aladhan ID | Fajr/Isha | Asr | Classification |
|---------|-----------------|------------|-----------|-----|----------------|
| Kuwait | `Kuwait` | 9 | 18° / 17.5° | Standard | 🟢 Established institutional preset; Kuwait fixture pending |
| Qatar | `Qatar` | 10 | 18° / Maghrib+90min | Standard | 🟢 Established institutional preset; QCH fixture pending |
| Bahrain | `Kuwait` fall-through | 9 | 18° / 17.5° | Standard | 🟡 Limited precedent / regional proxy |
| Oman | `Kuwait` fall-through | 9 | 18° / 17.5° | Standard | 🟡 Limited precedent / regional proxy |
| Yemen | `Kuwait` fall-through | 9 | 18° / 17.5° | Standard | 🟡 Limited precedent / regional proxy |

### Important corrections from review

- Aladhan method IDs updated from the live API: `GULF=8`, `KUWAIT=9`, `QATAR=10`.
- Removed unsupported empirical-validation claims for Kuwait/Qatar/Bahrain/Oman/Yemen.
- Downgraded Bahrain/Oman/Yemen from 🟡→🟢 to 🟡 Limited precedent until country-specific institutional fixtures exist.
- Rephrased Hanafi/Standard Asr wording so institutional Standard publication is not presented as every Hanafi individual's legal-madhhab rule.
- Rephrased Egypt promotion language: the ESA fixture supports future confidence promotion, but does not claim a grade lift before `docs/positions.md` / promotion logs change.
- Fixed Yemen minority wording: Ismaili pockets are distinct from Twelver Shia.
- Framed Bahrain Jaafari → Tehran/Sistani as a possible user-selected proxy pending a Bahrain Jaafari Awqaf fixture, not an established institutional mapping.

## What this is not

- Not an engine change.
- Not a calc change.
- Not an eval-corpus change.
- Not closing all of fajr#88. It closes the Gulf + Egypt cleanup segment; broader wiki alignment remains open.

## Verification

- `npm test`: 411/411 passing after rebase onto v1.9.0 master
- `node scripts/validate-city-registry.js`: 481 cities, 0 fail-class issues
- `git diff --check origin/master...HEAD`: clean
- Review-grep for prior blocker phrases / wrong Aladhan IDs: clean

[positions: no-change-required] — wiki wording/backfill only; no default method, confidence grade, known-disagreement verdict, or calculation position changes.

[known-disagreements: no-change-required] — region pages point to existing disagreement areas but do not change the known-disagreements registry.
