### PR TITLE
fix(ci): detect new ESA snapshot files

### DIFF
--- a/.github/workflows/egypt-esa-snapshot.yml
+++ b/.github/workflows/egypt-esa-snapshot.yml
@@ -103,7 +103,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- fixtures/egypt-esa/daily; then
+          # git diff does not report untracked files, which is exactly what a
+          # new daily snapshot is before git add. Use porcelain status so the
+          # first capture for a date opens a PR instead of being mistaken for
+          # an already-existing snapshot.
+          if [ -z "$(git status --porcelain -- fixtures/egypt-esa/daily)" ]; then
             echo "No new ESA snapshot to commit (already exists for today)."
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Fix the Egypt ESA daily snapshot workflow so new untracked daily JSON files are detected.
- The 2026-05-14 scheduled run fetched 15 ESA cities successfully, but `git diff --quiet -- fixtures/egypt-esa/daily` ignored the new untracked file and falsely exited as already-existing.
- Switch the gate to `git status --porcelain -- fixtures/egypt-esa/daily`, which sees both tracked changes and untracked first captures.

## Validation
- `git diff --check -- .github/workflows/egypt-esa-snapshot.yml`
- Confirmed run 25845653710 fetched 15 cities and then skipped PR creation because of the untracked-file check bug.

Fixes the workflow half of agiftoftime#36 / fajr#103 ESA carry-forward.

[positions: no-change-required] workflow-only fix; no source-position change.