### PR TITLE
data(egypt): capture ESA daily snapshot 2026-05-14

### DIFF
--- a/fixtures/egypt-esa/daily/2026-05-14.json
+++ b/fixtures/egypt-esa/daily/2026-05-14.json
@@ -1,0 +1,392 @@
+[
+  {
+    "city": "Alexandria",
+    "city_local": "الأسكندرية",
+    "country": "Egypt",
+    "latitude": 31.2001,
+    "longitude": 29.9187,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:24",
+        "sunrise": "06:05",
+        "dhuhr": "12:56",
+        "asr": "16:36",
+        "maghrib": "19:48",
+        "isha": "21:18"
+      }
+    ]
+  },
+  {
+    "city": "Tanta",
+    "city_local": "طنطا",
+    "country": "Egypt",
+    "latitude": 30.7865,
+    "longitude": 31.0004,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:22",
+        "sunrise": "06:02",
+        "dhuhr": "12:52",
+        "asr": "16:31",
+        "maghrib": "19:43",
+        "isha": "21:12"
+      }
+    ]
+  },
+  {
+    "city": "Mansoura",
+    "city_local": "المنصورة",
+    "country": "Egypt",
+    "latitude": 31.0364,
+    "longitude": 31.3807,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:19",
+        "sunrise": "06:00",
+        "dhuhr": "12:51",
+        "asr": "16:30",
+        "maghrib": "19:42",
+        "isha": "21:11"
+      }
+    ]
+  },
+  {
+    "city": "Zagazig",
+    "city_local": "الزقازيق",
+    "country": "Egypt",
+    "latitude": 30.5877,
+    "longitude": 31.5022,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:21",
+        "sunrise": "06:00",
+        "dhuhr": "12:50",
+        "asr": "16:28",
+        "maghrib": "19:41",
+        "isha": "21:09"
+      }
+    ]
+  },
+  {
+    "city": "Asyut",
+    "city_local": "أسيوط",
+    "country": "Egypt",
+    "latitude": 27.1809,
+    "longitude": 31.1837,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:33",
+        "sunrise": "06:08",
+        "dhuhr": "12:52",
+        "asr": "16:23",
+        "maghrib": "19:36",
+        "isha": "21:00"
+      }
+    ]
+  },
+  {
+    "city": "Sohag",
+    "city_local": "سوهاج",
+    "country": "Egypt",
+    "latitude": 26.5569,
+    "longitude": 31.6948,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:33",
+        "sunrise": "06:07",
+        "dhuhr": "12:50",
+        "asr": "16:19",
+        "maghrib": "19:33",
+        "isha": "20:56"
+      }
+    ]
+  },
+  {
+    "city": "Beni Suef",
+    "city_local": "بنى سويف",
+    "country": "Egypt",
+    "latitude": 29.0661,
+    "longitude": 31.0994,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:27",
+        "sunrise": "06:05",
+        "dhuhr": "12:52",
+        "asr": "16:27",
+        "maghrib": "19:40",
+        "isha": "21:06"
+      }
+    ]
+  },
+  {
+    "city": "Minya",
+    "city_local": "المنيا",
+    "country": "Egypt",
+    "latitude": 28.0871,
+    "longitude": 30.7618,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:32",
+        "sunrise": "06:08",
+        "dhuhr": "12:53",
+        "asr": "16:26",
+        "maghrib": "19:39",
+        "isha": "21:04"
+      }
+    ]
+  },
+  {
+    "city": "Qena",
+    "city_local": "قنا",
+    "country": "Egypt",
+    "latitude": 26.1551,
+    "longitude": 32.716,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:30",
+        "sunrise": "06:03",
+        "dhuhr": "12:46",
+        "asr": "16:14",
+        "maghrib": "19:28",
+        "isha": "20:51"
+      }
+    ]
+  },
+  {
+    "city": "Aswan",
+    "city_local": "أسوان",
+    "country": "Egypt",
+    "latitude": 24.0889,
+    "longitude": 32.8998,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:35",
+        "sunrise": "06:06",
+        "dhuhr": "12:45",
+        "asr": "16:09",
+        "maghrib": "19:23",
+        "isha": "20:44"
+      }
+    ]
+  },
+  {
+    "city": "Marsa Matruh",
+    "city_local": "مطروح",
+    "country": "Egypt",
+    "latitude": 31.3543,
+    "longitude": 27.2373,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.924Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:35",
+        "sunrise": "06:16",
+        "dhuhr": "13:07",
+        "asr": "16:47",
+        "maghrib": "19:59",
+        "isha": "21:29"
+      }
+    ]
+  },
+  {
+    "city": "Hurghada",
+    "city_local": "الغردقة",
+    "country": "Egypt",
+    "latitude": 27.2579,
+    "longitude": 33.8116,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.925Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:22",
+        "sunrise": "05:57",
+        "dhuhr": "12:41",
+        "asr": "16:12",
+        "maghrib": "19:25",
+        "isha": "20:49"
+      }
+    ]
+  },
+  {
+    "city": "Kharga Oasis",
+    "city_local": "الخارجة",
+    "country": "Egypt",
+    "latitude": 25.4513,
+    "longitude": 30.5429,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.925Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:42",
+        "sunrise": "06:14",
+        "dhuhr": "12:55",
+        "asr": "16:23",
+        "maghrib": "19:36",
+        "isha": "20:59"
+      }
+    ]
+  },
+  {
+    "city": "Ismailia",
+    "city_local": "الإسماعيلية",
+    "country": "Egypt",
+    "latitude": 30.5965,
+    "longitude": 32.2715,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.925Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:18",
+        "sunrise": "05:57",
+        "dhuhr": "12:47",
+        "asr": "16:25",
+        "maghrib": "19:38",
+        "isha": "21:06"
+      }
+    ]
+  },
+  {
+    "city": "Damietta",
+    "city_local": "دمياط",
+    "country": "Egypt",
+    "latitude": 31.4165,
+    "longitude": 31.8133,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-14T20:38:52.925Z",
+    "dates": [
+      {
+        "date": "2026-05-14",
+        "fajr": "04:16",
+        "sunrise": "05:57",
+        "dhuhr": "12:49",
+        "asr": "16:29",
+        "maghrib": "19:41",
+        "isha": "21:11"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Automated Egypt ESA daily snapshot.

- Source: Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)
- Date: 2026-05-14
- Cities: 15 mapped Egyptian cities

[positions: no-change-required] daily capture under fixtures/egypt-esa/daily; does not touch eval/data/.

Promotion into eval/data/test/ remains a separate human review step (fajr#133 follow-up: multi-season accumulation needed for Egypt C -> B promotion per docs/positions.md Promotion Criteria).

Opened manually by fajr-codex because the workflow successfully pushed the branch but GitHub Actions token is not permitted to create PRs in this repository.