### PR TITLE
fix(ci): tolerate ESA PR creation limits

### DIFF
--- a/.github/workflows/egypt-esa-snapshot.yml
+++ b/.github/workflows/egypt-esa-snapshot.yml
@@ -138,8 +138,10 @@ jobs:
           Promotion into eval/data/test/ remains a separate human review step (fajr#133 follow-up: multi-season accumulation needed for Egypt C → B promotion per docs/positions.md Promotion Criteria).
           EOF
 
-          gh pr create \
+          if ! gh pr create \
             --base master \
             --head "$branch" \
             --title "data(egypt): capture ESA daily snapshot ${ESA_SNAPSHOT_DATE}" \
-            --body-file /tmp/esa-snapshot-pr-body.md
+            --body-file /tmp/esa-snapshot-pr-body.md; then
+            echo "::warning::Snapshot branch pushed, but GitHub Actions could not create the PR. Open it manually from https://github.com/${{ github.repository }}/pull/new/${branch}."
+          fi


### PR DESCRIPTION
## Summary
- Keep the Egypt ESA snapshot workflow successful after it pushes a snapshot branch, even when this repository blocks PR creation by `GITHUB_TOKEN`.
- Emit an Actions warning with the manual PR URL instead of failing the job after a valid snapshot commit has been pushed.

## Why
The manual run 25884376939 proved the capture path now works: it fetched 15 ESA cities, created `automation/egypt-esa-2026-05-14`, and committed `fixtures/egypt-esa/daily/2026-05-14.json`. It failed only at `gh pr create` with `GitHub Actions is not permitted to create or approve pull requests`.

## Validation
- `git diff --check -- .github/workflows/egypt-esa-snapshot.yml`

[positions: no-change-required] workflow-only hardening; no source-position change.