### PR TITLE
docs: soften Saudi elevation citation wording

### DIFF
--- a/knowledge/wiki/regions/saudiarabia.md
+++ b/knowledge/wiki/regions/saudiarabia.md
@@ -4,8 +4,8 @@
 
 - **General Presidency for the Affairs of the Two Holy Mosques (الرئاسة العامة):** administers Masjid al-Haram (Mecca) + Al-Masjid an-Nabawi (Madinah) — the most-watched prayer times in the world (livestreamed Tarawih in Ramadan, Hajj season throughout Dhul Hijjah). URL: https://gph.gov.sa (geo-blocked from non-Saudi networks; reachable from Saudi-routable contributors).
 - **Umm al-Qura Calendar (Saudi Royal Court / KACST):** publishes the official Saudi Hijri calendar at https://www.ummulqura.org.sa (also geo-blocked from non-Saudi networks). Used as the global default for Hijri date computation by AlAdhan, IslamicFinder, IACAD, Microsoft Windows.
-- **Ministry of Islamic Affairs, Da'wah and Guidance (MoIA):** institutional dispatch for prayer-time conventions across all Saudi mosques. URL: https://moia.gov.sa (reachable; has a prayer-time widget on the homepage).
-- **Council of Senior Scholars / Permanent Committee for Fatwas (Al-Lajna al-Da'ima, الفتاوى للجنة الدائمة):** primary fatwa source for Saudi-stance positions on prayer-time methodology. URL: https://www.alifta.gov.sa (reachable with TLS warning).
+- **Ministry of Islamic Affairs, Da'wah and Guidance (MoIA):** institutional dispatch for prayer-time conventions across Saudi mosques. URL: https://moia.gov.sa (root URL reachable from the current network path; canonical `www.` variant may time out).
+- **Council of Senior Scholars / Permanent Committee for Fatwas (Al-Lajna al-Da'ima, الفتاوى للجنة الدائمة):** primary fatwa source for Saudi-stance positions on prayer-time methodology. URL: https://www.alifta.gov.sa (reachable from the current network path, but a specific high-rise / Haram-uniformity ruling has not been located).
 - **Population served:** ~32M Muslims (~94% of Saudi Arabia's ~35M total). Sunni-Hanbali institutional madhab; significant Twelver Shia minority in the Eastern Province (~10-15% of Saudi nationals).
 
 ## Calculation method (as implemented in fajr)
@@ -27,17 +27,28 @@ The **Asr school choice** uses the v1.7.22 metadata split:
 
 This is one of the cases where convention and applied formula align — no override needed for typical Saudi users.
 
-## The Two-Layer position on elevation correction
+## Elevation correction status
 
-**Layer 1 — Saudi scholarly endorsement of the elevation principle.** Primary Hanbali scholarship explicitly supports elevation-dependent prayer times:
-- **Sheikh Ibn 'Uthaymeen** *Majmoo' Fataawa* **Vol. 15 p. 437** addresses "high buildings" and rules each person follows their own personal sunset observation
-- **Standing Committee** (Lajnah ad-Daa'imah) is cited in IslamQA 220838 in support of the principle
+**Observer-specific principle.** Saudi/Hanbali scholarship cited through current
+secondary access supports elevation-dependent sunset handling:
+- **Sheikh Ibn 'Uthaymeen** *Majmoo' Fataawa* **Vol. 15 p. 437** is reported to address "high buildings" and rule that each person follows their own personal sunset observation.
+- **Standing Committee** (Lajnah ad-Daa'imah) is cited in IslamQA 220838 in support of the principle.
 
-**Layer 2 — Saudi institutional non-application at the Haram.** Despite endorsing the principle, Saudi Arabia **does not** apply elevation corrections near the Haram, despite the Abraj Al-Bait towers (601m, adjacent to Masjid al-Haram). The Umm al-Qura calendar uses uniform times for all of Makkah.
+**Observed institutional publication.** Saudi city timetables currently publish
+uniform times for cities such as Makkah and Madinah. fajr has not yet retrieved a
+primary GPH / MoIA / Al-Ifta text explaining whether that uniform publication is
+an explicit elevation policy, an administrative timetable convention, or a
+Haram-specific congregational practice.
 
-**Jurisprudential rationale:** the Saudi institutional position prioritizes **communal unity (jama'ah)** over individual astronomical precision **specifically at the Haram** — when the mu'adhin calls from the Haram, all Muslims in the city pray together; floor-stratified corrections would fragment the communal prayer at the world's most communally-organized prayer venue.
+**Rationale under investigation.** The jama'ah-unity explanation is plausible for
+the Haram context, but it is not yet backed by a retrieved primary ruling. Do not
+cite it as an established Saudi institutional position until fajr#132 lands.
 
-The two layers are not contradictory; they operate on different axes (scholarly principle vs. institutional application). See `knowledge/wiki/corrections/elevation.md` § "Saudi Arabia — The Two-Layer Position".
+This is why fajr treats Saudi elevation as a surfaced disagreement rather than a
+settled contradiction: the observer-specific principle has scholarly support,
+while the uniform-city publication practice remains an open primary-source
+citation gap. See `knowledge/wiki/corrections/elevation.md` for the
+correction-level position.
 
 ## Known points of ikhtilaf within the country
 
@@ -50,7 +61,10 @@ None at city level. Mecca, Madinah, Riyadh, Jeddah, Dammam all use the UmmAlQura
 
 ## Open questions / outstanding work
 
-- **GPH primary fatwa text** for the jama'ah-unity rationale (fajr#132) — blocked on Saudi-routable network access. Acquiring a primary text would lift Saudi's confidence grade from B → A per the [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
+- **GPH / MoIA / Al-Ifta primary text** for the uniform-city practice and any
+  Haram jama'ah-unity rationale (fajr#132) — still not retrieved. Acquiring a
+  primary text would lift Saudi's confidence grade from B → A per the
+  [Promotion Criteria](../../../docs/positions.md#promotion-criteria).
 - **Eastern Province Shia altMethods** — should expose Tehran/Sistani-aligned alternative for cities like Qatif, Hofuf, Awamiyya. Demographic data supports this; institutional source is Sistani.org's Imsakiyya.
 - **Mecca + Madinah Mawaqit yearly fixture** (commit `b281775`, 6 mosques × 366 days) shipped 2026-05-13 is the closest fajr-routable proxy for GPH-equivalent ground truth. Not GPH-official but useful for empirical validation of the UmmAlQura dispatch.
 
@@ -61,5 +75,5 @@ None at city level. Mecca, Madinah, Riyadh, Jeddah, Dammam all use the UmmAlQura
 - Ministry of Islamic Affairs: https://moia.gov.sa
 - Permanent Committee for Fatwas: https://www.alifta.gov.sa
 - Aladhan method 4 (Umm al-Qura): https://aladhan.com/calculation-methods
-- IslamQA 220838 (Ibn Uthaymeen + Standing Committee on elevation): https://islamqa.info/en/answers/220838
+- IslamQA 220838 (secondary access to Ibn Uthaymeen + Standing Committee on elevation): https://islamqa.info/en/answers/220838
 - Mawaqit Saudi yearly fixture: `eval/data/test/mawaqit-saudi-arabia-yearly.json` (6 mosques × 366 days)


### PR DESCRIPTION
## Summary
- softens the Saudi Arabia region wiki so the Haram jama'ah-unity explanation is presented as plausible but unresolved, not established policy
- records that MoIA root is currently reachable while `www.moia.gov.sa`, GPH, and Umm al-Qura remain unreliable from this network path
- keeps Saudi confidence at B and leaves the primary-source retrieval tracked in #132

## Issue status
Refs #132. This does not close the issue because the primary GPH / MoIA / Al-Ifta source text still has not been retrieved.

## Source check
- `curl -I --max-time 12 https://gph.gov.sa` timed out
- `curl -I --max-time 12 https://www.ummulqura.org.sa` timed out
- `curl -I --max-time 12 https://www.moia.gov.sa` timed out
- `curl -I --max-time 12 https://moia.gov.sa` returned HTTP 302
- `curl -k -I --max-time 12 https://alifta.gov.sa` returned HTTP 200
- web search found IslamQA 220838 as secondary access to Ibn Uthaymeen / Standing Committee elevation principle, but no primary Saudi uniform-city / Haram policy text

## Positions consistency
[positions: no-change-required] Wording-only downgrade of an unresolved citation claim; Saudi remains B in docs/positions.md.
[known-disagreements: no-change-required] docs/known-disagreements.md already says jama'ah unity is plausible but not backed by retrieved primary ruling.

## Maintainer-directed wiki exception
This touches `knowledge/wiki/regions/saudiarabia.md` as a maintainer-directed cleanup of a citation overclaim, not as an AutoResearch engine correction.

## Verification
- `npm test`
- `node scripts/validate-city-registry.js`
- `node scripts/audit-city-geometry.js --format json`