### PR TITLE
fix(geometry): add Klang Valley city cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 
 ## [Unreleased]
 
+### Fixed — Klang Valley city-geometry provenance
+
+- Added WOF-backed runtime rows for `Klang|MY` and `Petaling Jaya|MY`, and
+  updated `Kuala Lumpur|MY` / `Shah Alam|MY` toward reviewed WOF locality
+  envelopes.
+- Klang Valley lookup now preserves distinct city provenance for Kuala Lumpur,
+  Petaling Jaya, Shah Alam, and Klang instead of routing the western metro
+  area through overbroad Kuala Lumpur/Shah Alam cells.
+- No prayer-time calculation math, public API, regional default, or method
+  dispatch changed.
+
 ### Fixed — Singapore/Johor city-geometry seam
 
 - Added reviewed WOF source-map rows for `Singapore|SG` and `Johor Bahru|MY`.

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -172,6 +172,22 @@ The Singapore/Johor Bahru border seam also requires clipping:
   spelling row. The runtime cell uses the WOF north/east/west extents and clips
   south to `1.45`, preserving city provenance on both sides of the Causeway.
 
+The Klang Valley metro should not be represented as only Kuala Lumpur and Shah
+Alam:
+
+- WOF has current locality rows for Kuala Lumpur, Shah Alam, Petaling Jaya,
+  Subang Jaya, and Klang. Petaling Jaya and Klang are now bundled as distinct
+  registry rows, all inheriting the Malaysia/JAKIM country default.
+- Kuala Lumpur, Petaling Jaya, and Klang use current WOF locality envelopes
+  directly. Shah Alam clips between Klang and Petaling Jaya, and Kuala Lumpur
+  clips west of Petaling Jaya, so each runtime rectangle validates to itself.
+- Subang Jaya remains a reviewed-but-unshipped lead: its WOF rectangle is
+  nested inside Petaling Jaya, and a single rectangular runtime cell would break
+  the current validator. It should wait for polygon/split-cell support or a
+  separate reviewed local source.
+- This is a provenance/routing fix, not a prayer-math change. The Malaysia
+  timezone and country default remain unchanged across the cluster.
+
 Reference URLs checked in this pass:
 
 - HDX Morocco COD-AB:
@@ -232,6 +248,9 @@ from neighboring Morocco rows during `detectLocation()`'s smallest-match scan:
   Northern Singapore coordinates now keep Singapore city/timezone provenance,
   while the old overbroad Johor Bahru north/east corners no longer resolve to
   Johor Bahru city provenance.
+- `Kuala Lumpur|MY`, `Shah Alam|MY`, `Petaling Jaya|MY`, and `Klang|MY`:
+  converted from a two-cell KL/Shah approximation into WOF-backed Klang Valley
+  city cells. Petaling Jaya and Klang now exist as explicit registry rows.
 - Morocco WOF-backed runtime rows now have source-map status aligned with the
   shipped registry bboxes: Rabat, Agadir, Berrechid, Settat, Fes, Sefrou,
   Tangier, Nador, and Oujda. OSM-only rows remain audit candidates pending
@@ -278,10 +297,12 @@ validator warnings, or known clipping gaps:
 - Resolved high-risk border cluster: Singapore/Johor Bahru. It now has
   reviewed WOF source-map rows and clipped runtime cells that preserve the
   MUIS/JAKIM source boundary.
+- Resolved high-risk metro cluster: Kuala Lumpur/Shah Alam. It now has
+  reviewed WOF source-map rows plus explicit Petaling Jaya and Klang registry
+  rows, preserving Malaysia/JAKIM provenance at city level.
 - High-risk metro/border clusters: Cairo/Giza/6th of October,
-  Dubai/Sharjah/Ajman, Kuala Lumpur/Shah Alam, Toronto/Mississauga/Laval/
-  Montreal, Lahore/Sialkot/Gujranwala, Basra/Ahvaz/Kuwait City,
-  Damascus/Homs/Gaziantep.
+  Dubai/Sharjah/Ajman, Toronto/Mississauga/Laval/Montreal,
+  Lahore/Sialkot/Gujranwala, Basra/Ahvaz/Kuwait City, Damascus/Homs/Gaziantep.
 - Large heuristic bboxes such as Karachi, Istanbul, Jakarta, Bangalore, Dhaka,
   Tokyo, Seoul, Moscow, Melbourne, Sydney, Shanghai, Lagos, London, New York.
 

--- a/scripts/build-city-registry.js
+++ b/scripts/build-city-registry.js
@@ -308,6 +308,8 @@ const MUSLIM_POPULATION_CENTERS = [
 
   // ─── Malaysia non-capital ─────────────────────────────────────────────────
   { name: 'Shah Alam',  countryISO: 'MY', adminRegion: 'Selangor', lat: 3.0731, lon: 101.5183, elevation: 28, timezone: 'Asia/Kuala_Lumpur', population: 740000 },
+  { name: 'Petaling Jaya', countryISO: 'MY', adminRegion: 'Selangor', lat: 3.1074, lon: 101.6180, elevation: 45, timezone: 'Asia/Kuala_Lumpur', population: 639000 },
+  { name: 'Klang',      countryISO: 'MY', adminRegion: 'Selangor', lat: 3.1062, lon: 101.3994, elevation: 10, timezone: 'Asia/Kuala_Lumpur', population: 879000 },
   { name: 'George Town', countryISO: 'MY', adminRegion: 'Penang', lat: 5.4141, lon: 100.3288, elevation: 4, timezone: 'Asia/Kuala_Lumpur', population: 708000 },
   { name: 'Johor Bahru', countryISO: 'MY', adminRegion: 'Johor', lat: 1.4927, lon: 103.7414, elevation: 26, timezone: 'Asia/Kuala_Lumpur', population: 858000 },
   { name: 'Kuching',    countryISO: 'MY', adminRegion: 'Sarawak', lat: 1.5533, lon: 110.3592, elevation: 27, timezone: 'Asia/Kuching', population: 325000 },
@@ -819,11 +821,8 @@ const BBOX_OVERRIDES = {
   // south of central Cairo). v1.8.0 #118: western lon raised to 30.98 so
   // 6th of October no longer shadows Giza's western validation samples.
   'Giza|EG':            [29.6131, 30.10, 30.98, 31.22],
-  // v1.7.5 #47: Shah Alam (740K) is ~25 km west of KL (1.8M). Same-radius
-  // 0.15° bbox put Shah Alam at lon 101.32-101.72, KL at 101.39-101.99.
-  // KL CBD (3.14, 101.69) sat in both. Shrink Shah Alam's eastern lon to
-  // 101.55 (Shah Alam city centre 101.52 stays inside; KL CBD excluded).
-  'Shah Alam|MY':       [2.8731, 3.2731, 101.3183, 101.55],
+  // v1.7.5 #47 / v1.8.0 #118: Klang Valley overrides now live below in the
+  // WOF-backed runtime-cell block.
   // v1.7.5 #47: Johor Bahru (858K) sits across the Causeway from Singapore.
   // Same-radius 0.15° bbox extended south to lat 1.29 — well inside
   // Singapore's island. Trim southern lat to 1.43 (just north of Singapore's
@@ -917,9 +916,13 @@ const BBOX_OVERRIDES = {
   // Fes row and matches the OSM admin-8 envelope; use it to avoid broad
   // city-provenance leakage around the Fes lookup cell.
   'Fes|MA':             [33.97125, 34.076345, -5.078619, -4.937726],
-  // v1.7.22 #86: keep Shah Alam's own centre lon 101.5183 inside the bbox
-  // while still excluding KL CBD at lon ~101.69.
-  'Shah Alam|MY':       [2.8731, 3.2731, 101.3183, 101.55],
+  // v1.7.22 #86 / v1.8.0 #118: Klang Valley WOF-backed runtime cells.
+  // Petaling Jaya and Klang are distinct city rows so KL and Shah Alam no
+  // longer need to absorb those coordinates. Subang Jaya remains unbundled
+  // until the registry supports non-rectangular cells or reviewed splits.
+  'Klang|MY':           [2.917544, 3.220857, 101.348877, 101.497192],
+  'Shah Alam|MY':       [2.939489, 3.207902, 101.497192, 101.557617],
+  'Petaling Jaya|MY':   [3.04761, 3.208733, 101.557617, 101.661987],
   // v1.8.0 #118: Singapore/Johor WOF-backed seam. Singapore uses WOF
   // government-sourced west/east/south extents and clips north just below
   // Johor; Johor Bahru uses the WOF locality envelope clipped south at the
@@ -927,7 +930,7 @@ const BBOX_OVERRIDES = {
   // returning Johor Bahru for Singapore coordinates.
   'Singapore|SG':       [1.158699, 1.4499, 103.605701, 104.088483],
   'Johor Bahru|MY':     [1.45, 1.609285, 103.564621, 103.872185],
-  'Kuala Lumpur|MY':    [2.939, 3.339, 101.55, 101.99],
+  'Kuala Lumpur|MY':    [3.036487, 3.319571, 101.661987, 101.777344],
   // v1.8.0 #118: WOF locality envelopes remove the Basel/Mulhouse
   // cross-border validator warning without clipping either city centre.
   'Basel|CH':           [47.519297, 47.589902, 7.554659, 7.634148],

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -812,6 +812,108 @@
       ]
     },
     {
+      "cityKey": "Klang|MY",
+      "priority": ["klang-valley-metro", "wof-locality-runtime-bbox", "apac-p0", "clipped"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox added from WOF current locality geometry as the western Klang Valley cell."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Shah Alam|MY", "kind": "runtime-edge-touch", "status": "Klang east edge meets Shah Alam west edge at lon 101.497192." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:102022835",
+          "ids": { "wofId": 102022835, "repo": "whosonfirst-data-admin-my", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "MY/klang/wof-locality-102022835.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["Runtime bbox uses the WOF current locality envelope."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Shah Alam|MY",
+      "priority": ["klang-valley-metro", "wof-locality-runtime-bbox", "apac-p0", "clipped"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox updated from WOF current locality geometry and clipped between Klang and Petaling Jaya."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Klang|MY", "kind": "runtime-edge-touch", "status": "Shah Alam west edge meets Klang east edge at lon 101.497192." },
+        { "cityKey": "Petaling Jaya|MY", "kind": "runtime-edge-touch", "status": "Shah Alam east edge meets Petaling Jaya west edge at lon 101.557617." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:102022833",
+          "ids": { "wofId": 102022833, "repo": "whosonfirst-data-admin-my", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "MY/shah-alam/wof-locality-102022833.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["Full WOF locality bbox spans lon 101.436768-101.596756; runtime clips west/east edges so Klang and Petaling Jaya keep their own city provenance."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Petaling Jaya|MY",
+      "priority": ["klang-valley-metro", "wof-locality-runtime-bbox", "apac-p0", "clipped"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox added from WOF current locality geometry and clipped as the western neighbor of Kuala Lumpur."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Shah Alam|MY", "kind": "runtime-edge-touch", "status": "Petaling Jaya west edge meets Shah Alam east edge at lon 101.557617." },
+        { "cityKey": "Kuala Lumpur|MY", "kind": "runtime-edge-touch", "status": "Petaling Jaya east edge meets Kuala Lumpur west edge at lon 101.661987." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:102023395",
+          "ids": { "wofId": 102023395, "repo": "whosonfirst-data-admin-my", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "MY/petaling-jaya/wof-locality-102023395.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["Runtime bbox uses the WOF current locality envelope."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Kuala Lumpur|MY",
+      "priority": ["klang-valley-metro", "wof-locality-runtime-bbox", "apac-p0", "clipped"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox updated from WOF current locality geometry and clipped west of Petaling Jaya."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Petaling Jaya|MY", "kind": "runtime-edge-touch", "status": "Kuala Lumpur west edge meets Petaling Jaya east edge at lon 101.661987." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:102023407",
+          "ids": { "wofId": 102023407, "repo": "whosonfirst-data-admin-my", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "MY/kuala-lumpur/wof-locality-102023407.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["Full WOF locality bbox starts at lon 101.57959; runtime clips west edge to 101.661987 so Petaling Jaya keeps its own city provenance."]
+        }
+      ]
+    },
+    {
       "cityKey": "Windsor|CA",
       "priority": ["detroit-windsor-border", "wof-locality-runtime-bbox", "clipped"],
       "review": {

--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -1,6 +1,6 @@
 {
   "version": "1.7.0-alpha.0",
-  "generated": "2026-05-14T21:51:17.168Z",
+  "generated": "2026-05-14T22:06:46.714Z",
   "license": {
     "world-cities": "Capital data from UN Statistics Division and Wikipedia (public-domain reference, MIT-aligned)",
     "mawaqit-slugs": "Curated metadata derived from public Mawaqit profile pages (slugs only)",
@@ -8,7 +8,7 @@
     "population-centers": "Manual, sourced from UN World Cities + World Population Review 2024-2025"
   },
   "notes": "Cities sorted by bbox area ascending. detectLocation() linear-scans this array and returns the first bbox that contains (lat, lon) — smallest match wins. Each city carries an institutional `source` (mawaqit | national-authority | inherited) so apps can attribute timetable provenance to users. Method overrides are city-level institutional decisions documented in scripts/data/city-method-overrides.json with citation strings.",
-  "total": 481,
+  "total": 483,
   "cities": [
     {"name":"Alburikent (Dagestan)","countryISO":"RU","lat":42.9234,"lon":47.5089,"bbox":[42.92,42.94,47.5,47.52],"timezone":"Europe/Moscow","adminRegion":"Dagestan","population":11000,"elevation":50,"source":{"type":"mawaqit","slug":"alburkent-dzhuma-mechet-alburikent-367026-russia"}},
     {"name":"Isa Town","countryISO":"BH","lat":26.1762,"lon":50.5495,"bbox":[26.16,26.19,50.53,50.56],"timezone":"Asia/Bahrain","population":38000,"elevation":21,"source":{"type":"mawaqit","slug":"masjid-madina-issa-south-810-issa-town-bahrain"}},
@@ -45,7 +45,9 @@
     {"name":"Temara","countryISO":"MA","lat":33.9281,"lon":-6.9067,"bbox":[33.85,33.96,-7,-6.86],"timezone":"Africa/Casablanca","population":313000,"elevation":75,"source":{"type":"mawaqit","slug":"msjd-bd-llh-bn-ysyn-temara-12123-morocco"}},
     {"name":"Strasbourg","countryISO":"FR","lat":48.5734,"lon":7.7521,"bbox":[48.492024,48.646236,7.687934,7.79],"timezone":"Europe/Paris","adminRegion":"Grand Est","population":287000,"elevation":142,"source":{"type":"mawaqit","slug":"mosquee-quba-neudorf-strasbourg-67100-france"}},
     {"name":"Dearborn","countryISO":"US","lat":42.3223,"lon":-83.1763,"bbox":[42.32,42.4,-83.28,-83.08],"timezone":"America/Detroit","adminRegion":"Michigan","population":109000,"elevation":184,"methodOverride":"ISNA","altMethods":[{"method":"Tehran","source":"Iraqi-Lebanese Shia diaspora — Islamic Center of America (Dearborn) and other Najaf-Karbala diaspora institutions follow Tehran-style timing for the Twelver Shia community"}],"source":{"type":"national-authority","institution":"Islamic Society of North America"}},
+    {"name":"Shah Alam","countryISO":"MY","lat":3.0731,"lon":101.5183,"bbox":[2.939489,3.207902,101.497192,101.557617],"timezone":"Asia/Kuala_Lumpur","adminRegion":"Selangor","population":740000,"elevation":28,"source":{"type":"inherited","from":"Malaysia"}},
     {"name":"Luton","countryISO":"GB","lat":51.8787,"lon":-0.42,"bbox":[51.82,51.94,-0.5,-0.36],"timezone":"Europe/London","adminRegion":"Bedfordshire","population":213000,"elevation":122,"source":{"type":"inherited","from":"UK"}},
+    {"name":"Petaling Jaya","countryISO":"MY","lat":3.1074,"lon":101.618,"bbox":[3.04761,3.208733,101.557617,101.661987],"timezone":"Asia/Kuala_Lumpur","adminRegion":"Selangor","population":639000,"elevation":45,"source":{"type":"inherited","from":"Malaysia"}},
     {"name":"Bursa","countryISO":"TR","lat":40.1885,"lon":29.061,"bbox":[40.16606,40.253447,28.996355,29.20099],"timezone":"Europe/Istanbul","adminRegion":"Bursa Province","population":3139000,"elevation":100,"source":{"type":"inherited","from":"Turkey"}},
     {"name":"Dusseldorf","countryISO":"DE","lat":51.2277,"lon":6.7735,"bbox":[51.18,51.3,6.7,6.85],"timezone":"Europe/Berlin","nameLocal":"Düsseldorf","adminRegion":"North Rhine-Westphalia","population":619000,"elevation":38,"source":{"type":"inherited","from":"Germany"}},
     {"name":"Manama","countryISO":"BH","lat":26.2285,"lon":50.586,"bbox":[26.2,26.3,50.46,50.65],"timezone":"Asia/Bahrain","population":158000,"elevation":5,"source":{"type":"mawaqit","slug":"jm-lsyf-manama-seef-428-bahrain"}},
@@ -67,6 +69,7 @@
     {"name":"Dire Dawa","countryISO":"ET","lat":9.5898,"lon":41.855,"bbox":[9.5,9.68,41.78,41.95],"timezone":"Africa/Addis_Ababa","adminRegion":"Dire Dawa","population":466000,"elevation":1276,"source":{"type":"inherited","from":"Ethiopia"}},
     {"name":"Khartoum","countryISO":"SD","lat":15.5007,"lon":32.5599,"bbox":[15.4,15.6,32.5,32.66],"timezone":"Africa/Khartoum","elevation":381,"source":{"type":"national-authority","institution":"Egyptian General Authority of Survey"}},
     {"name":"Leeds","countryISO":"GB","lat":53.8008,"lon":-1.5491,"bbox":[53.74,53.87,-1.65,-1.4],"timezone":"Europe/London","adminRegion":"West Yorkshire","population":793000,"elevation":64,"source":{"type":"inherited","from":"UK"}},
+    {"name":"Kuala Lumpur","countryISO":"MY","lat":3.139,"lon":101.6869,"bbox":[3.036487,3.319571,101.661987,101.777344],"timezone":"Asia/Kuala_Lumpur","population":1809000,"elevation":22,"source":{"type":"mawaqit","slug":"surau-ar-raudhah-islamiah-kuala-lumpur-54200-malaysia-2"}},
     {"name":"The Hague","countryISO":"NL","lat":52.0705,"lon":4.3007,"bbox":[52,52.18,4.2,4.4],"timezone":"Europe/Amsterdam","adminRegion":"South Holland","population":552000,"elevation":1,"source":{"type":"inherited","from":"Netherlands"}},
     {"name":"Sharjah","countryISO":"AE","lat":25.3463,"lon":55.4209,"bbox":[25.3,25.398821,55.3,55.678456],"timezone":"Asia/Dubai","nameLocal":"الشارقة","adminRegion":"Sharjah Emirate","population":1684000,"elevation":14,"source":{"type":"inherited","from":"UAE"}},
     {"name":"Astana","countryISO":"KZ","lat":51.1694,"lon":71.4491,"bbox":[51.0694,51.2694,71.3491,71.5491],"timezone":"Asia/Almaty","elevation":347,"source":{"type":"national-authority","institution":"Muslim World League"}},
@@ -206,6 +209,7 @@
     {"name":"Wellington","countryISO":"NZ","lat":-41.2865,"lon":174.7762,"bbox":[-41.3865,-41.1865,174.6762,174.8762],"timezone":"Pacific/Auckland","elevation":13,"source":{"type":"inherited","from":"NZ"}},
     {"name":"Port Moresby","countryISO":"PG","lat":-9.4438,"lon":147.1803,"bbox":[-9.5438,-9.3438,147.0803,147.2803],"timezone":"Pacific/Port_Moresby","elevation":49,"source":{"type":"inherited","from":"PG"}},
     {"name":"Casablanca","countryISO":"MA","lat":33.5731,"lon":-7.5898,"bbox":[33.494823,33.647306,-7.738187,-7.459445],"timezone":"Africa/Casablanca","nameLocal":"الدار البيضاء","adminRegion":"Casablanca-Settat","population":3460000,"elevation":27,"source":{"type":"mawaqit","slug":"moulay-ismail-casablanca-20400-morocco"}},
+    {"name":"Klang","countryISO":"MY","lat":3.1062,"lon":101.3994,"bbox":[2.917544,3.220857,101.348877,101.497192],"timezone":"Asia/Kuala_Lumpur","adminRegion":"Selangor","population":879000,"elevation":10,"source":{"type":"inherited","from":"Malaysia"}},
     {"name":"Johor Bahru","countryISO":"MY","lat":1.4927,"lon":103.7414,"bbox":[1.45,1.609285,103.564621,103.872185],"timezone":"Asia/Kuala_Lumpur","adminRegion":"Johor","population":858000,"elevation":26,"source":{"type":"inherited","from":"Malaysia"}},
     {"name":"Antalya","countryISO":"TR","lat":36.8841,"lon":30.7056,"bbox":[36.821577,37.012346,30.583049,30.853306],"timezone":"Europe/Istanbul","adminRegion":"Antalya Province","population":1259000,"elevation":30,"source":{"type":"inherited","from":"Turkey"}},
     {"name":"Laval","countryISO":"CA","lat":45.6066,"lon":-73.7124,"bbox":[45.55,45.75,-73.86,-73.59],"timezone":"America/Toronto","population":438000,"elevation":39,"source":{"type":"mawaqit","slug":"iqra-laval-h7v-2v5-canada"}},
@@ -288,7 +292,6 @@
     {"name":"Kuching","countryISO":"MY","lat":1.5533,"lon":110.3592,"bbox":[1.4033,1.7033,110.2092,110.5092],"timezone":"Asia/Kuching","adminRegion":"Sarawak","population":325000,"elevation":27,"source":{"type":"inherited","from":"Malaysia"}},
     {"name":"Miami","countryISO":"US","lat":25.7617,"lon":-80.1918,"bbox":[25.6117,25.9117,-80.3418,-80.0418],"timezone":"America/New_York","adminRegion":"Florida","population":467000,"elevation":2,"source":{"type":"inherited","from":"USA"}},
     {"name":"Khujand","countryISO":"TJ","lat":40.2854,"lon":69.6203,"bbox":[40.1354,40.4354,69.4703,69.7703],"timezone":"Asia/Dushanbe","nameLocal":"Хуҷанд","adminRegion":"Sughd","population":181000,"elevation":320,"source":{"type":"inherited","from":"Tajikistan"}},
-    {"name":"Shah Alam","countryISO":"MY","lat":3.0731,"lon":101.5183,"bbox":[2.8731,3.2731,101.3183,101.55],"timezone":"Asia/Kuala_Lumpur","adminRegion":"Selangor","population":740000,"elevation":28,"source":{"type":"inherited","from":"Malaysia"}},
     {"name":"Ankara","countryISO":"TR","lat":39.9334,"lon":32.8597,"bbox":[39.776496,40.032011,32.611664,33.007367],"timezone":"Europe/Istanbul","elevation":938,"source":{"type":"national-authority","institution":"Diyanet İşleri Başkanlığı"}},
     {"name":"Rotterdam","countryISO":"NL","lat":51.9244,"lon":4.4777,"bbox":[51.72,52,4.28,4.68],"timezone":"Europe/Amsterdam","adminRegion":"South Holland","population":651000,"elevation":0,"source":{"type":"mawaqit","slug":"pakistan-islamic-centre-rotterdam-rotterdam-3014-ed-netherlands"}},
     {"name":"Doha","countryISO":"QA","lat":25.2854,"lon":51.531,"bbox":[25.05,25.5,51.4,51.65],"timezone":"Asia/Qatar","population":2382000,"elevation":10,"source":{"type":"mawaqit","slug":"masjid-imam-muhammad-bin-abdul-wahhab-doha-00000-qatar"}},
@@ -369,7 +372,6 @@
     {"name":"Nampula","countryISO":"MZ","lat":-15.1167,"lon":39.2667,"bbox":[-15.3167,-14.9167,39.0667,39.4667],"timezone":"Africa/Maputo","population":743000,"elevation":441,"source":{"type":"mawaqit","slug":"masjid-fatimah-rua-monomotapa-3100-nampula-mozambique"}},
     {"name":"Rajshahi","countryISO":"BD","lat":24.3636,"lon":88.6241,"bbox":[24.1636,24.5636,88.4241,88.8241],"timezone":"Asia/Dhaka","nameLocal":"রাজশাহী","adminRegion":"Rajshahi Division","population":760000,"elevation":18,"source":{"type":"inherited","from":"Bangladesh"}},
     {"name":"Bahawalpur","countryISO":"PK","lat":29.3956,"lon":71.6722,"bbox":[29.1956,29.5956,71.4722,71.8722],"timezone":"Asia/Karachi","nameLocal":"بہاولپور","adminRegion":"Punjab","population":762000,"elevation":116,"source":{"type":"inherited","from":"Pakistan"}},
-    {"name":"Kuala Lumpur","countryISO":"MY","lat":3.139,"lon":101.6869,"bbox":[2.939,3.339,101.55,101.99],"timezone":"Asia/Kuala_Lumpur","population":1809000,"elevation":22,"source":{"type":"mawaqit","slug":"surau-ar-raudhah-islamiah-kuala-lumpur-54200-malaysia-2"}},
     {"name":"Dubai","countryISO":"AE","lat":25.2048,"lon":55.2708,"bbox":[24.9,25.3,55.05,55.5],"timezone":"Asia/Dubai","nameLocal":"دبي","adminRegion":"Dubai Emirate","population":3604000,"elevation":5,"source":{"type":"inherited","from":"UAE"}},
     {"name":"Al Ain","countryISO":"AE","lat":24.2075,"lon":55.7447,"bbox":[24.013749,24.414416,55.464609,56.018126],"timezone":"Asia/Dubai","nameLocal":"العين","adminRegion":"Abu Dhabi Emirate","population":766000,"elevation":295,"source":{"type":"inherited","from":"UAE"}},
     {"name":"Hong Kong","countryISO":"HK","lat":22.3193,"lon":114.1694,"bbox":[22.16,22.55,113.85,114.43],"timezone":"Asia/Hong_Kong","population":7482000,"elevation":50,"source":{"type":"inherited","from":"HongKong"}},

--- a/test/detectLocation.test.js
+++ b/test/detectLocation.test.js
@@ -541,6 +541,26 @@ describe('detectLocation — issue #47 regression', () => {
     expect(oldEastCorner.country).toBe('Malaysia')
   })
 
+  it('Klang Valley WOF-clipped cells preserve local city provenance', () => {
+    const kualaLumpur = detectLocation(3.139, 101.6869)
+    expect(kualaLumpur.city?.name).toBe('Kuala Lumpur')
+    expect(kualaLumpur.country).toBe('Malaysia')
+    expect(kualaLumpur.timezone).toBe('Asia/Kuala_Lumpur')
+
+    const petalingJaya = detectLocation(3.1074, 101.6180)
+    expect(petalingJaya.city?.name).toBe('Petaling Jaya')
+    expect(petalingJaya.country).toBe('Malaysia')
+    expect(petalingJaya.timezone).toBe('Asia/Kuala_Lumpur')
+
+    const shahAlam = detectLocation(3.0844, 101.5246)
+    expect(shahAlam.city?.name).toBe('Shah Alam')
+    expect(shahAlam.country).toBe('Malaysia')
+
+    const klang = detectLocation(3.1062, 101.3994)
+    expect(klang.city?.name).toBe('Klang')
+    expect(klang.country).toBe('Malaysia')
+  })
+
   // Additional v1.7.5 regression cases (Reviewer C's "definitely wrong" list).
   it('Sharm el-Sheikh → country=Egypt with Egyptian method (was SaudiArabia/UmmAlQura)', () => {
     const loc = detectLocation(27.92, 34.33)

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -99,6 +99,10 @@ describe('city geometry source map', () => {
       ['Trabzon|TR', 'wof:locality:101912783'],
       ['Singapore|SG', 'wof:locality:102032341'],
       ['Johor Bahru|MY', 'wof:locality:102022781'],
+      ['Klang|MY', 'wof:locality:102022835'],
+      ['Shah Alam|MY', 'wof:locality:102022833'],
+      ['Petaling Jaya|MY', 'wof:locality:102023395'],
+      ['Kuala Lumpur|MY', 'wof:locality:102023407'],
       ['Windsor|CA', 'wof:locality:101735855'],
       ['Geneva|CH', 'wof:locality:101748445'],
       ['Annemasse|FR', 'wof:locality:101757307'],
@@ -152,6 +156,10 @@ describe('city geometry source map', () => {
     expect(statusFor('Trabzon|TR')).toBe('runtime-bbox-shipped')
     expect(statusFor('Singapore|SG')).toBe('runtime-bbox-shipped')
     expect(statusFor('Johor Bahru|MY')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Klang|MY')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Shah Alam|MY')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Petaling Jaya|MY')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Kuala Lumpur|MY')).toBe('runtime-bbox-shipped')
     expect(statusFor('Windsor|CA')).toBe('runtime-bbox-shipped')
     expect(statusFor('Geneva|CH')).toBe('runtime-bbox-shipped')
     expect(statusFor('Annemasse|FR')).toBe('runtime-bbox-shipped')


### PR DESCRIPTION
Refs #118

[positions: no-change-required]
[known-disagreements: no-change-required]

## Summary
- Add WOF-backed runtime rows for `Klang|MY` and `Petaling Jaya|MY`.
- Update `Kuala Lumpur|MY` and `Shah Alam|MY` toward reviewed WOF locality geometry with clipped edge-touching runtime cells.
- Add Klang Valley WOF source-map rows for Kuala Lumpur, Shah Alam, Petaling Jaya, and Klang.
- Regenerate `src/data/cities.json` after the new city rows.

## User-visible behavior
- `detectLocation(3.139, 101.6869)` remains Kuala Lumpur / Malaysia / `Asia/Kuala_Lumpur`.
- `detectLocation(3.1074, 101.6180)` now resolves to Petaling Jaya instead of overbroad Kuala Lumpur.
- `detectLocation(3.0844, 101.5246)` remains Shah Alam.
- `detectLocation(3.1062, 101.3994)` now resolves to Klang instead of overbroad Shah Alam.

## Review notes
- This is a reverse-geolocation/provenance fix only. Malaysia timezone, JAKIM country default, prayer math, public API, and regional positions are unchanged.
- Subang Jaya has a current WOF row, but I did not ship it as a runtime row in this PR. Its WOF rectangle is nested inside Petaling Jaya, and a single rectangular cell breaks the registry validator. The docs record it as a reviewed-but-unshipped lead for polygon/split-cell support.
- Klang and Petaling Jaya inherit Malaysia/JAKIM country defaults like the rest of the cluster.

## Verification
- `npm test` — 21 files / 413 tests passed
- `npm run validate:registry` — passed, 0 fail-class issues; 1 existing warn-class allowlist
- `node scripts/build-city-registry.js --check` — passed
- `npx vitest run test/detectLocation.test.js test/geometrySourceMap.test.js test/cityRegistryValidation.test.js` — 70/70 passed
- `node scripts/audit-city-geometry.js --format json` — 47 source-map cities; 61 rows; 60 checked; 0 missing cache files; 0 missing geometry; 0 city-not-found
- `npm run build:charts` — run after `src/data/cities.json` regeneration; no chart/progress diff remained
- `npm pack --dry-run` — 146.9 kB packed / 539.1 kB unpacked / 21 files
- `git diff --check` — passed

## Eval note
I did not run `node eval/eval.js` because this is a city reverse-geolocation/provenance change, not an engine calibration or prayer-time math change. No eval data or ratchet files were modified.
