### PR TITLE
fix(geometry): tighten Sialkot lookup cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 
 ## [Unreleased]
 
+### Fixed — Sialkot/Gujranwala city-geometry overlap
+
+- Updated `Sialkot|PK` to a reviewed WOF current locality envelope, removing
+  the previous overlap where Gujranwala north-east coordinates could resolve to
+  Sialkot city provenance.
+- Lahore and Gujranwala WOF rows were reviewed but left out of runtime changes
+  to avoid a broader coverage shift in this patch.
+- No prayer-time calculation math, public API, regional default, or method
+  dispatch changed.
+
 ### Fixed — Klang Valley city-geometry provenance
 
 - Added WOF-backed runtime rows for `Klang|MY` and `Petaling Jaya|MY`, and

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -188,6 +188,18 @@ Alam:
 - This is a provenance/routing fix, not a prayer-math change. The Malaysia
   timezone and country default remain unchanged across the cluster.
 
+The Pakistan Punjab Sialkot/Gujranwala overlap has a small, source-backed fix:
+
+- WOF has current locality rows for Lahore, Gujranwala, and Sialkot. This pass
+  ships only Sialkot because the concrete runtime bug was a remaining overlap:
+  Gujranwala north-east coordinates such as `(32.42, 74.46)` resolved to
+  Sialkot.
+- Sialkot now uses the reviewed WOF current locality envelope. Lahore and
+  Gujranwala WOF rows remain reviewed leads, not runtime changes, to avoid a
+  broader coverage shift in the same PR.
+- This is a Pakistan city-provenance fix only. Country, timezone, and Karachi
+  method routing remain unchanged.
+
 Reference URLs checked in this pass:
 
 - HDX Morocco COD-AB:
@@ -251,6 +263,8 @@ from neighboring Morocco rows during `detectLocation()`'s smallest-match scan:
 - `Kuala Lumpur|MY`, `Shah Alam|MY`, `Petaling Jaya|MY`, and `Klang|MY`:
   converted from a two-cell KL/Shah approximation into WOF-backed Klang Valley
   city cells. Petaling Jaya and Klang now exist as explicit registry rows.
+- `Sialkot|PK`: moved to a reviewed WOF current locality envelope so
+  Gujranwala north-east coordinates no longer resolve to Sialkot.
 - Morocco WOF-backed runtime rows now have source-map status aligned with the
   shipped registry bboxes: Rabat, Agadir, Berrechid, Settat, Fes, Sefrou,
   Tangier, Nador, and Oujda. OSM-only rows remain audit candidates pending
@@ -300,9 +314,12 @@ validator warnings, or known clipping gaps:
 - Resolved high-risk metro cluster: Kuala Lumpur/Shah Alam. It now has
   reviewed WOF source-map rows plus explicit Petaling Jaya and Klang registry
   rows, preserving Malaysia/JAKIM provenance at city level.
+- Resolved high-risk overlap: Sialkot/Gujranwala. Sialkot now has a reviewed
+  WOF source-map row and no longer shadows Gujranwala's north-east edge.
 - High-risk metro/border clusters: Cairo/Giza/6th of October,
   Dubai/Sharjah/Ajman, Toronto/Mississauga/Laval/Montreal,
-  Lahore/Sialkot/Gujranwala, Basra/Ahvaz/Kuwait City, Damascus/Homs/Gaziantep.
+  Lahore/Gujranwala broader coverage, Basra/Ahvaz/Kuwait City,
+  Damascus/Homs/Gaziantep.
 - Large heuristic bboxes such as Karachi, Istanbul, Jakarta, Bangalore, Dhaka,
   Tokyo, Seoul, Moscow, Melbourne, Sydney, Shanghai, Lagos, London, New York.
 

--- a/scripts/build-city-registry.js
+++ b/scripts/build-city-registry.js
@@ -1064,11 +1064,11 @@ const BBOX_OVERRIDES = {
   // so Jaamuuq (lat 9.78) is outside.
   'Dire Dawa|ET':       [9.50, 9.68, 41.78, 41.95],
 
-  // v1.7.19 (#75): Sialkot PK (32.49, 74.52) vs Gujranwala PK (32.19, 74.19).
-  // Both Pakistan. Default formula bboxes overlap on lat 32.29-32.49 / lon
-  // 74.32-74.49. Tighten Sialkot to its own metro extent, leaving Gujranwala
-  // unambiguous below.
-  'Sialkot|PK':         [32.40, 32.60, 74.45, 74.65],
+  // v1.7.19 (#75) / v1.8.0 #118: Sialkot PK vs Gujranwala PK. The older
+  // hand-tightened Sialkot box still overlapped Gujranwala's north-east edge,
+  // so Gujranwala samples such as (32.42, 74.46) resolved to Sialkot. Use the
+  // reviewed WOF current locality envelope for Sialkot to remove that overlap.
+  'Sialkot|PK':         [32.471302, 32.536788, 74.494765, 74.594771],
 
   // v1.7.18: Manama BH (lat 26.23) vs Isa Town BH (lat 26.18). Isa Town
   // has tight 0.03° bbox at 26.16-26.19 / 50.53-50.56. Pre-existing

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -914,6 +914,31 @@
       ]
     },
     {
+      "cityKey": "Sialkot|PK",
+      "priority": ["pakistan-punjab-metro", "wof-locality-runtime-bbox", "overlap-fix", "apac-p0"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": ["2026-05-14: runtime bbox updated to WOF current locality geometry to remove overlap with Gujranwala's north-east edge."]
+      },
+      "neighborRelations": [
+        { "cityKey": "Gujranwala|PK", "kind": "runtime-separated", "status": "Sialkot west edge now starts east of Gujranwala's runtime east edge." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421175525",
+          "ids": { "wofId": 421175525, "repo": "whosonfirst-data-admin-pk", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "PK/sialkot/wof-locality-421175525.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["Runtime bbox uses the WOF current locality envelope. Lahore and Gujranwala WOF rows were reviewed but not shipped in this PR to avoid broad coverage changes."]
+        }
+      ]
+    },
+    {
       "cityKey": "Windsor|CA",
       "priority": ["detroit-windsor-border", "wof-locality-runtime-bbox", "clipped"],
       "review": {

--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -1,6 +1,6 @@
 {
   "version": "1.7.0-alpha.0",
-  "generated": "2026-05-14T22:06:46.714Z",
+  "generated": "2026-05-14T22:12:36.873Z",
   "license": {
     "world-cities": "Capital data from UN Statistics Division and Wikipedia (public-domain reference, MIT-aligned)",
     "mawaqit-slugs": "Curated metadata derived from public Mawaqit profile pages (slugs only)",
@@ -25,6 +25,7 @@
     {"name":"Basel","countryISO":"CH","lat":47.5596,"lon":7.5886,"bbox":[47.519297,47.589902,7.554659,7.634148],"timezone":"Europe/Zurich","population":173000,"elevation":260,"source":{"type":"mawaqit","slug":"masjid-arrahma-bale-4057-switzerland"}},
     {"name":"Inezgane","countryISO":"MA","lat":30.3552,"lon":-9.5378,"bbox":[30.32,30.39,-9.58,-9.49],"timezone":"Africa/Casablanca","population":130000,"elevation":33,"source":{"type":"mawaqit","slug":"msjd-lbrr-nzkn-86150-morocco"}},
     {"name":"Izmir","countryISO":"TR","lat":38.4237,"lon":27.1428,"bbox":[38.392484,38.44875,27.071401,27.184235],"timezone":"Europe/Istanbul","adminRegion":"Izmir Province","population":4367000,"elevation":25,"source":{"type":"inherited","from":"Turkey"}},
+    {"name":"Sialkot","countryISO":"PK","lat":32.4945,"lon":74.5229,"bbox":[32.471302,32.536788,74.494765,74.594771],"timezone":"Asia/Karachi","adminRegion":"Punjab","population":656000,"elevation":256,"source":{"type":"inherited","from":"Pakistan"}},
     {"name":"Niagara Falls","countryISO":"CA","lat":43.0896,"lon":-79.0849,"bbox":[43.05,43.13,-79.13,-79.04],"timezone":"America/Toronto","adminRegion":"Ontario","population":88000,"elevation":167,"source":{"type":"inherited","from":"Canada"}},
     {"name":"Nador","countryISO":"MA","lat":35.1741,"lon":-2.9287,"bbox":[35.126272,35.223768,-2.962899,-2.88235],"timezone":"Africa/Casablanca","population":188000,"elevation":6,"source":{"type":"mawaqit","slug":"masjid-al-falah-nador-66000-morocco"}},
     {"name":"Settat","countryISO":"MA","lat":33.0017,"lon":-7.6166,"bbox":[32.959792,33.036468,-7.679587,-7.576121],"timezone":"Africa/Casablanca","population":142000,"elevation":369,"source":{"type":"mawaqit","slug":"mosquee-imam-tarmidi-settat-26000-morocco"}},
@@ -205,7 +206,6 @@
     {"name":"Ulaanbaatar","countryISO":"MN","lat":47.8864,"lon":106.9057,"bbox":[47.7864,47.9864,106.8057,107.0057],"timezone":"Asia/Ulaanbaatar","elevation":1310,"source":{"type":"inherited","from":"MN"}},
     {"name":"Pyongyang","countryISO":"KP","lat":39.0392,"lon":125.7625,"bbox":[38.9392,39.1392,125.6625,125.8625],"timezone":"Asia/Pyongyang","elevation":38,"source":{"type":"inherited","from":"KP"}},
     {"name":"Santiago","countryISO":"CL","lat":-33.4489,"lon":-70.6693,"bbox":[-33.5489,-33.3489,-70.7693,-70.5693],"timezone":"America/Santiago","elevation":520,"source":{"type":"inherited","from":"CL"}},
-    {"name":"Sialkot","countryISO":"PK","lat":32.4945,"lon":74.5229,"bbox":[32.4,32.6,74.45,74.65],"timezone":"Asia/Karachi","adminRegion":"Punjab","population":656000,"elevation":256,"source":{"type":"inherited","from":"Pakistan"}},
     {"name":"Wellington","countryISO":"NZ","lat":-41.2865,"lon":174.7762,"bbox":[-41.3865,-41.1865,174.6762,174.8762],"timezone":"Pacific/Auckland","elevation":13,"source":{"type":"inherited","from":"NZ"}},
     {"name":"Port Moresby","countryISO":"PG","lat":-9.4438,"lon":147.1803,"bbox":[-9.5438,-9.3438,147.0803,147.2803],"timezone":"Pacific/Port_Moresby","elevation":49,"source":{"type":"inherited","from":"PG"}},
     {"name":"Casablanca","countryISO":"MA","lat":33.5731,"lon":-7.5898,"bbox":[33.494823,33.647306,-7.738187,-7.459445],"timezone":"Africa/Casablanca","nameLocal":"الدار البيضاء","adminRegion":"Casablanca-Settat","population":3460000,"elevation":27,"source":{"type":"mawaqit","slug":"moulay-ismail-casablanca-20400-morocco"}},

--- a/test/detectLocation.test.js
+++ b/test/detectLocation.test.js
@@ -561,6 +561,22 @@ describe('detectLocation — issue #47 regression', () => {
     expect(klang.country).toBe('Malaysia')
   })
 
+  it('Sialkot WOF cell no longer shadows Gujranwala north-east edge', () => {
+    const gujranwalaEdge = detectLocation(32.42, 74.46)
+    expect(gujranwalaEdge.city?.name).toBe('Gujranwala')
+    expect(gujranwalaEdge.country).toBe('Pakistan')
+    expect(gujranwalaEdge.timezone).toBe('Asia/Karachi')
+
+    const sialkotCenter = detectLocation(32.4945, 74.5229)
+    expect(sialkotCenter.city?.name).toBe('Sialkot')
+    expect(sialkotCenter.country).toBe('Pakistan')
+    expect(sialkotCenter.timezone).toBe('Asia/Karachi')
+
+    const sialkotWestEdge = detectLocation(32.49, 74.495)
+    expect(sialkotWestEdge.city?.name).toBe('Sialkot')
+    expect(sialkotWestEdge.country).toBe('Pakistan')
+  })
+
   // Additional v1.7.5 regression cases (Reviewer C's "definitely wrong" list).
   it('Sharm el-Sheikh → country=Egypt with Egyptian method (was SaudiArabia/UmmAlQura)', () => {
     const loc = detectLocation(27.92, 34.33)

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -103,6 +103,7 @@ describe('city geometry source map', () => {
       ['Shah Alam|MY', 'wof:locality:102022833'],
       ['Petaling Jaya|MY', 'wof:locality:102023395'],
       ['Kuala Lumpur|MY', 'wof:locality:102023407'],
+      ['Sialkot|PK', 'wof:locality:421175525'],
       ['Windsor|CA', 'wof:locality:101735855'],
       ['Geneva|CH', 'wof:locality:101748445'],
       ['Annemasse|FR', 'wof:locality:101757307'],
@@ -160,6 +161,7 @@ describe('city geometry source map', () => {
     expect(statusFor('Shah Alam|MY')).toBe('runtime-bbox-shipped')
     expect(statusFor('Petaling Jaya|MY')).toBe('runtime-bbox-shipped')
     expect(statusFor('Kuala Lumpur|MY')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Sialkot|PK')).toBe('runtime-bbox-shipped')
     expect(statusFor('Windsor|CA')).toBe('runtime-bbox-shipped')
     expect(statusFor('Geneva|CH')).toBe('runtime-bbox-shipped')
     expect(statusFor('Annemasse|FR')).toBe('runtime-bbox-shipped')


### PR DESCRIPTION
Refs #118

[positions: no-change-required]
[known-disagreements: no-change-required]

## Summary
- Update `Sialkot|PK` to the reviewed WOF current locality envelope.
- Add a WOF source-map row for `Sialkot|PK`.
- Add regression coverage for the former Sialkot/Gujranwala overlap.

## User-visible behavior
- `detectLocation(32.42, 74.46)` now resolves to Gujranwala instead of Sialkot.
- `detectLocation(32.4945, 74.5229)` remains Sialkot.
- Pakistan country, timezone, Karachi method routing, prayer math, and API surface are unchanged.

## Review notes
- I reviewed WOF rows for Lahore, Gujranwala, and Sialkot. Only Sialkot ships here because this PR targets the concrete overlap bug; shrinking Lahore/Gujranwala would be a broader coverage change.
- This is a city reverse-geolocation/provenance fix only.

## Verification
- `npm test` — 21 files / 414 tests passed
- `npm run validate:registry` — passed, 0 fail-class issues; 1 existing warn-class allowlist; bbox-overlap pairs down to 2
- `node scripts/build-city-registry.js --check` — passed
- `node scripts/audit-city-geometry.js --format json` — 48 source-map cities; 62 rows; 61 checked; 0 missing cache files; 0 missing geometry; 0 city-not-found
- `npm run build:charts` — run after `src/data/cities.json` regeneration; no chart/progress diff remained
- `npm pack --dry-run` — 146.9 kB packed / 539.1 kB unpacked / 21 files
- `git diff --check` — passed

## Eval note
I did not run `node eval/eval.js` because this is a city reverse-geolocation/provenance change, not an engine calibration or prayer-time math change. No eval data or ratchet files were modified.
