### PR TITLE
data(morocco): archive first Habous monthly snapshot

### DIFF
--- a/.github/workflows/habous-morocco-snapshot.yml
+++ b/.github/workflows/habous-morocco-snapshot.yml
@@ -92,7 +92,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- fixtures/habous-morocco/monthly; then
+          if [ -z "$(git status --porcelain -- fixtures/habous-morocco/monthly)" ]; then
             echo "No new Habous monthly snapshot to commit."
             exit 0
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 
 ## [Unreleased]
 
+### Added — Morocco Habous monthly source archive
+
+- Added the first archived Morocco Habous monthly source snapshot under
+  `fixtures/habous-morocco/monthly/`, covering 33 mapped Moroccan cities from
+  2026-04-19 through 2026-05-18.
+- Fixed the scheduled Habous capture workflow so untracked snapshot files are
+  detected and committed instead of being skipped by `git diff --quiet`.
+- Added source-archive tests that verify monthly snapshot filenames, city
+  coverage, source metadata, sorted dates, and HH:MM prayer rows before any
+  later promotion into `eval/data/`.
+
 ## [1.9.1] — 2026-05-14
 
 ### Fixed — Sialkot/Gujranwala city-geometry overlap

--- a/fixtures/habous-morocco/README.md
+++ b/fixtures/habous-morocco/README.md
@@ -26,6 +26,11 @@ The path is based on the Gregorian date range in the official monthly table. If
 that range was already captured, the workflow exits without opening a duplicate
 PR.
 
+## Archived Snapshots
+
+- `monthly/2026-04-19_to_2026-05-18.json` — 33 mapped Moroccan cities x 30
+  days from the official Habous current Hijri-month table.
+
 ## Promotion Rule
 
 Do not move these snapshots into `eval/data/` mechanically. A curated fixture PR

--- a/fixtures/habous-morocco/monthly/2026-04-19_to_2026-05-18.json
+++ b/fixtures/habous-morocco/monthly/2026-04-19_to_2026-05-18.json
@@ -1,0 +1,9506 @@
+[
+  {
+    "city": "Rabat",
+    "country": "Morocco",
+    "latitude": 34.0209,
+    "longitude": -6.8416,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (الرباط)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=1",
+    "source_url": "https://www.habous.gov.ma/prieres/index.php",
+    "source_fetched": "2026-05-15T01:15:21.644Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:17",
+        "sunrise": "06:49",
+        "dhuhr": "13:32",
+        "asr": "17:07",
+        "maghrib": "20:06",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:16",
+        "sunrise": "06:48",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:07",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:14",
+        "sunrise": "06:46",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:07",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:13",
+        "sunrise": "06:45",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:08",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:11",
+        "sunrise": "06:44",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:09",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:10",
+        "sunrise": "06:43",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:10",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:08",
+        "sunrise": "06:42",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:10",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:07",
+        "sunrise": "06:41",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:11",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:05",
+        "sunrise": "06:40",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:12",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:04",
+        "sunrise": "06:38",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:13",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:03",
+        "sunrise": "06:37",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:14",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:01",
+        "sunrise": "06:36",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:14",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:00",
+        "sunrise": "06:35",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:15",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:58",
+        "sunrise": "06:34",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:16",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:57",
+        "sunrise": "06:33",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:17",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:56",
+        "sunrise": "06:32",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:17",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:54",
+        "sunrise": "06:31",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:18",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:53",
+        "sunrise": "06:30",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:19",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:52",
+        "sunrise": "06:30",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:20",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:51",
+        "sunrise": "06:29",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:21",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:49",
+        "sunrise": "06:28",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:21",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:48",
+        "sunrise": "06:27",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:22",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:47",
+        "sunrise": "06:26",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:23",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:46",
+        "sunrise": "06:25",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:24",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:45",
+        "sunrise": "06:24",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:24",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:44",
+        "sunrise": "06:24",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:25",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:42",
+        "sunrise": "06:23",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:26",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:41",
+        "sunrise": "06:22",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:27",
+        "isha": "21:54"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:40",
+        "sunrise": "06:22",
+        "dhuhr": "13:29",
+        "asr": "17:09",
+        "maghrib": "20:27",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:39",
+        "sunrise": "06:21",
+        "dhuhr": "13:29",
+        "asr": "17:09",
+        "maghrib": "20:28",
+        "isha": "21:56"
+      }
+    ]
+  },
+  {
+    "city": "Sale",
+    "country": "Morocco",
+    "latitude": 34.0531,
+    "longitude": -6.7985,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (الرباط)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=nearest-official-city; ville=1",
+    "source_url": "https://www.habous.gov.ma/prieres/index.php",
+    "source_fetched": "2026-05-15T01:15:23.068Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:17",
+        "sunrise": "06:49",
+        "dhuhr": "13:32",
+        "asr": "17:07",
+        "maghrib": "20:06",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:16",
+        "sunrise": "06:48",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:07",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:14",
+        "sunrise": "06:46",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:07",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:13",
+        "sunrise": "06:45",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:08",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:11",
+        "sunrise": "06:44",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:09",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:10",
+        "sunrise": "06:43",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:10",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:08",
+        "sunrise": "06:42",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:10",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:07",
+        "sunrise": "06:41",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:11",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:05",
+        "sunrise": "06:40",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:12",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:04",
+        "sunrise": "06:38",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:13",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:03",
+        "sunrise": "06:37",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:14",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:01",
+        "sunrise": "06:36",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:14",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:00",
+        "sunrise": "06:35",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:15",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:58",
+        "sunrise": "06:34",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:16",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:57",
+        "sunrise": "06:33",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:17",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:56",
+        "sunrise": "06:32",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:17",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:54",
+        "sunrise": "06:31",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:18",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:53",
+        "sunrise": "06:30",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:19",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:52",
+        "sunrise": "06:30",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:20",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:51",
+        "sunrise": "06:29",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:21",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:49",
+        "sunrise": "06:28",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:21",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:48",
+        "sunrise": "06:27",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:22",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:47",
+        "sunrise": "06:26",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:23",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:46",
+        "sunrise": "06:25",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:24",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:45",
+        "sunrise": "06:24",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:24",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:44",
+        "sunrise": "06:24",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:25",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:42",
+        "sunrise": "06:23",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:26",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:41",
+        "sunrise": "06:22",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:27",
+        "isha": "21:54"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:40",
+        "sunrise": "06:22",
+        "dhuhr": "13:29",
+        "asr": "17:09",
+        "maghrib": "20:27",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:39",
+        "sunrise": "06:21",
+        "dhuhr": "13:29",
+        "asr": "17:09",
+        "maghrib": "20:28",
+        "isha": "21:56"
+      }
+    ]
+  },
+  {
+    "city": "Temara",
+    "country": "Morocco",
+    "latitude": 33.9281,
+    "longitude": -6.9067,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (الرباط)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=nearest-official-city; ville=1",
+    "source_url": "https://www.habous.gov.ma/prieres/index.php",
+    "source_fetched": "2026-05-15T01:15:24.507Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:17",
+        "sunrise": "06:49",
+        "dhuhr": "13:32",
+        "asr": "17:07",
+        "maghrib": "20:06",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:16",
+        "sunrise": "06:48",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:07",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:14",
+        "sunrise": "06:46",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:07",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:13",
+        "sunrise": "06:45",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:08",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:11",
+        "sunrise": "06:44",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:09",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:10",
+        "sunrise": "06:43",
+        "dhuhr": "13:31",
+        "asr": "17:07",
+        "maghrib": "20:10",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:08",
+        "sunrise": "06:42",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:10",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:07",
+        "sunrise": "06:41",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:11",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:05",
+        "sunrise": "06:40",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:12",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:04",
+        "sunrise": "06:38",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:13",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:03",
+        "sunrise": "06:37",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:14",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:01",
+        "sunrise": "06:36",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:14",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:00",
+        "sunrise": "06:35",
+        "dhuhr": "13:30",
+        "asr": "17:07",
+        "maghrib": "20:15",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:58",
+        "sunrise": "06:34",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:16",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:57",
+        "sunrise": "06:33",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:17",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:56",
+        "sunrise": "06:32",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:17",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:54",
+        "sunrise": "06:31",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:18",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:53",
+        "sunrise": "06:30",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:19",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:52",
+        "sunrise": "06:30",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:20",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:51",
+        "sunrise": "06:29",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:21",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:49",
+        "sunrise": "06:28",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:21",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:48",
+        "sunrise": "06:27",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:22",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:47",
+        "sunrise": "06:26",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:23",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:46",
+        "sunrise": "06:25",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:24",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:45",
+        "sunrise": "06:24",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:24",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:44",
+        "sunrise": "06:24",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:25",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:42",
+        "sunrise": "06:23",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:26",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:41",
+        "sunrise": "06:22",
+        "dhuhr": "13:29",
+        "asr": "17:08",
+        "maghrib": "20:27",
+        "isha": "21:54"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:40",
+        "sunrise": "06:22",
+        "dhuhr": "13:29",
+        "asr": "17:09",
+        "maghrib": "20:27",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:39",
+        "sunrise": "06:21",
+        "dhuhr": "13:29",
+        "asr": "17:09",
+        "maghrib": "20:28",
+        "isha": "21:56"
+      }
+    ]
+  },
+  {
+    "city": "Kenitra",
+    "country": "Morocco",
+    "latitude": 34.261,
+    "longitude": -6.5802,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (القنيطرة)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=7",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=7",
+    "source_fetched": "2026-05-15T01:15:25.929Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:15",
+        "sunrise": "06:47",
+        "dhuhr": "13:31",
+        "asr": "17:06",
+        "maghrib": "20:06",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:14",
+        "sunrise": "06:46",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:06",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:12",
+        "sunrise": "06:45",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:07",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:11",
+        "sunrise": "06:43",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:08",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:10",
+        "sunrise": "06:42",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:09",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:08",
+        "sunrise": "06:41",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:09",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:07",
+        "sunrise": "06:40",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:10",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:05",
+        "sunrise": "06:39",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:11",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:04",
+        "sunrise": "06:38",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:12",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:02",
+        "sunrise": "06:37",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:13",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:01",
+        "sunrise": "06:36",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:13",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:59",
+        "sunrise": "06:34",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:14",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:58",
+        "sunrise": "06:33",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:15",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:57",
+        "sunrise": "06:32",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:16",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:55",
+        "sunrise": "06:31",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:17",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:54",
+        "sunrise": "06:30",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:17",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:53",
+        "sunrise": "06:29",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:18",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:51",
+        "sunrise": "06:29",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:19",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:50",
+        "sunrise": "06:28",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:20",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:49",
+        "sunrise": "06:27",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:21",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:48",
+        "sunrise": "06:26",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:21",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:46",
+        "sunrise": "06:25",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:22",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:45",
+        "sunrise": "06:24",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:23",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:44",
+        "sunrise": "06:23",
+        "dhuhr": "13:28",
+        "asr": "17:07",
+        "maghrib": "20:24",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:43",
+        "sunrise": "06:22",
+        "dhuhr": "13:28",
+        "asr": "17:08",
+        "maghrib": "20:24",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:42",
+        "sunrise": "06:22",
+        "dhuhr": "13:28",
+        "asr": "17:08",
+        "maghrib": "20:25",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:40",
+        "sunrise": "06:21",
+        "dhuhr": "13:28",
+        "asr": "17:08",
+        "maghrib": "20:26",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:39",
+        "sunrise": "06:20",
+        "dhuhr": "13:28",
+        "asr": "17:08",
+        "maghrib": "20:27",
+        "isha": "21:54"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:38",
+        "sunrise": "06:19",
+        "dhuhr": "13:28",
+        "asr": "17:08",
+        "maghrib": "20:27",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:37",
+        "sunrise": "06:19",
+        "dhuhr": "13:28",
+        "asr": "17:08",
+        "maghrib": "20:28",
+        "isha": "21:56"
+      }
+    ]
+  },
+  {
+    "city": "Sidi Kacem",
+    "country": "Morocco",
+    "latitude": 34.2208,
+    "longitude": -5.7081,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (سيدي قاسم)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=8",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=8",
+    "source_fetched": "2026-05-15T01:15:27.397Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:12",
+        "sunrise": "06:42",
+        "dhuhr": "13:27",
+        "asr": "17:02",
+        "maghrib": "20:03",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:11",
+        "sunrise": "06:41",
+        "dhuhr": "13:27",
+        "asr": "17:02",
+        "maghrib": "20:04",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:09",
+        "sunrise": "06:40",
+        "dhuhr": "13:27",
+        "asr": "17:02",
+        "maghrib": "20:05",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:08",
+        "sunrise": "06:39",
+        "dhuhr": "13:26",
+        "asr": "17:02",
+        "maghrib": "20:05",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:06",
+        "sunrise": "06:38",
+        "dhuhr": "13:26",
+        "asr": "17:03",
+        "maghrib": "20:06",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:05",
+        "sunrise": "06:36",
+        "dhuhr": "13:26",
+        "asr": "17:03",
+        "maghrib": "20:07",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:03",
+        "sunrise": "06:35",
+        "dhuhr": "13:26",
+        "asr": "17:03",
+        "maghrib": "20:08",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:02",
+        "sunrise": "06:34",
+        "dhuhr": "13:26",
+        "asr": "17:03",
+        "maghrib": "20:08",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:00",
+        "sunrise": "06:33",
+        "dhuhr": "13:26",
+        "asr": "17:03",
+        "maghrib": "20:09",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:59",
+        "sunrise": "06:32",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:10",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:57",
+        "sunrise": "06:31",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:11",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:56",
+        "sunrise": "06:30",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:12",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:55",
+        "sunrise": "06:29",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:12",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:53",
+        "sunrise": "06:28",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:13",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:52",
+        "sunrise": "06:27",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:14",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:51",
+        "sunrise": "06:26",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:15",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:49",
+        "sunrise": "06:25",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:16",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:48",
+        "sunrise": "06:24",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:16",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:47",
+        "sunrise": "06:23",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:17",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:45",
+        "sunrise": "06:22",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:18",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:44",
+        "sunrise": "06:21",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:19",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:43",
+        "sunrise": "06:20",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:20",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:42",
+        "sunrise": "06:19",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:20",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:41",
+        "sunrise": "06:19",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:21",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:39",
+        "sunrise": "06:18",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:22",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:38",
+        "sunrise": "06:17",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:23",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:37",
+        "sunrise": "06:16",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:23",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:36",
+        "sunrise": "06:16",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:24",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:35",
+        "sunrise": "06:15",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:25",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:34",
+        "sunrise": "06:14",
+        "dhuhr": "13:24",
+        "asr": "17:05",
+        "maghrib": "20:26",
+        "isha": "21:52"
+      }
+    ]
+  },
+  {
+    "city": "Tangier",
+    "country": "Morocco",
+    "latitude": 35.7595,
+    "longitude": -5.834,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (طنجة)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=14",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=14",
+    "source_fetched": "2026-05-15T01:15:28.804Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:08",
+        "sunrise": "06:41",
+        "dhuhr": "13:27",
+        "asr": "17:04",
+        "maghrib": "20:05",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:07",
+        "sunrise": "06:40",
+        "dhuhr": "13:27",
+        "asr": "17:04",
+        "maghrib": "20:06",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:05",
+        "sunrise": "06:39",
+        "dhuhr": "13:27",
+        "asr": "17:04",
+        "maghrib": "20:07",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:03",
+        "sunrise": "06:38",
+        "dhuhr": "13:27",
+        "asr": "17:05",
+        "maghrib": "20:07",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:02",
+        "sunrise": "06:36",
+        "dhuhr": "13:27",
+        "asr": "17:05",
+        "maghrib": "20:08",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:00",
+        "sunrise": "06:35",
+        "dhuhr": "13:26",
+        "asr": "17:05",
+        "maghrib": "20:09",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "04:59",
+        "sunrise": "06:34",
+        "dhuhr": "13:26",
+        "asr": "17:05",
+        "maghrib": "20:10",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "04:57",
+        "sunrise": "06:33",
+        "dhuhr": "13:26",
+        "asr": "17:05",
+        "maghrib": "20:11",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "04:56",
+        "sunrise": "06:32",
+        "dhuhr": "13:26",
+        "asr": "17:05",
+        "maghrib": "20:12",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:54",
+        "sunrise": "06:30",
+        "dhuhr": "13:26",
+        "asr": "17:05",
+        "maghrib": "20:12",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:53",
+        "sunrise": "06:29",
+        "dhuhr": "13:26",
+        "asr": "17:05",
+        "maghrib": "20:13",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:51",
+        "sunrise": "06:28",
+        "dhuhr": "13:25",
+        "asr": "17:05",
+        "maghrib": "20:14",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:50",
+        "sunrise": "06:27",
+        "dhuhr": "13:25",
+        "asr": "17:06",
+        "maghrib": "20:15",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:48",
+        "sunrise": "06:26",
+        "dhuhr": "13:25",
+        "asr": "17:06",
+        "maghrib": "20:16",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:47",
+        "sunrise": "06:25",
+        "dhuhr": "13:25",
+        "asr": "17:06",
+        "maghrib": "20:17",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:45",
+        "sunrise": "06:24",
+        "dhuhr": "13:25",
+        "asr": "17:06",
+        "maghrib": "20:18",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:44",
+        "sunrise": "06:23",
+        "dhuhr": "13:25",
+        "asr": "17:06",
+        "maghrib": "20:18",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:43",
+        "sunrise": "06:22",
+        "dhuhr": "13:25",
+        "asr": "17:06",
+        "maghrib": "20:19",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:41",
+        "sunrise": "06:21",
+        "dhuhr": "13:25",
+        "asr": "17:06",
+        "maghrib": "20:20",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:40",
+        "sunrise": "06:20",
+        "dhuhr": "13:25",
+        "asr": "17:06",
+        "maghrib": "20:21",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:38",
+        "sunrise": "06:19",
+        "dhuhr": "13:25",
+        "asr": "17:07",
+        "maghrib": "20:22",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:37",
+        "sunrise": "06:18",
+        "dhuhr": "13:25",
+        "asr": "17:07",
+        "maghrib": "20:23",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:36",
+        "sunrise": "06:17",
+        "dhuhr": "13:25",
+        "asr": "17:07",
+        "maghrib": "20:23",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:35",
+        "sunrise": "06:16",
+        "dhuhr": "13:25",
+        "asr": "17:07",
+        "maghrib": "20:24",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:33",
+        "sunrise": "06:16",
+        "dhuhr": "13:25",
+        "asr": "17:07",
+        "maghrib": "20:25",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:32",
+        "sunrise": "06:15",
+        "dhuhr": "13:25",
+        "asr": "17:07",
+        "maghrib": "20:26",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:31",
+        "sunrise": "06:14",
+        "dhuhr": "13:25",
+        "asr": "17:07",
+        "maghrib": "20:27",
+        "isha": "21:56"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:30",
+        "sunrise": "06:13",
+        "dhuhr": "13:25",
+        "asr": "17:08",
+        "maghrib": "20:28",
+        "isha": "21:57"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:29",
+        "sunrise": "06:12",
+        "dhuhr": "13:25",
+        "asr": "17:08",
+        "maghrib": "20:28",
+        "isha": "21:58"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:27",
+        "sunrise": "06:12",
+        "dhuhr": "13:25",
+        "asr": "17:08",
+        "maghrib": "20:29",
+        "isha": "21:59"
+      }
+    ]
+  },
+  {
+    "city": "Tetouan",
+    "country": "Morocco",
+    "latitude": 35.5712,
+    "longitude": -5.3727,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (تطوان)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=15",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=15",
+    "source_fetched": "2026-05-15T01:15:30.209Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:07",
+        "sunrise": "06:39",
+        "dhuhr": "13:26",
+        "asr": "17:02",
+        "maghrib": "20:04",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:05",
+        "sunrise": "06:38",
+        "dhuhr": "13:25",
+        "asr": "17:02",
+        "maghrib": "20:04",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:04",
+        "sunrise": "06:36",
+        "dhuhr": "13:25",
+        "asr": "17:02",
+        "maghrib": "20:05",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:02",
+        "sunrise": "06:35",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:06",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:01",
+        "sunrise": "06:34",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:07",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "04:59",
+        "sunrise": "06:33",
+        "dhuhr": "13:25",
+        "asr": "17:03",
+        "maghrib": "20:08",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "04:58",
+        "sunrise": "06:32",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:09",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "04:56",
+        "sunrise": "06:30",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:09",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "04:55",
+        "sunrise": "06:29",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:10",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:53",
+        "sunrise": "06:28",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:11",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:52",
+        "sunrise": "06:27",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:12",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:50",
+        "sunrise": "06:26",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:13",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:49",
+        "sunrise": "06:25",
+        "dhuhr": "13:24",
+        "asr": "17:04",
+        "maghrib": "20:14",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:47",
+        "sunrise": "06:24",
+        "dhuhr": "13:23",
+        "asr": "17:04",
+        "maghrib": "20:14",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:46",
+        "sunrise": "06:23",
+        "dhuhr": "13:23",
+        "asr": "17:04",
+        "maghrib": "20:15",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:44",
+        "sunrise": "06:22",
+        "dhuhr": "13:23",
+        "asr": "17:04",
+        "maghrib": "20:16",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:43",
+        "sunrise": "06:21",
+        "dhuhr": "13:23",
+        "asr": "17:04",
+        "maghrib": "20:17",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:42",
+        "sunrise": "06:20",
+        "dhuhr": "13:23",
+        "asr": "17:04",
+        "maghrib": "20:18",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:40",
+        "sunrise": "06:19",
+        "dhuhr": "13:23",
+        "asr": "17:04",
+        "maghrib": "20:19",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:39",
+        "sunrise": "06:18",
+        "dhuhr": "13:23",
+        "asr": "17:04",
+        "maghrib": "20:20",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:37",
+        "sunrise": "06:17",
+        "dhuhr": "13:23",
+        "asr": "17:04",
+        "maghrib": "20:20",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:36",
+        "sunrise": "06:16",
+        "dhuhr": "13:23",
+        "asr": "17:05",
+        "maghrib": "20:21",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:35",
+        "sunrise": "06:15",
+        "dhuhr": "13:23",
+        "asr": "17:05",
+        "maghrib": "20:22",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:34",
+        "sunrise": "06:14",
+        "dhuhr": "13:23",
+        "asr": "17:05",
+        "maghrib": "20:23",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:32",
+        "sunrise": "06:13",
+        "dhuhr": "13:23",
+        "asr": "17:05",
+        "maghrib": "20:24",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:31",
+        "sunrise": "06:12",
+        "dhuhr": "13:23",
+        "asr": "17:05",
+        "maghrib": "20:24",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:30",
+        "sunrise": "06:12",
+        "dhuhr": "13:23",
+        "asr": "17:05",
+        "maghrib": "20:25",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:29",
+        "sunrise": "06:11",
+        "dhuhr": "13:23",
+        "asr": "17:05",
+        "maghrib": "20:26",
+        "isha": "21:54"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:28",
+        "sunrise": "06:10",
+        "dhuhr": "13:23",
+        "asr": "17:05",
+        "maghrib": "20:27",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:27",
+        "sunrise": "06:09",
+        "dhuhr": "13:23",
+        "asr": "17:06",
+        "maghrib": "20:28",
+        "isha": "21:56"
+      }
+    ]
+  },
+  {
+    "city": "Oujda",
+    "country": "Morocco",
+    "latitude": 34.6814,
+    "longitude": -1.9086,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (وجدة)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=31",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=31",
+    "source_fetched": "2026-05-15T01:15:31.611Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "04:56",
+        "sunrise": "06:26",
+        "dhuhr": "13:12",
+        "asr": "16:48",
+        "maghrib": "19:49",
+        "isha": "21:07"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "04:54",
+        "sunrise": "06:24",
+        "dhuhr": "13:12",
+        "asr": "16:48",
+        "maghrib": "19:50",
+        "isha": "21:08"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "04:53",
+        "sunrise": "06:23",
+        "dhuhr": "13:11",
+        "asr": "16:48",
+        "maghrib": "19:51",
+        "isha": "21:09"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "04:51",
+        "sunrise": "06:22",
+        "dhuhr": "13:11",
+        "asr": "16:48",
+        "maghrib": "19:52",
+        "isha": "21:11"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "04:50",
+        "sunrise": "06:21",
+        "dhuhr": "13:11",
+        "asr": "16:48",
+        "maghrib": "19:52",
+        "isha": "21:12"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "04:48",
+        "sunrise": "06:20",
+        "dhuhr": "13:11",
+        "asr": "16:48",
+        "maghrib": "19:53",
+        "isha": "21:13"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "04:47",
+        "sunrise": "06:19",
+        "dhuhr": "13:11",
+        "asr": "16:48",
+        "maghrib": "19:54",
+        "isha": "21:14"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "04:45",
+        "sunrise": "06:17",
+        "dhuhr": "13:11",
+        "asr": "16:48",
+        "maghrib": "19:55",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "04:44",
+        "sunrise": "06:16",
+        "dhuhr": "13:10",
+        "asr": "16:48",
+        "maghrib": "19:56",
+        "isha": "21:16"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:42",
+        "sunrise": "06:15",
+        "dhuhr": "13:10",
+        "asr": "16:48",
+        "maghrib": "19:56",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:41",
+        "sunrise": "06:14",
+        "dhuhr": "13:10",
+        "asr": "16:48",
+        "maghrib": "19:57",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:39",
+        "sunrise": "06:13",
+        "dhuhr": "13:10",
+        "asr": "16:49",
+        "maghrib": "19:58",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:38",
+        "sunrise": "06:12",
+        "dhuhr": "13:10",
+        "asr": "16:49",
+        "maghrib": "19:59",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:37",
+        "sunrise": "06:11",
+        "dhuhr": "13:10",
+        "asr": "16:49",
+        "maghrib": "20:00",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:35",
+        "sunrise": "06:10",
+        "dhuhr": "13:10",
+        "asr": "16:49",
+        "maghrib": "20:01",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:34",
+        "sunrise": "06:09",
+        "dhuhr": "13:10",
+        "asr": "16:49",
+        "maghrib": "20:01",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:32",
+        "sunrise": "06:08",
+        "dhuhr": "13:09",
+        "asr": "16:49",
+        "maghrib": "20:02",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:31",
+        "sunrise": "06:07",
+        "dhuhr": "13:09",
+        "asr": "16:49",
+        "maghrib": "20:03",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:30",
+        "sunrise": "06:06",
+        "dhuhr": "13:09",
+        "asr": "16:49",
+        "maghrib": "20:04",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:29",
+        "sunrise": "06:05",
+        "dhuhr": "13:09",
+        "asr": "16:49",
+        "maghrib": "20:05",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:27",
+        "sunrise": "06:04",
+        "dhuhr": "13:09",
+        "asr": "16:49",
+        "maghrib": "20:05",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:26",
+        "sunrise": "06:03",
+        "dhuhr": "13:09",
+        "asr": "16:49",
+        "maghrib": "20:06",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:25",
+        "sunrise": "06:02",
+        "dhuhr": "13:09",
+        "asr": "16:49",
+        "maghrib": "20:07",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:24",
+        "sunrise": "06:02",
+        "dhuhr": "13:09",
+        "asr": "16:50",
+        "maghrib": "20:08",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:22",
+        "sunrise": "06:01",
+        "dhuhr": "13:09",
+        "asr": "16:50",
+        "maghrib": "20:09",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:21",
+        "sunrise": "06:00",
+        "dhuhr": "13:09",
+        "asr": "16:50",
+        "maghrib": "20:09",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:20",
+        "sunrise": "05:59",
+        "dhuhr": "13:09",
+        "asr": "16:50",
+        "maghrib": "20:10",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:19",
+        "sunrise": "05:58",
+        "dhuhr": "13:09",
+        "asr": "16:50",
+        "maghrib": "20:11",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:18",
+        "sunrise": "05:58",
+        "dhuhr": "13:09",
+        "asr": "16:50",
+        "maghrib": "20:12",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:17",
+        "sunrise": "05:57",
+        "dhuhr": "13:09",
+        "asr": "16:50",
+        "maghrib": "20:12",
+        "isha": "21:39"
+      }
+    ]
+  },
+  {
+    "city": "Taourirt",
+    "country": "Morocco",
+    "latitude": 34.4115,
+    "longitude": -2.8975,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (تاوريرت)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=38",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=38",
+    "source_fetched": "2026-05-15T01:15:33.005Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:00",
+        "sunrise": "06:29",
+        "dhuhr": "13:16",
+        "asr": "16:51",
+        "maghrib": "19:53",
+        "isha": "21:10"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "04:59",
+        "sunrise": "06:28",
+        "dhuhr": "13:15",
+        "asr": "16:51",
+        "maghrib": "19:54",
+        "isha": "21:12"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "04:57",
+        "sunrise": "06:27",
+        "dhuhr": "13:15",
+        "asr": "16:51",
+        "maghrib": "19:55",
+        "isha": "21:13"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "04:56",
+        "sunrise": "06:25",
+        "dhuhr": "13:15",
+        "asr": "16:51",
+        "maghrib": "19:56",
+        "isha": "21:14"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "04:54",
+        "sunrise": "06:24",
+        "dhuhr": "13:15",
+        "asr": "16:51",
+        "maghrib": "19:56",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "04:53",
+        "sunrise": "06:23",
+        "dhuhr": "13:15",
+        "asr": "16:52",
+        "maghrib": "19:57",
+        "isha": "21:16"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "04:51",
+        "sunrise": "06:22",
+        "dhuhr": "13:15",
+        "asr": "16:52",
+        "maghrib": "19:58",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "04:50",
+        "sunrise": "06:21",
+        "dhuhr": "13:14",
+        "asr": "16:52",
+        "maghrib": "19:59",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "04:48",
+        "sunrise": "06:20",
+        "dhuhr": "13:14",
+        "asr": "16:52",
+        "maghrib": "20:00",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:47",
+        "sunrise": "06:19",
+        "dhuhr": "13:14",
+        "asr": "16:52",
+        "maghrib": "20:00",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:45",
+        "sunrise": "06:18",
+        "dhuhr": "13:14",
+        "asr": "16:52",
+        "maghrib": "20:01",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:44",
+        "sunrise": "06:16",
+        "dhuhr": "13:14",
+        "asr": "16:52",
+        "maghrib": "20:02",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:43",
+        "sunrise": "06:15",
+        "dhuhr": "13:14",
+        "asr": "16:52",
+        "maghrib": "20:03",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:41",
+        "sunrise": "06:14",
+        "dhuhr": "13:14",
+        "asr": "16:52",
+        "maghrib": "20:04",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:40",
+        "sunrise": "06:13",
+        "dhuhr": "13:13",
+        "asr": "16:52",
+        "maghrib": "20:05",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:39",
+        "sunrise": "06:12",
+        "dhuhr": "13:13",
+        "asr": "16:52",
+        "maghrib": "20:05",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:37",
+        "sunrise": "06:11",
+        "dhuhr": "13:13",
+        "asr": "16:52",
+        "maghrib": "20:06",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:36",
+        "sunrise": "06:10",
+        "dhuhr": "13:13",
+        "asr": "16:52",
+        "maghrib": "20:07",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:35",
+        "sunrise": "06:09",
+        "dhuhr": "13:13",
+        "asr": "16:52",
+        "maghrib": "20:08",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:33",
+        "sunrise": "06:09",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:09",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:32",
+        "sunrise": "06:08",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:09",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:31",
+        "sunrise": "06:07",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:10",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:30",
+        "sunrise": "06:06",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:11",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:28",
+        "sunrise": "06:05",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:12",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:27",
+        "sunrise": "06:04",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:12",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:26",
+        "sunrise": "06:03",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:13",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:25",
+        "sunrise": "06:03",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:14",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:24",
+        "sunrise": "06:02",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:15",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:23",
+        "sunrise": "06:01",
+        "dhuhr": "13:13",
+        "asr": "16:53",
+        "maghrib": "20:16",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:22",
+        "sunrise": "06:01",
+        "dhuhr": "13:13",
+        "asr": "16:54",
+        "maghrib": "20:16",
+        "isha": "21:42"
+      }
+    ]
+  },
+  {
+    "city": "Nador",
+    "country": "Morocco",
+    "latitude": 35.1741,
+    "longitude": -2.9287,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (الناظور)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=39",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=39",
+    "source_fetched": "2026-05-15T01:15:34.396Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "04:58",
+        "sunrise": "06:31",
+        "dhuhr": "13:16",
+        "asr": "16:52",
+        "maghrib": "19:52",
+        "isha": "21:13"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "04:57",
+        "sunrise": "06:30",
+        "dhuhr": "13:16",
+        "asr": "16:52",
+        "maghrib": "19:53",
+        "isha": "21:14"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "04:55",
+        "sunrise": "06:29",
+        "dhuhr": "13:15",
+        "asr": "16:52",
+        "maghrib": "19:54",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "04:54",
+        "sunrise": "06:27",
+        "dhuhr": "13:15",
+        "asr": "16:52",
+        "maghrib": "19:55",
+        "isha": "21:16"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "04:52",
+        "sunrise": "06:26",
+        "dhuhr": "13:15",
+        "asr": "16:53",
+        "maghrib": "19:55",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "04:51",
+        "sunrise": "06:25",
+        "dhuhr": "13:15",
+        "asr": "16:53",
+        "maghrib": "19:56",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "04:49",
+        "sunrise": "06:24",
+        "dhuhr": "13:15",
+        "asr": "16:53",
+        "maghrib": "19:57",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "04:48",
+        "sunrise": "06:23",
+        "dhuhr": "13:15",
+        "asr": "16:53",
+        "maghrib": "19:58",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "04:46",
+        "sunrise": "06:22",
+        "dhuhr": "13:14",
+        "asr": "16:53",
+        "maghrib": "19:59",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:45",
+        "sunrise": "06:20",
+        "dhuhr": "13:14",
+        "asr": "16:53",
+        "maghrib": "19:59",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:43",
+        "sunrise": "06:19",
+        "dhuhr": "13:14",
+        "asr": "16:53",
+        "maghrib": "20:00",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:42",
+        "sunrise": "06:18",
+        "dhuhr": "13:14",
+        "asr": "16:53",
+        "maghrib": "20:01",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:40",
+        "sunrise": "06:17",
+        "dhuhr": "13:14",
+        "asr": "16:53",
+        "maghrib": "20:02",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:39",
+        "sunrise": "06:16",
+        "dhuhr": "13:14",
+        "asr": "16:53",
+        "maghrib": "20:03",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:37",
+        "sunrise": "06:15",
+        "dhuhr": "13:14",
+        "asr": "16:53",
+        "maghrib": "20:04",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:36",
+        "sunrise": "06:14",
+        "dhuhr": "13:14",
+        "asr": "16:54",
+        "maghrib": "20:04",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:35",
+        "sunrise": "06:13",
+        "dhuhr": "13:13",
+        "asr": "16:54",
+        "maghrib": "20:05",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:33",
+        "sunrise": "06:12",
+        "dhuhr": "13:13",
+        "asr": "16:54",
+        "maghrib": "20:06",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:32",
+        "sunrise": "06:11",
+        "dhuhr": "13:13",
+        "asr": "16:54",
+        "maghrib": "20:07",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:31",
+        "sunrise": "06:10",
+        "dhuhr": "13:13",
+        "asr": "16:54",
+        "maghrib": "20:08",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:29",
+        "sunrise": "06:09",
+        "dhuhr": "13:13",
+        "asr": "16:54",
+        "maghrib": "20:09",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:28",
+        "sunrise": "06:08",
+        "dhuhr": "13:13",
+        "asr": "16:54",
+        "maghrib": "20:09",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:27",
+        "sunrise": "06:07",
+        "dhuhr": "13:13",
+        "asr": "16:54",
+        "maghrib": "20:10",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:25",
+        "sunrise": "06:07",
+        "dhuhr": "13:13",
+        "asr": "16:54",
+        "maghrib": "20:11",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:24",
+        "sunrise": "06:06",
+        "dhuhr": "13:13",
+        "asr": "16:55",
+        "maghrib": "20:12",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:23",
+        "sunrise": "06:05",
+        "dhuhr": "13:13",
+        "asr": "16:55",
+        "maghrib": "20:13",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:22",
+        "sunrise": "06:04",
+        "dhuhr": "13:13",
+        "asr": "16:55",
+        "maghrib": "20:13",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:21",
+        "sunrise": "06:03",
+        "dhuhr": "13:13",
+        "asr": "16:55",
+        "maghrib": "20:14",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:20",
+        "sunrise": "06:03",
+        "dhuhr": "13:13",
+        "asr": "16:55",
+        "maghrib": "20:15",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:19",
+        "sunrise": "06:02",
+        "dhuhr": "13:13",
+        "asr": "16:55",
+        "maghrib": "20:16",
+        "isha": "21:45"
+      }
+    ]
+  },
+  {
+    "city": "Casablanca",
+    "country": "Morocco",
+    "latitude": 33.5731,
+    "longitude": -7.5898,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (الدار البيضاء)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=58",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=58",
+    "source_fetched": "2026-05-15T01:15:35.805Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:22",
+        "sunrise": "06:52",
+        "dhuhr": "13:35",
+        "asr": "17:09",
+        "maghrib": "20:09",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:20",
+        "sunrise": "06:51",
+        "dhuhr": "13:35",
+        "asr": "17:09",
+        "maghrib": "20:10",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:19",
+        "sunrise": "06:50",
+        "dhuhr": "13:34",
+        "asr": "17:10",
+        "maghrib": "20:10",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:17",
+        "sunrise": "06:49",
+        "dhuhr": "13:34",
+        "asr": "17:10",
+        "maghrib": "20:11",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:16",
+        "sunrise": "06:47",
+        "dhuhr": "13:34",
+        "asr": "17:10",
+        "maghrib": "20:12",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:14",
+        "sunrise": "06:46",
+        "dhuhr": "13:34",
+        "asr": "17:10",
+        "maghrib": "20:13",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:13",
+        "sunrise": "06:45",
+        "dhuhr": "13:34",
+        "asr": "17:10",
+        "maghrib": "20:13",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:11",
+        "sunrise": "06:44",
+        "dhuhr": "13:33",
+        "asr": "17:10",
+        "maghrib": "20:14",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:10",
+        "sunrise": "06:43",
+        "dhuhr": "13:33",
+        "asr": "17:10",
+        "maghrib": "20:15",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:09",
+        "sunrise": "06:42",
+        "dhuhr": "13:33",
+        "asr": "17:10",
+        "maghrib": "20:16",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:07",
+        "sunrise": "06:41",
+        "dhuhr": "13:33",
+        "asr": "17:10",
+        "maghrib": "20:17",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:06",
+        "sunrise": "06:40",
+        "dhuhr": "13:33",
+        "asr": "17:10",
+        "maghrib": "20:17",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:05",
+        "sunrise": "06:39",
+        "dhuhr": "13:33",
+        "asr": "17:10",
+        "maghrib": "20:18",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:03",
+        "sunrise": "06:38",
+        "dhuhr": "13:33",
+        "asr": "17:10",
+        "maghrib": "20:19",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:02",
+        "sunrise": "06:37",
+        "dhuhr": "13:33",
+        "asr": "17:10",
+        "maghrib": "20:20",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:01",
+        "sunrise": "06:36",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:20",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:59",
+        "sunrise": "06:35",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:21",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:58",
+        "sunrise": "06:34",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:22",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:57",
+        "sunrise": "06:33",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:23",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:56",
+        "sunrise": "06:32",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:23",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:54",
+        "sunrise": "06:31",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:24",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:53",
+        "sunrise": "06:31",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:25",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:52",
+        "sunrise": "06:30",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:26",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:51",
+        "sunrise": "06:29",
+        "dhuhr": "13:32",
+        "asr": "17:11",
+        "maghrib": "20:27",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:50",
+        "sunrise": "06:28",
+        "dhuhr": "13:32",
+        "asr": "17:11",
+        "maghrib": "20:27",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:49",
+        "sunrise": "06:27",
+        "dhuhr": "13:32",
+        "asr": "17:11",
+        "maghrib": "20:28",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:48",
+        "sunrise": "06:27",
+        "dhuhr": "13:32",
+        "asr": "17:11",
+        "maghrib": "20:29",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:46",
+        "sunrise": "06:26",
+        "dhuhr": "13:32",
+        "asr": "17:11",
+        "maghrib": "20:29",
+        "isha": "21:56"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:45",
+        "sunrise": "06:25",
+        "dhuhr": "13:32",
+        "asr": "17:11",
+        "maghrib": "20:30",
+        "isha": "21:57"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:44",
+        "sunrise": "06:25",
+        "dhuhr": "13:32",
+        "asr": "17:11",
+        "maghrib": "20:31",
+        "isha": "21:58"
+      }
+    ]
+  },
+  {
+    "city": "Settat",
+    "country": "Morocco",
+    "latitude": 33.0017,
+    "longitude": -7.6166,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (سطات)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=61",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=61",
+    "source_fetched": "2026-05-15T01:15:37.214Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:23",
+        "sunrise": "06:52",
+        "dhuhr": "13:35",
+        "asr": "17:09",
+        "maghrib": "20:09",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:21",
+        "sunrise": "06:51",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:10",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:20",
+        "sunrise": "06:49",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:10",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:19",
+        "sunrise": "06:48",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:11",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:17",
+        "sunrise": "06:47",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:12",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:16",
+        "sunrise": "06:46",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:13",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:14",
+        "sunrise": "06:45",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:13",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:13",
+        "sunrise": "06:44",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:14",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:12",
+        "sunrise": "06:43",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:15",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:10",
+        "sunrise": "06:42",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:16",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:09",
+        "sunrise": "06:41",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:16",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:08",
+        "sunrise": "06:40",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:17",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:06",
+        "sunrise": "06:39",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:18",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:05",
+        "sunrise": "06:38",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:19",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:04",
+        "sunrise": "06:37",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:19",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:02",
+        "sunrise": "06:36",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:20",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:01",
+        "sunrise": "06:35",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:21",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:00",
+        "sunrise": "06:34",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:22",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:59",
+        "sunrise": "06:33",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:22",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:57",
+        "sunrise": "06:32",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:23",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:56",
+        "sunrise": "06:31",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:24",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:55",
+        "sunrise": "06:30",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:25",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:54",
+        "sunrise": "06:30",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:25",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:53",
+        "sunrise": "06:29",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:26",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:52",
+        "sunrise": "06:28",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:27",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:51",
+        "sunrise": "06:27",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:28",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:50",
+        "sunrise": "06:27",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:28",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:49",
+        "sunrise": "06:26",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:29",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:48",
+        "sunrise": "06:25",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:30",
+        "isha": "21:54"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:47",
+        "sunrise": "06:25",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:30",
+        "isha": "21:55"
+      }
+    ]
+  },
+  {
+    "city": "Berrechid",
+    "country": "Morocco",
+    "latitude": 33.2659,
+    "longitude": -7.5867,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (برشيد)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=65",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=65",
+    "source_fetched": "2026-05-15T01:15:38.714Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:22",
+        "sunrise": "06:52",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:08",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:21",
+        "sunrise": "06:51",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:09",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:19",
+        "sunrise": "06:50",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:10",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:18",
+        "sunrise": "06:48",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:11",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:16",
+        "sunrise": "06:47",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:11",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:15",
+        "sunrise": "06:46",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:12",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:13",
+        "sunrise": "06:45",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:13",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:12",
+        "sunrise": "06:44",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:14",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:11",
+        "sunrise": "06:43",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:14",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:09",
+        "sunrise": "06:42",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:15",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:08",
+        "sunrise": "06:41",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:16",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:07",
+        "sunrise": "06:40",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:17",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:05",
+        "sunrise": "06:39",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:18",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:04",
+        "sunrise": "06:38",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:18",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:03",
+        "sunrise": "06:37",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:19",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:01",
+        "sunrise": "06:36",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:20",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:00",
+        "sunrise": "06:35",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:21",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:59",
+        "sunrise": "06:34",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:21",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:58",
+        "sunrise": "06:33",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:22",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:56",
+        "sunrise": "06:32",
+        "dhuhr": "13:32",
+        "asr": "17:09",
+        "maghrib": "20:23",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:55",
+        "sunrise": "06:31",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:24",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:54",
+        "sunrise": "06:31",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:24",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:53",
+        "sunrise": "06:30",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:25",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:52",
+        "sunrise": "06:29",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:26",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:51",
+        "sunrise": "06:28",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:27",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:49",
+        "sunrise": "06:27",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:27",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:48",
+        "sunrise": "06:27",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:28",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:47",
+        "sunrise": "06:26",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:29",
+        "isha": "21:54"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:46",
+        "sunrise": "06:25",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:29",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:45",
+        "sunrise": "06:25",
+        "dhuhr": "13:32",
+        "asr": "17:10",
+        "maghrib": "20:30",
+        "isha": "21:56"
+      }
+    ]
+  },
+  {
+    "city": "Fquih Ben Salah",
+    "country": "Morocco",
+    "latitude": 32.5021,
+    "longitude": -6.8989,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (الفقيه بنصالح)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=75",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=75",
+    "source_fetched": "2026-05-15T01:15:40.115Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:20",
+        "sunrise": "06:48",
+        "dhuhr": "13:31",
+        "asr": "17:04",
+        "maghrib": "20:05",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:19",
+        "sunrise": "06:47",
+        "dhuhr": "13:31",
+        "asr": "17:04",
+        "maghrib": "20:06",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:18",
+        "sunrise": "06:46",
+        "dhuhr": "13:31",
+        "asr": "17:04",
+        "maghrib": "20:06",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:16",
+        "sunrise": "06:45",
+        "dhuhr": "13:30",
+        "asr": "17:04",
+        "maghrib": "20:07",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:15",
+        "sunrise": "06:44",
+        "dhuhr": "13:30",
+        "asr": "17:04",
+        "maghrib": "20:08",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:13",
+        "sunrise": "06:43",
+        "dhuhr": "13:30",
+        "asr": "17:04",
+        "maghrib": "20:08",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:12",
+        "sunrise": "06:42",
+        "dhuhr": "13:30",
+        "asr": "17:04",
+        "maghrib": "20:09",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:11",
+        "sunrise": "06:40",
+        "dhuhr": "13:30",
+        "asr": "17:05",
+        "maghrib": "20:10",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:09",
+        "sunrise": "06:39",
+        "dhuhr": "13:29",
+        "asr": "17:05",
+        "maghrib": "20:11",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:08",
+        "sunrise": "06:38",
+        "dhuhr": "13:29",
+        "asr": "17:05",
+        "maghrib": "20:11",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:07",
+        "sunrise": "06:37",
+        "dhuhr": "13:29",
+        "asr": "17:05",
+        "maghrib": "20:12",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:05",
+        "sunrise": "06:36",
+        "dhuhr": "13:29",
+        "asr": "17:05",
+        "maghrib": "20:13",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:04",
+        "sunrise": "06:35",
+        "dhuhr": "13:29",
+        "asr": "17:05",
+        "maghrib": "20:14",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:03",
+        "sunrise": "06:34",
+        "dhuhr": "13:29",
+        "asr": "17:05",
+        "maghrib": "20:14",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:02",
+        "sunrise": "06:33",
+        "dhuhr": "13:29",
+        "asr": "17:05",
+        "maghrib": "20:15",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:00",
+        "sunrise": "06:33",
+        "dhuhr": "13:29",
+        "asr": "17:05",
+        "maghrib": "20:16",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:59",
+        "sunrise": "06:32",
+        "dhuhr": "13:29",
+        "asr": "17:05",
+        "maghrib": "20:17",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:58",
+        "sunrise": "06:31",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:17",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:57",
+        "sunrise": "06:30",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:18",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:55",
+        "sunrise": "06:29",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:19",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:54",
+        "sunrise": "06:28",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:20",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:53",
+        "sunrise": "06:27",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:20",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:52",
+        "sunrise": "06:27",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:21",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:51",
+        "sunrise": "06:26",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:22",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:50",
+        "sunrise": "06:25",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:22",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:49",
+        "sunrise": "06:24",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:23",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:48",
+        "sunrise": "06:24",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:24",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:47",
+        "sunrise": "06:23",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:25",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:46",
+        "sunrise": "06:22",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:25",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:45",
+        "sunrise": "06:22",
+        "dhuhr": "13:28",
+        "asr": "17:05",
+        "maghrib": "20:26",
+        "isha": "21:50"
+      }
+    ]
+  },
+  {
+    "city": "Khouribga",
+    "country": "Morocco",
+    "latitude": 32.881,
+    "longitude": -6.9063,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (خريبكة)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=79",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=79",
+    "source_fetched": "2026-05-15T01:15:41.517Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:20",
+        "sunrise": "06:48",
+        "dhuhr": "13:32",
+        "asr": "17:06",
+        "maghrib": "20:07",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:19",
+        "sunrise": "06:46",
+        "dhuhr": "13:32",
+        "asr": "17:06",
+        "maghrib": "20:08",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:17",
+        "sunrise": "06:45",
+        "dhuhr": "13:31",
+        "asr": "17:06",
+        "maghrib": "20:09",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:16",
+        "sunrise": "06:44",
+        "dhuhr": "13:31",
+        "asr": "17:06",
+        "maghrib": "20:09",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:15",
+        "sunrise": "06:43",
+        "dhuhr": "13:31",
+        "asr": "17:06",
+        "maghrib": "20:10",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:13",
+        "sunrise": "06:42",
+        "dhuhr": "13:31",
+        "asr": "17:06",
+        "maghrib": "20:11",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:12",
+        "sunrise": "06:41",
+        "dhuhr": "13:31",
+        "asr": "17:06",
+        "maghrib": "20:12",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:10",
+        "sunrise": "06:40",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:12",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:09",
+        "sunrise": "06:39",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:13",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:08",
+        "sunrise": "06:38",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:14",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:06",
+        "sunrise": "06:37",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:15",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:05",
+        "sunrise": "06:36",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:15",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:04",
+        "sunrise": "06:35",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:16",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:02",
+        "sunrise": "06:34",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:17",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:01",
+        "sunrise": "06:33",
+        "dhuhr": "13:30",
+        "asr": "17:06",
+        "maghrib": "20:18",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:00",
+        "sunrise": "06:32",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:18",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:59",
+        "sunrise": "06:31",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:19",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:57",
+        "sunrise": "06:30",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:20",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:56",
+        "sunrise": "06:29",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:21",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:55",
+        "sunrise": "06:28",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:21",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:54",
+        "sunrise": "06:27",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:22",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:53",
+        "sunrise": "06:26",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:23",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:52",
+        "sunrise": "06:26",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:24",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:50",
+        "sunrise": "06:25",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:24",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:49",
+        "sunrise": "06:24",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:25",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:48",
+        "sunrise": "06:23",
+        "dhuhr": "13:29",
+        "asr": "17:06",
+        "maghrib": "20:26",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:47",
+        "sunrise": "06:23",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:26",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:46",
+        "sunrise": "06:22",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:27",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:45",
+        "sunrise": "06:21",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:28",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:44",
+        "sunrise": "06:21",
+        "dhuhr": "13:29",
+        "asr": "17:07",
+        "maghrib": "20:29",
+        "isha": "21:52"
+      }
+    ]
+  },
+  {
+    "city": "Fes",
+    "country": "Morocco",
+    "latitude": 34.0331,
+    "longitude": -5.0003,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (فاس)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=81",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=81",
+    "source_fetched": "2026-05-15T01:15:42.927Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:10",
+        "sunrise": "06:40",
+        "dhuhr": "13:24",
+        "asr": "16:59",
+        "maghrib": "20:00",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:08",
+        "sunrise": "06:39",
+        "dhuhr": "13:24",
+        "asr": "16:59",
+        "maghrib": "20:01",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:07",
+        "sunrise": "06:37",
+        "dhuhr": "13:24",
+        "asr": "16:59",
+        "maghrib": "20:02",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:05",
+        "sunrise": "06:36",
+        "dhuhr": "13:24",
+        "asr": "17:00",
+        "maghrib": "20:02",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:04",
+        "sunrise": "06:35",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:03",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:02",
+        "sunrise": "06:34",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:04",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:01",
+        "sunrise": "06:33",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:05",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "04:59",
+        "sunrise": "06:32",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:05",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "04:58",
+        "sunrise": "06:31",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:06",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:57",
+        "sunrise": "06:29",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:07",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:55",
+        "sunrise": "06:28",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:08",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:54",
+        "sunrise": "06:27",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:09",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:52",
+        "sunrise": "06:26",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:09",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:51",
+        "sunrise": "06:25",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:10",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:50",
+        "sunrise": "06:24",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:11",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:48",
+        "sunrise": "06:23",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:12",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:47",
+        "sunrise": "06:22",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:13",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:46",
+        "sunrise": "06:21",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:13",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:44",
+        "sunrise": "06:20",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:14",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:43",
+        "sunrise": "06:20",
+        "dhuhr": "13:22",
+        "asr": "17:01",
+        "maghrib": "20:15",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:42",
+        "sunrise": "06:19",
+        "dhuhr": "13:22",
+        "asr": "17:01",
+        "maghrib": "20:16",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:41",
+        "sunrise": "06:18",
+        "dhuhr": "13:21",
+        "asr": "17:01",
+        "maghrib": "20:16",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:39",
+        "sunrise": "06:17",
+        "dhuhr": "13:21",
+        "asr": "17:01",
+        "maghrib": "20:17",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:38",
+        "sunrise": "06:16",
+        "dhuhr": "13:21",
+        "asr": "17:01",
+        "maghrib": "20:18",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:37",
+        "sunrise": "06:15",
+        "dhuhr": "13:21",
+        "asr": "17:01",
+        "maghrib": "20:19",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:36",
+        "sunrise": "06:15",
+        "dhuhr": "13:21",
+        "asr": "17:01",
+        "maghrib": "20:20",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:35",
+        "sunrise": "06:14",
+        "dhuhr": "13:21",
+        "asr": "17:01",
+        "maghrib": "20:20",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:34",
+        "sunrise": "06:13",
+        "dhuhr": "13:21",
+        "asr": "17:01",
+        "maghrib": "20:21",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:33",
+        "sunrise": "06:12",
+        "dhuhr": "13:21",
+        "asr": "17:01",
+        "maghrib": "20:22",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:32",
+        "sunrise": "06:12",
+        "dhuhr": "13:22",
+        "asr": "17:01",
+        "maghrib": "20:23",
+        "isha": "21:49"
+      }
+    ]
+  },
+  {
+    "city": "Sefrou",
+    "country": "Morocco",
+    "latitude": 33.8311,
+    "longitude": -4.8294,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (صفرو)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=82",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=82",
+    "source_fetched": "2026-05-15T01:15:44.374Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:10",
+        "sunrise": "06:38",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:00",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:08",
+        "sunrise": "06:37",
+        "dhuhr": "13:23",
+        "asr": "16:58",
+        "maghrib": "20:01",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:07",
+        "sunrise": "06:35",
+        "dhuhr": "13:23",
+        "asr": "16:59",
+        "maghrib": "20:02",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:05",
+        "sunrise": "06:34",
+        "dhuhr": "13:23",
+        "asr": "16:59",
+        "maghrib": "20:03",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:04",
+        "sunrise": "06:33",
+        "dhuhr": "13:23",
+        "asr": "16:59",
+        "maghrib": "20:03",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:02",
+        "sunrise": "06:32",
+        "dhuhr": "13:23",
+        "asr": "16:59",
+        "maghrib": "20:04",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:01",
+        "sunrise": "06:31",
+        "dhuhr": "13:22",
+        "asr": "16:59",
+        "maghrib": "20:05",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "04:59",
+        "sunrise": "06:30",
+        "dhuhr": "13:22",
+        "asr": "16:59",
+        "maghrib": "20:06",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "04:58",
+        "sunrise": "06:29",
+        "dhuhr": "13:22",
+        "asr": "16:59",
+        "maghrib": "20:07",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:57",
+        "sunrise": "06:27",
+        "dhuhr": "13:22",
+        "asr": "16:59",
+        "maghrib": "20:07",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:55",
+        "sunrise": "06:26",
+        "dhuhr": "13:22",
+        "asr": "16:59",
+        "maghrib": "20:08",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:54",
+        "sunrise": "06:25",
+        "dhuhr": "13:22",
+        "asr": "16:59",
+        "maghrib": "20:09",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:52",
+        "sunrise": "06:24",
+        "dhuhr": "13:22",
+        "asr": "16:59",
+        "maghrib": "20:10",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:51",
+        "sunrise": "06:23",
+        "dhuhr": "13:21",
+        "asr": "16:59",
+        "maghrib": "20:11",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:50",
+        "sunrise": "06:22",
+        "dhuhr": "13:21",
+        "asr": "16:59",
+        "maghrib": "20:11",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:48",
+        "sunrise": "06:21",
+        "dhuhr": "13:21",
+        "asr": "16:59",
+        "maghrib": "20:12",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:47",
+        "sunrise": "06:20",
+        "dhuhr": "13:21",
+        "asr": "16:59",
+        "maghrib": "20:13",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:46",
+        "sunrise": "06:19",
+        "dhuhr": "13:21",
+        "asr": "16:59",
+        "maghrib": "20:14",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:45",
+        "sunrise": "06:18",
+        "dhuhr": "13:21",
+        "asr": "16:59",
+        "maghrib": "20:14",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:43",
+        "sunrise": "06:18",
+        "dhuhr": "13:21",
+        "asr": "16:59",
+        "maghrib": "20:15",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:42",
+        "sunrise": "06:17",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:16",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:41",
+        "sunrise": "06:16",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:17",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:40",
+        "sunrise": "06:15",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:18",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:39",
+        "sunrise": "06:14",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:18",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:37",
+        "sunrise": "06:13",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:19",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:36",
+        "sunrise": "06:13",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:20",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:35",
+        "sunrise": "06:12",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:21",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:34",
+        "sunrise": "06:11",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:21",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:33",
+        "sunrise": "06:10",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:22",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:32",
+        "sunrise": "06:10",
+        "dhuhr": "13:21",
+        "asr": "17:00",
+        "maghrib": "20:23",
+        "isha": "21:47"
+      }
+    ]
+  },
+  {
+    "city": "Taza",
+    "country": "Morocco",
+    "latitude": 34.2138,
+    "longitude": -4.0099,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (تازة)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=89",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=89",
+    "source_fetched": "2026-05-15T01:15:46.085Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:05",
+        "sunrise": "06:34",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "19:57",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:04",
+        "sunrise": "06:33",
+        "dhuhr": "13:20",
+        "asr": "16:56",
+        "maghrib": "19:58",
+        "isha": "21:16"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:02",
+        "sunrise": "06:32",
+        "dhuhr": "13:20",
+        "asr": "16:56",
+        "maghrib": "19:59",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:01",
+        "sunrise": "06:31",
+        "dhuhr": "13:20",
+        "asr": "16:56",
+        "maghrib": "20:00",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "04:59",
+        "sunrise": "06:29",
+        "dhuhr": "13:19",
+        "asr": "16:56",
+        "maghrib": "20:00",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "04:58",
+        "sunrise": "06:28",
+        "dhuhr": "13:19",
+        "asr": "16:56",
+        "maghrib": "20:01",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "04:56",
+        "sunrise": "06:27",
+        "dhuhr": "13:19",
+        "asr": "16:56",
+        "maghrib": "20:02",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "04:55",
+        "sunrise": "06:26",
+        "dhuhr": "13:19",
+        "asr": "16:56",
+        "maghrib": "20:03",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "04:53",
+        "sunrise": "06:25",
+        "dhuhr": "13:19",
+        "asr": "16:56",
+        "maghrib": "20:04",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:52",
+        "sunrise": "06:24",
+        "dhuhr": "13:19",
+        "asr": "16:56",
+        "maghrib": "20:04",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:51",
+        "sunrise": "06:23",
+        "dhuhr": "13:18",
+        "asr": "16:56",
+        "maghrib": "20:05",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:49",
+        "sunrise": "06:22",
+        "dhuhr": "13:18",
+        "asr": "16:56",
+        "maghrib": "20:06",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:48",
+        "sunrise": "06:21",
+        "dhuhr": "13:18",
+        "asr": "16:56",
+        "maghrib": "20:07",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:46",
+        "sunrise": "06:20",
+        "dhuhr": "13:18",
+        "asr": "16:56",
+        "maghrib": "20:08",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:45",
+        "sunrise": "06:19",
+        "dhuhr": "13:18",
+        "asr": "16:56",
+        "maghrib": "20:08",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:44",
+        "sunrise": "06:18",
+        "dhuhr": "13:18",
+        "asr": "16:56",
+        "maghrib": "20:09",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:42",
+        "sunrise": "06:17",
+        "dhuhr": "13:18",
+        "asr": "16:57",
+        "maghrib": "20:10",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:41",
+        "sunrise": "06:16",
+        "dhuhr": "13:18",
+        "asr": "16:57",
+        "maghrib": "20:11",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:40",
+        "sunrise": "06:15",
+        "dhuhr": "13:18",
+        "asr": "16:57",
+        "maghrib": "20:12",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:39",
+        "sunrise": "06:14",
+        "dhuhr": "13:18",
+        "asr": "16:57",
+        "maghrib": "20:12",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:37",
+        "sunrise": "06:13",
+        "dhuhr": "13:18",
+        "asr": "16:57",
+        "maghrib": "20:13",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:36",
+        "sunrise": "06:12",
+        "dhuhr": "13:17",
+        "asr": "16:57",
+        "maghrib": "20:14",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:35",
+        "sunrise": "06:11",
+        "dhuhr": "13:17",
+        "asr": "16:57",
+        "maghrib": "20:15",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:34",
+        "sunrise": "06:10",
+        "dhuhr": "13:17",
+        "asr": "16:57",
+        "maghrib": "20:16",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:33",
+        "sunrise": "06:10",
+        "dhuhr": "13:17",
+        "asr": "16:57",
+        "maghrib": "20:16",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:31",
+        "sunrise": "06:09",
+        "dhuhr": "13:17",
+        "asr": "16:57",
+        "maghrib": "20:17",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:30",
+        "sunrise": "06:08",
+        "dhuhr": "13:17",
+        "asr": "16:57",
+        "maghrib": "20:18",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:29",
+        "sunrise": "06:07",
+        "dhuhr": "13:17",
+        "asr": "16:57",
+        "maghrib": "20:19",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:28",
+        "sunrise": "06:07",
+        "dhuhr": "13:17",
+        "asr": "16:58",
+        "maghrib": "20:19",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:27",
+        "sunrise": "06:06",
+        "dhuhr": "13:18",
+        "asr": "16:58",
+        "maghrib": "20:20",
+        "isha": "21:45"
+      }
+    ]
+  },
+  {
+    "city": "Meknes",
+    "country": "Morocco",
+    "latitude": 33.8935,
+    "longitude": -5.5473,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (مكناس)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=99",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=99",
+    "source_fetched": "2026-05-15T01:15:47.549Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:12",
+        "sunrise": "06:42",
+        "dhuhr": "13:26",
+        "asr": "17:01",
+        "maghrib": "20:02",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:11",
+        "sunrise": "06:41",
+        "dhuhr": "13:26",
+        "asr": "17:01",
+        "maghrib": "20:03",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:09",
+        "sunrise": "06:39",
+        "dhuhr": "13:26",
+        "asr": "17:02",
+        "maghrib": "20:04",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:08",
+        "sunrise": "06:38",
+        "dhuhr": "13:26",
+        "asr": "17:02",
+        "maghrib": "20:05",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:06",
+        "sunrise": "06:37",
+        "dhuhr": "13:26",
+        "asr": "17:02",
+        "maghrib": "20:06",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:05",
+        "sunrise": "06:36",
+        "dhuhr": "13:25",
+        "asr": "17:02",
+        "maghrib": "20:06",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:04",
+        "sunrise": "06:35",
+        "dhuhr": "13:25",
+        "asr": "17:02",
+        "maghrib": "20:07",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:02",
+        "sunrise": "06:34",
+        "dhuhr": "13:25",
+        "asr": "17:02",
+        "maghrib": "20:08",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:01",
+        "sunrise": "06:33",
+        "dhuhr": "13:25",
+        "asr": "17:02",
+        "maghrib": "20:09",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:59",
+        "sunrise": "06:31",
+        "dhuhr": "13:25",
+        "asr": "17:02",
+        "maghrib": "20:09",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:58",
+        "sunrise": "06:30",
+        "dhuhr": "13:25",
+        "asr": "17:02",
+        "maghrib": "20:10",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:57",
+        "sunrise": "06:29",
+        "dhuhr": "13:25",
+        "asr": "17:02",
+        "maghrib": "20:11",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:55",
+        "sunrise": "06:28",
+        "dhuhr": "13:24",
+        "asr": "17:02",
+        "maghrib": "20:12",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:54",
+        "sunrise": "06:27",
+        "dhuhr": "13:24",
+        "asr": "17:02",
+        "maghrib": "20:13",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:52",
+        "sunrise": "06:26",
+        "dhuhr": "13:24",
+        "asr": "17:02",
+        "maghrib": "20:13",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:51",
+        "sunrise": "06:25",
+        "dhuhr": "13:24",
+        "asr": "17:02",
+        "maghrib": "20:14",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:50",
+        "sunrise": "06:24",
+        "dhuhr": "13:24",
+        "asr": "17:02",
+        "maghrib": "20:15",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:49",
+        "sunrise": "06:23",
+        "dhuhr": "13:24",
+        "asr": "17:02",
+        "maghrib": "20:16",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:47",
+        "sunrise": "06:22",
+        "dhuhr": "13:24",
+        "asr": "17:02",
+        "maghrib": "20:17",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:46",
+        "sunrise": "06:22",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:17",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:45",
+        "sunrise": "06:21",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:18",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:44",
+        "sunrise": "06:20",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:19",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:42",
+        "sunrise": "06:19",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:20",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:41",
+        "sunrise": "06:18",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:20",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:40",
+        "sunrise": "06:17",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:21",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:39",
+        "sunrise": "06:17",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:22",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:38",
+        "sunrise": "06:16",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:23",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:37",
+        "sunrise": "06:15",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:23",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:36",
+        "sunrise": "06:14",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:24",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:35",
+        "sunrise": "06:14",
+        "dhuhr": "13:24",
+        "asr": "17:03",
+        "maghrib": "20:25",
+        "isha": "21:51"
+      }
+    ]
+  },
+  {
+    "city": "Ifrane",
+    "country": "Morocco",
+    "latitude": 33.5228,
+    "longitude": -5.1106,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (يفرن)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=100",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=100",
+    "source_fetched": "2026-05-15T01:15:49.567Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:11",
+        "sunrise": "06:38",
+        "dhuhr": "13:25",
+        "asr": "16:59",
+        "maghrib": "20:02",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:10",
+        "sunrise": "06:37",
+        "dhuhr": "13:24",
+        "asr": "16:59",
+        "maghrib": "20:03",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:09",
+        "sunrise": "06:36",
+        "dhuhr": "13:24",
+        "asr": "16:59",
+        "maghrib": "20:03",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:07",
+        "sunrise": "06:35",
+        "dhuhr": "13:24",
+        "asr": "16:59",
+        "maghrib": "20:04",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:06",
+        "sunrise": "06:33",
+        "dhuhr": "13:24",
+        "asr": "16:59",
+        "maghrib": "20:05",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:04",
+        "sunrise": "06:32",
+        "dhuhr": "13:24",
+        "asr": "16:59",
+        "maghrib": "20:06",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:03",
+        "sunrise": "06:31",
+        "dhuhr": "13:23",
+        "asr": "16:59",
+        "maghrib": "20:07",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:01",
+        "sunrise": "06:30",
+        "dhuhr": "13:23",
+        "asr": "16:59",
+        "maghrib": "20:07",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:00",
+        "sunrise": "06:29",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:08",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "04:59",
+        "sunrise": "06:28",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:09",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:57",
+        "sunrise": "06:27",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:10",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:56",
+        "sunrise": "06:26",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:10",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:54",
+        "sunrise": "06:25",
+        "dhuhr": "13:23",
+        "asr": "17:00",
+        "maghrib": "20:11",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:53",
+        "sunrise": "06:24",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:12",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:52",
+        "sunrise": "06:23",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:13",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:51",
+        "sunrise": "06:22",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:14",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:49",
+        "sunrise": "06:21",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:14",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:48",
+        "sunrise": "06:20",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:15",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:47",
+        "sunrise": "06:19",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:16",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:45",
+        "sunrise": "06:18",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:17",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:44",
+        "sunrise": "06:17",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:17",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:43",
+        "sunrise": "06:16",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:18",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:42",
+        "sunrise": "06:15",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:19",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:41",
+        "sunrise": "06:15",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:20",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:40",
+        "sunrise": "06:14",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:20",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:39",
+        "sunrise": "06:13",
+        "dhuhr": "13:22",
+        "asr": "17:00",
+        "maghrib": "20:21",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:37",
+        "sunrise": "06:12",
+        "dhuhr": "13:22",
+        "asr": "17:01",
+        "maghrib": "20:22",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:36",
+        "sunrise": "06:12",
+        "dhuhr": "13:22",
+        "asr": "17:01",
+        "maghrib": "20:23",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:35",
+        "sunrise": "06:11",
+        "dhuhr": "13:22",
+        "asr": "17:01",
+        "maghrib": "20:23",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:34",
+        "sunrise": "06:10",
+        "dhuhr": "13:22",
+        "asr": "17:01",
+        "maghrib": "20:24",
+        "isha": "21:47"
+      }
+    ]
+  },
+  {
+    "city": "Marrakech",
+    "country": "Morocco",
+    "latitude": 31.6295,
+    "longitude": -7.9811,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (مراكش)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=104",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=104",
+    "source_fetched": "2026-05-15T01:15:51.000Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:28",
+        "sunrise": "06:54",
+        "dhuhr": "13:36",
+        "asr": "17:09",
+        "maghrib": "20:09",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:26",
+        "sunrise": "06:53",
+        "dhuhr": "13:36",
+        "asr": "17:09",
+        "maghrib": "20:10",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:25",
+        "sunrise": "06:52",
+        "dhuhr": "13:36",
+        "asr": "17:09",
+        "maghrib": "20:11",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:24",
+        "sunrise": "06:51",
+        "dhuhr": "13:36",
+        "asr": "17:09",
+        "maghrib": "20:12",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:22",
+        "sunrise": "06:50",
+        "dhuhr": "13:35",
+        "asr": "17:09",
+        "maghrib": "20:12",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:21",
+        "sunrise": "06:49",
+        "dhuhr": "13:35",
+        "asr": "17:09",
+        "maghrib": "20:13",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:20",
+        "sunrise": "06:48",
+        "dhuhr": "13:35",
+        "asr": "17:09",
+        "maghrib": "20:14",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:18",
+        "sunrise": "06:47",
+        "dhuhr": "13:35",
+        "asr": "17:09",
+        "maghrib": "20:14",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:17",
+        "sunrise": "06:46",
+        "dhuhr": "13:35",
+        "asr": "17:09",
+        "maghrib": "20:15",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:16",
+        "sunrise": "06:45",
+        "dhuhr": "13:35",
+        "asr": "17:09",
+        "maghrib": "20:16",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:15",
+        "sunrise": "06:44",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:16",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:13",
+        "sunrise": "06:43",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:17",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:12",
+        "sunrise": "06:42",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:18",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:11",
+        "sunrise": "06:41",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:19",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:10",
+        "sunrise": "06:40",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:19",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:08",
+        "sunrise": "06:39",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:20",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:07",
+        "sunrise": "06:38",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:21",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:06",
+        "sunrise": "06:37",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:21",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "05:05",
+        "sunrise": "06:36",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:22",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "05:04",
+        "sunrise": "06:36",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:23",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "05:03",
+        "sunrise": "06:35",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:23",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "05:02",
+        "sunrise": "06:34",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:24",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "05:00",
+        "sunrise": "06:33",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:25",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:59",
+        "sunrise": "06:33",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:26",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:58",
+        "sunrise": "06:32",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:26",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:57",
+        "sunrise": "06:31",
+        "dhuhr": "13:33",
+        "asr": "17:09",
+        "maghrib": "20:27",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:56",
+        "sunrise": "06:30",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:28",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:55",
+        "sunrise": "06:30",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:28",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:54",
+        "sunrise": "06:29",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:29",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:54",
+        "sunrise": "06:28",
+        "dhuhr": "13:34",
+        "asr": "17:09",
+        "maghrib": "20:30",
+        "isha": "21:52"
+      }
+    ]
+  },
+  {
+    "city": "Essaouira",
+    "country": "Morocco",
+    "latitude": 31.5085,
+    "longitude": -9.7595,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (الصويرة)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=106",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=106",
+    "source_fetched": "2026-05-15T01:15:52.426Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:35",
+        "sunrise": "07:04",
+        "dhuhr": "13:43",
+        "asr": "17:16",
+        "maghrib": "20:14",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:34",
+        "sunrise": "07:02",
+        "dhuhr": "13:43",
+        "asr": "17:16",
+        "maghrib": "20:15",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:32",
+        "sunrise": "07:01",
+        "dhuhr": "13:43",
+        "asr": "17:16",
+        "maghrib": "20:16",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:31",
+        "sunrise": "07:00",
+        "dhuhr": "13:43",
+        "asr": "17:16",
+        "maghrib": "20:16",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:30",
+        "sunrise": "06:59",
+        "dhuhr": "13:42",
+        "asr": "17:16",
+        "maghrib": "20:17",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:28",
+        "sunrise": "06:58",
+        "dhuhr": "13:42",
+        "asr": "17:16",
+        "maghrib": "20:18",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:27",
+        "sunrise": "06:57",
+        "dhuhr": "13:42",
+        "asr": "17:16",
+        "maghrib": "20:19",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:26",
+        "sunrise": "06:56",
+        "dhuhr": "13:42",
+        "asr": "17:16",
+        "maghrib": "20:19",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:24",
+        "sunrise": "06:55",
+        "dhuhr": "13:42",
+        "asr": "17:15",
+        "maghrib": "20:20",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:23",
+        "sunrise": "06:54",
+        "dhuhr": "13:42",
+        "asr": "17:15",
+        "maghrib": "20:21",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:22",
+        "sunrise": "06:53",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:21",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:21",
+        "sunrise": "06:52",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:22",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:19",
+        "sunrise": "06:51",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:23",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:18",
+        "sunrise": "06:50",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:23",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:17",
+        "sunrise": "06:49",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:24",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:16",
+        "sunrise": "06:48",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:25",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:15",
+        "sunrise": "06:48",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:26",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:13",
+        "sunrise": "06:47",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:26",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "05:12",
+        "sunrise": "06:46",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:27",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "05:11",
+        "sunrise": "06:45",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:28",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "05:10",
+        "sunrise": "06:44",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:28",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "05:09",
+        "sunrise": "06:43",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:29",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "05:08",
+        "sunrise": "06:43",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:30",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "05:07",
+        "sunrise": "06:42",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:30",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "05:06",
+        "sunrise": "06:41",
+        "dhuhr": "13:40",
+        "asr": "17:15",
+        "maghrib": "20:31",
+        "isha": "21:54"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "05:05",
+        "sunrise": "06:41",
+        "dhuhr": "13:40",
+        "asr": "17:15",
+        "maghrib": "20:32",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "05:04",
+        "sunrise": "06:40",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:32",
+        "isha": "21:56"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "05:03",
+        "sunrise": "06:39",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:33",
+        "isha": "21:57"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "05:02",
+        "sunrise": "06:39",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:34",
+        "isha": "21:58"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "05:01",
+        "sunrise": "06:38",
+        "dhuhr": "13:41",
+        "asr": "17:15",
+        "maghrib": "20:35",
+        "isha": "21:58"
+      }
+    ]
+  },
+  {
+    "city": "Safi",
+    "country": "Morocco",
+    "latitude": 32.2994,
+    "longitude": -9.2372,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (آسفي)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=111",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=111",
+    "source_fetched": "2026-05-15T01:15:53.844Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:31",
+        "sunrise": "07:00",
+        "dhuhr": "13:41",
+        "asr": "17:14",
+        "maghrib": "20:13",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:30",
+        "sunrise": "06:59",
+        "dhuhr": "13:41",
+        "asr": "17:14",
+        "maghrib": "20:14",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:28",
+        "sunrise": "06:58",
+        "dhuhr": "13:41",
+        "asr": "17:14",
+        "maghrib": "20:15",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:27",
+        "sunrise": "06:57",
+        "dhuhr": "13:41",
+        "asr": "17:14",
+        "maghrib": "20:16",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:25",
+        "sunrise": "06:56",
+        "dhuhr": "13:40",
+        "asr": "17:14",
+        "maghrib": "20:16",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:24",
+        "sunrise": "06:55",
+        "dhuhr": "13:40",
+        "asr": "17:14",
+        "maghrib": "20:17",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:23",
+        "sunrise": "06:54",
+        "dhuhr": "13:40",
+        "asr": "17:14",
+        "maghrib": "20:18",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:21",
+        "sunrise": "06:53",
+        "dhuhr": "13:40",
+        "asr": "17:14",
+        "maghrib": "20:18",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:20",
+        "sunrise": "06:52",
+        "dhuhr": "13:40",
+        "asr": "17:14",
+        "maghrib": "20:19",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:19",
+        "sunrise": "06:51",
+        "dhuhr": "13:39",
+        "asr": "17:14",
+        "maghrib": "20:20",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:17",
+        "sunrise": "06:50",
+        "dhuhr": "13:39",
+        "asr": "17:14",
+        "maghrib": "20:21",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:16",
+        "sunrise": "06:49",
+        "dhuhr": "13:39",
+        "asr": "17:14",
+        "maghrib": "20:21",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:15",
+        "sunrise": "06:48",
+        "dhuhr": "13:39",
+        "asr": "17:14",
+        "maghrib": "20:22",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:14",
+        "sunrise": "06:47",
+        "dhuhr": "13:39",
+        "asr": "17:14",
+        "maghrib": "20:23",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:12",
+        "sunrise": "06:46",
+        "dhuhr": "13:39",
+        "asr": "17:14",
+        "maghrib": "20:24",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:11",
+        "sunrise": "06:45",
+        "dhuhr": "13:39",
+        "asr": "17:14",
+        "maghrib": "20:24",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:10",
+        "sunrise": "06:44",
+        "dhuhr": "13:39",
+        "asr": "17:14",
+        "maghrib": "20:25",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:09",
+        "sunrise": "06:43",
+        "dhuhr": "13:39",
+        "asr": "17:14",
+        "maghrib": "20:26",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "05:08",
+        "sunrise": "06:42",
+        "dhuhr": "13:39",
+        "asr": "17:15",
+        "maghrib": "20:26",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "05:06",
+        "sunrise": "06:41",
+        "dhuhr": "13:39",
+        "asr": "17:15",
+        "maghrib": "20:27",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "05:05",
+        "sunrise": "06:40",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:28",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "05:04",
+        "sunrise": "06:40",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:29",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "05:03",
+        "sunrise": "06:39",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:29",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "05:02",
+        "sunrise": "06:38",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:30",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "05:01",
+        "sunrise": "06:37",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:31",
+        "isha": "21:54"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "05:00",
+        "sunrise": "06:37",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:31",
+        "isha": "21:55"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:59",
+        "sunrise": "06:36",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:32",
+        "isha": "21:56"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:58",
+        "sunrise": "06:35",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:33",
+        "isha": "21:57"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:57",
+        "sunrise": "06:35",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:34",
+        "isha": "21:58"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:56",
+        "sunrise": "06:34",
+        "dhuhr": "13:38",
+        "asr": "17:15",
+        "maghrib": "20:34",
+        "isha": "21:59"
+      }
+    ]
+  },
+  {
+    "city": "Agadir",
+    "country": "Morocco",
+    "latitude": 30.4278,
+    "longitude": -9.5981,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (أكادير)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=117",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=117",
+    "source_fetched": "2026-05-15T01:15:55.269Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:37",
+        "sunrise": "07:03",
+        "dhuhr": "13:42",
+        "asr": "17:14",
+        "maghrib": "20:13",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:36",
+        "sunrise": "07:02",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:14",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:34",
+        "sunrise": "07:01",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:14",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:33",
+        "sunrise": "07:00",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:15",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:32",
+        "sunrise": "06:59",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:16",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:30",
+        "sunrise": "06:58",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:16",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:29",
+        "sunrise": "06:57",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:17",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:28",
+        "sunrise": "06:56",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:18",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:27",
+        "sunrise": "06:55",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:18",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:25",
+        "sunrise": "06:54",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:19",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:24",
+        "sunrise": "06:53",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:20",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:23",
+        "sunrise": "06:52",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:20",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:22",
+        "sunrise": "06:51",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:21",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:21",
+        "sunrise": "06:50",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:22",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:19",
+        "sunrise": "06:49",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:22",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:18",
+        "sunrise": "06:48",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:23",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:17",
+        "sunrise": "06:48",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:24",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:16",
+        "sunrise": "06:47",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:24",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "05:15",
+        "sunrise": "06:46",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:25",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "05:14",
+        "sunrise": "06:45",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:26",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "05:13",
+        "sunrise": "06:44",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:26",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "05:12",
+        "sunrise": "06:44",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:27",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "05:11",
+        "sunrise": "06:43",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:28",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "05:10",
+        "sunrise": "06:42",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:28",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "05:09",
+        "sunrise": "06:42",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:29",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "05:08",
+        "sunrise": "06:41",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:30",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "05:07",
+        "sunrise": "06:40",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:30",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "05:06",
+        "sunrise": "06:40",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:31",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "05:05",
+        "sunrise": "06:39",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:32",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "05:04",
+        "sunrise": "06:38",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:32",
+        "isha": "21:54"
+      }
+    ]
+  },
+  {
+    "city": "Taroudant",
+    "country": "Morocco",
+    "latitude": 30.4727,
+    "longitude": -8.8769,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (تارودانت)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=118",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=118",
+    "source_fetched": "2026-05-15T01:15:56.748Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:34",
+        "sunrise": "07:00",
+        "dhuhr": "13:39",
+        "asr": "17:11",
+        "maghrib": "20:10",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:32",
+        "sunrise": "06:59",
+        "dhuhr": "13:39",
+        "asr": "17:11",
+        "maghrib": "20:11",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:31",
+        "sunrise": "06:58",
+        "dhuhr": "13:39",
+        "asr": "17:10",
+        "maghrib": "20:11",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:30",
+        "sunrise": "06:57",
+        "dhuhr": "13:39",
+        "asr": "17:10",
+        "maghrib": "20:12",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:28",
+        "sunrise": "06:56",
+        "dhuhr": "13:39",
+        "asr": "17:10",
+        "maghrib": "20:13",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:27",
+        "sunrise": "06:55",
+        "dhuhr": "13:38",
+        "asr": "17:10",
+        "maghrib": "20:13",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:26",
+        "sunrise": "06:54",
+        "dhuhr": "13:38",
+        "asr": "17:10",
+        "maghrib": "20:14",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:25",
+        "sunrise": "06:53",
+        "dhuhr": "13:38",
+        "asr": "17:10",
+        "maghrib": "20:15",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:23",
+        "sunrise": "06:52",
+        "dhuhr": "13:38",
+        "asr": "17:10",
+        "maghrib": "20:15",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:22",
+        "sunrise": "06:51",
+        "dhuhr": "13:38",
+        "asr": "17:10",
+        "maghrib": "20:16",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:21",
+        "sunrise": "06:50",
+        "dhuhr": "13:38",
+        "asr": "17:10",
+        "maghrib": "20:17",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:20",
+        "sunrise": "06:49",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:17",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:18",
+        "sunrise": "06:48",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:18",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:17",
+        "sunrise": "06:47",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:19",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:16",
+        "sunrise": "06:46",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:19",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:15",
+        "sunrise": "06:45",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:20",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:14",
+        "sunrise": "06:44",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:21",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:13",
+        "sunrise": "06:44",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:21",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "05:12",
+        "sunrise": "06:43",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:22",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "05:11",
+        "sunrise": "06:42",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:23",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "05:09",
+        "sunrise": "06:41",
+        "dhuhr": "13:37",
+        "asr": "17:10",
+        "maghrib": "20:23",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "05:08",
+        "sunrise": "06:40",
+        "dhuhr": "13:37",
+        "asr": "17:09",
+        "maghrib": "20:24",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "05:07",
+        "sunrise": "06:40",
+        "dhuhr": "13:37",
+        "asr": "17:09",
+        "maghrib": "20:25",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "05:06",
+        "sunrise": "06:39",
+        "dhuhr": "13:37",
+        "asr": "17:09",
+        "maghrib": "20:25",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "05:05",
+        "sunrise": "06:38",
+        "dhuhr": "13:37",
+        "asr": "17:09",
+        "maghrib": "20:26",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "05:04",
+        "sunrise": "06:38",
+        "dhuhr": "13:37",
+        "asr": "17:09",
+        "maghrib": "20:27",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "05:03",
+        "sunrise": "06:37",
+        "dhuhr": "13:37",
+        "asr": "17:09",
+        "maghrib": "20:27",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "05:03",
+        "sunrise": "06:36",
+        "dhuhr": "13:37",
+        "asr": "17:09",
+        "maghrib": "20:28",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "05:02",
+        "sunrise": "06:36",
+        "dhuhr": "13:37",
+        "asr": "17:09",
+        "maghrib": "20:29",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "05:01",
+        "sunrise": "06:35",
+        "dhuhr": "13:37",
+        "asr": "17:09",
+        "maghrib": "20:29",
+        "isha": "21:51"
+      }
+    ]
+  },
+  {
+    "city": "Inezgane",
+    "country": "Morocco",
+    "latitude": 30.3552,
+    "longitude": -9.5378,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (أكادير)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=nearest-official-city; ville=117",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=117",
+    "source_fetched": "2026-05-15T01:15:58.220Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:37",
+        "sunrise": "07:03",
+        "dhuhr": "13:42",
+        "asr": "17:14",
+        "maghrib": "20:13",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:36",
+        "sunrise": "07:02",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:14",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:34",
+        "sunrise": "07:01",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:14",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:33",
+        "sunrise": "07:00",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:15",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:32",
+        "sunrise": "06:59",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:16",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:30",
+        "sunrise": "06:58",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:16",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:29",
+        "sunrise": "06:57",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:17",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:28",
+        "sunrise": "06:56",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:18",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:27",
+        "sunrise": "06:55",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:18",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:25",
+        "sunrise": "06:54",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:19",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:24",
+        "sunrise": "06:53",
+        "dhuhr": "13:41",
+        "asr": "17:13",
+        "maghrib": "20:20",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:23",
+        "sunrise": "06:52",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:20",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:22",
+        "sunrise": "06:51",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:21",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:21",
+        "sunrise": "06:50",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:22",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:19",
+        "sunrise": "06:49",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:22",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:18",
+        "sunrise": "06:48",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:23",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:17",
+        "sunrise": "06:48",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:24",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:16",
+        "sunrise": "06:47",
+        "dhuhr": "13:40",
+        "asr": "17:13",
+        "maghrib": "20:24",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "05:15",
+        "sunrise": "06:46",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:25",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "05:14",
+        "sunrise": "06:45",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:26",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "05:13",
+        "sunrise": "06:44",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:26",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "05:12",
+        "sunrise": "06:44",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:27",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "05:11",
+        "sunrise": "06:43",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:28",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "05:10",
+        "sunrise": "06:42",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:28",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "05:09",
+        "sunrise": "06:42",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:29",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "05:08",
+        "sunrise": "06:41",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:30",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "05:07",
+        "sunrise": "06:40",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:30",
+        "isha": "21:51"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "05:06",
+        "sunrise": "06:40",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:31",
+        "isha": "21:52"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "05:05",
+        "sunrise": "06:39",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:32",
+        "isha": "21:53"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "05:04",
+        "sunrise": "06:38",
+        "dhuhr": "13:40",
+        "asr": "17:12",
+        "maghrib": "20:32",
+        "isha": "21:54"
+      }
+    ]
+  },
+  {
+    "city": "Errachidia",
+    "country": "Morocco",
+    "latitude": 31.9314,
+    "longitude": -4.4248,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (الرشيدية)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=128",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=128",
+    "source_fetched": "2026-05-15T01:15:59.634Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:13",
+        "sunrise": "06:38",
+        "dhuhr": "13:22",
+        "asr": "16:55",
+        "maghrib": "19:56",
+        "isha": "21:11"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:11",
+        "sunrise": "06:37",
+        "dhuhr": "13:22",
+        "asr": "16:55",
+        "maghrib": "19:57",
+        "isha": "21:12"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:10",
+        "sunrise": "06:36",
+        "dhuhr": "13:22",
+        "asr": "16:55",
+        "maghrib": "19:58",
+        "isha": "21:13"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:09",
+        "sunrise": "06:35",
+        "dhuhr": "13:21",
+        "asr": "16:55",
+        "maghrib": "19:58",
+        "isha": "21:14"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:07",
+        "sunrise": "06:34",
+        "dhuhr": "13:21",
+        "asr": "16:55",
+        "maghrib": "19:59",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:06",
+        "sunrise": "06:33",
+        "dhuhr": "13:21",
+        "asr": "16:55",
+        "maghrib": "20:00",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:05",
+        "sunrise": "06:32",
+        "dhuhr": "13:21",
+        "asr": "16:55",
+        "maghrib": "20:01",
+        "isha": "21:16"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:03",
+        "sunrise": "06:31",
+        "dhuhr": "13:21",
+        "asr": "16:55",
+        "maghrib": "20:01",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:02",
+        "sunrise": "06:30",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "20:02",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:01",
+        "sunrise": "06:29",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "20:03",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:59",
+        "sunrise": "06:28",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "20:03",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:58",
+        "sunrise": "06:27",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "20:04",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:57",
+        "sunrise": "06:26",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "20:05",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:56",
+        "sunrise": "06:25",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "20:06",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:54",
+        "sunrise": "06:24",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "20:06",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:53",
+        "sunrise": "06:23",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "20:07",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:52",
+        "sunrise": "06:22",
+        "dhuhr": "13:20",
+        "asr": "16:55",
+        "maghrib": "20:08",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:51",
+        "sunrise": "06:21",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:09",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:50",
+        "sunrise": "06:20",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:09",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:48",
+        "sunrise": "06:20",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:10",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:47",
+        "sunrise": "06:19",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:11",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:46",
+        "sunrise": "06:18",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:11",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:45",
+        "sunrise": "06:17",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:12",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:44",
+        "sunrise": "06:16",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:13",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:43",
+        "sunrise": "06:16",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:14",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:42",
+        "sunrise": "06:15",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:14",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:41",
+        "sunrise": "06:14",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:15",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:40",
+        "sunrise": "06:14",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:16",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:39",
+        "sunrise": "06:13",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:16",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:38",
+        "sunrise": "06:12",
+        "dhuhr": "13:19",
+        "asr": "16:55",
+        "maghrib": "20:17",
+        "isha": "21:39"
+      }
+    ]
+  },
+  {
+    "city": "Erfoud",
+    "country": "Morocco",
+    "latitude": 31.4326,
+    "longitude": -4.2369,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (أرفود)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=130",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=130",
+    "source_fetched": "2026-05-15T01:16:01.073Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:13",
+        "sunrise": "06:38",
+        "dhuhr": "13:21",
+        "asr": "16:53",
+        "maghrib": "19:55",
+        "isha": "21:09"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:12",
+        "sunrise": "06:37",
+        "dhuhr": "13:21",
+        "asr": "16:53",
+        "maghrib": "19:56",
+        "isha": "21:10"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:10",
+        "sunrise": "06:36",
+        "dhuhr": "13:21",
+        "asr": "16:53",
+        "maghrib": "19:56",
+        "isha": "21:11"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:09",
+        "sunrise": "06:35",
+        "dhuhr": "13:20",
+        "asr": "16:53",
+        "maghrib": "19:57",
+        "isha": "21:11"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:08",
+        "sunrise": "06:34",
+        "dhuhr": "13:20",
+        "asr": "16:53",
+        "maghrib": "19:58",
+        "isha": "21:12"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:06",
+        "sunrise": "06:33",
+        "dhuhr": "13:20",
+        "asr": "16:53",
+        "maghrib": "19:58",
+        "isha": "21:13"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:05",
+        "sunrise": "06:32",
+        "dhuhr": "13:20",
+        "asr": "16:53",
+        "maghrib": "19:59",
+        "isha": "21:14"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:04",
+        "sunrise": "06:31",
+        "dhuhr": "13:20",
+        "asr": "16:53",
+        "maghrib": "20:00",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:03",
+        "sunrise": "06:30",
+        "dhuhr": "13:20",
+        "asr": "16:53",
+        "maghrib": "20:00",
+        "isha": "21:16"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:01",
+        "sunrise": "06:29",
+        "dhuhr": "13:19",
+        "asr": "16:53",
+        "maghrib": "20:01",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:00",
+        "sunrise": "06:28",
+        "dhuhr": "13:19",
+        "asr": "16:53",
+        "maghrib": "20:02",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:59",
+        "sunrise": "06:27",
+        "dhuhr": "13:19",
+        "asr": "16:53",
+        "maghrib": "20:03",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:57",
+        "sunrise": "06:26",
+        "dhuhr": "13:19",
+        "asr": "16:53",
+        "maghrib": "20:03",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:56",
+        "sunrise": "06:25",
+        "dhuhr": "13:19",
+        "asr": "16:53",
+        "maghrib": "20:04",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:55",
+        "sunrise": "06:24",
+        "dhuhr": "13:19",
+        "asr": "16:53",
+        "maghrib": "20:05",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:54",
+        "sunrise": "06:23",
+        "dhuhr": "13:19",
+        "asr": "16:53",
+        "maghrib": "20:05",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:53",
+        "sunrise": "06:22",
+        "dhuhr": "13:19",
+        "asr": "16:53",
+        "maghrib": "20:06",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:52",
+        "sunrise": "06:21",
+        "dhuhr": "13:19",
+        "asr": "16:53",
+        "maghrib": "20:07",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:50",
+        "sunrise": "06:20",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:07",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:49",
+        "sunrise": "06:20",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:08",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:48",
+        "sunrise": "06:19",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:09",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:47",
+        "sunrise": "06:18",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:10",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:46",
+        "sunrise": "06:17",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:10",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:45",
+        "sunrise": "06:17",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:11",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:44",
+        "sunrise": "06:16",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:12",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:43",
+        "sunrise": "06:15",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:12",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:42",
+        "sunrise": "06:14",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:13",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:41",
+        "sunrise": "06:14",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:14",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:40",
+        "sunrise": "06:13",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:14",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:39",
+        "sunrise": "06:13",
+        "dhuhr": "13:18",
+        "asr": "16:53",
+        "maghrib": "20:15",
+        "isha": "21:36"
+      }
+    ]
+  },
+  {
+    "city": "Midelt",
+    "country": "Morocco",
+    "latitude": 32.6852,
+    "longitude": -4.7448,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (ميدلت)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=136",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=136",
+    "source_fetched": "2026-05-15T01:16:02.510Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:12",
+        "sunrise": "06:37",
+        "dhuhr": "13:23",
+        "asr": "16:57",
+        "maghrib": "20:00",
+        "isha": "21:14"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:11",
+        "sunrise": "06:36",
+        "dhuhr": "13:23",
+        "asr": "16:57",
+        "maghrib": "20:00",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:09",
+        "sunrise": "06:35",
+        "dhuhr": "13:23",
+        "asr": "16:57",
+        "maghrib": "20:01",
+        "isha": "21:16"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:08",
+        "sunrise": "06:34",
+        "dhuhr": "13:23",
+        "asr": "16:57",
+        "maghrib": "20:02",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:06",
+        "sunrise": "06:33",
+        "dhuhr": "13:22",
+        "asr": "16:57",
+        "maghrib": "20:02",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:05",
+        "sunrise": "06:32",
+        "dhuhr": "13:22",
+        "asr": "16:57",
+        "maghrib": "20:03",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:04",
+        "sunrise": "06:31",
+        "dhuhr": "13:22",
+        "asr": "16:57",
+        "maghrib": "20:04",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:02",
+        "sunrise": "06:30",
+        "dhuhr": "13:22",
+        "asr": "16:57",
+        "maghrib": "20:05",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:01",
+        "sunrise": "06:29",
+        "dhuhr": "13:22",
+        "asr": "16:57",
+        "maghrib": "20:05",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:00",
+        "sunrise": "06:27",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:06",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "04:58",
+        "sunrise": "06:26",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:07",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "04:57",
+        "sunrise": "06:25",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:08",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "04:56",
+        "sunrise": "06:24",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:08",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "04:54",
+        "sunrise": "06:23",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:09",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "04:53",
+        "sunrise": "06:23",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:10",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:52",
+        "sunrise": "06:22",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:11",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:51",
+        "sunrise": "06:21",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:11",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:49",
+        "sunrise": "06:20",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:12",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:48",
+        "sunrise": "06:19",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:13",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:47",
+        "sunrise": "06:18",
+        "dhuhr": "13:21",
+        "asr": "16:57",
+        "maghrib": "20:14",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:46",
+        "sunrise": "06:17",
+        "dhuhr": "13:20",
+        "asr": "16:57",
+        "maghrib": "20:14",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:45",
+        "sunrise": "06:16",
+        "dhuhr": "13:20",
+        "asr": "16:57",
+        "maghrib": "20:15",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:44",
+        "sunrise": "06:16",
+        "dhuhr": "13:20",
+        "asr": "16:57",
+        "maghrib": "20:16",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:42",
+        "sunrise": "06:15",
+        "dhuhr": "13:20",
+        "asr": "16:57",
+        "maghrib": "20:17",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:41",
+        "sunrise": "06:14",
+        "dhuhr": "13:20",
+        "asr": "16:57",
+        "maghrib": "20:17",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:40",
+        "sunrise": "06:13",
+        "dhuhr": "13:20",
+        "asr": "16:57",
+        "maghrib": "20:18",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:39",
+        "sunrise": "06:13",
+        "dhuhr": "13:20",
+        "asr": "16:57",
+        "maghrib": "20:19",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:38",
+        "sunrise": "06:12",
+        "dhuhr": "13:20",
+        "asr": "16:58",
+        "maghrib": "20:20",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:37",
+        "sunrise": "06:11",
+        "dhuhr": "13:20",
+        "asr": "16:58",
+        "maghrib": "20:20",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:36",
+        "sunrise": "06:10",
+        "dhuhr": "13:20",
+        "asr": "16:58",
+        "maghrib": "20:21",
+        "isha": "21:43"
+      }
+    ]
+  },
+  {
+    "city": "Zagora",
+    "country": "Morocco",
+    "latitude": 30.332,
+    "longitude": -5.8377,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (زاكورة)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=137",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=137",
+    "source_fetched": "2026-05-15T01:16:03.945Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:22",
+        "sunrise": "06:47",
+        "dhuhr": "13:28",
+        "asr": "16:59",
+        "maghrib": "20:00",
+        "isha": "21:13"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:21",
+        "sunrise": "06:45",
+        "dhuhr": "13:27",
+        "asr": "16:59",
+        "maghrib": "20:00",
+        "isha": "21:14"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:20",
+        "sunrise": "06:44",
+        "dhuhr": "13:27",
+        "asr": "16:58",
+        "maghrib": "20:01",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:18",
+        "sunrise": "06:43",
+        "dhuhr": "13:27",
+        "asr": "16:58",
+        "maghrib": "20:02",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:17",
+        "sunrise": "06:42",
+        "dhuhr": "13:27",
+        "asr": "16:58",
+        "maghrib": "20:02",
+        "isha": "21:16"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:16",
+        "sunrise": "06:41",
+        "dhuhr": "13:27",
+        "asr": "16:58",
+        "maghrib": "20:03",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:14",
+        "sunrise": "06:40",
+        "dhuhr": "13:26",
+        "asr": "16:58",
+        "maghrib": "20:04",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:13",
+        "sunrise": "06:39",
+        "dhuhr": "13:26",
+        "asr": "16:58",
+        "maghrib": "20:04",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:12",
+        "sunrise": "06:38",
+        "dhuhr": "13:26",
+        "asr": "16:58",
+        "maghrib": "20:05",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:11",
+        "sunrise": "06:37",
+        "dhuhr": "13:26",
+        "asr": "16:58",
+        "maghrib": "20:05",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:10",
+        "sunrise": "06:36",
+        "dhuhr": "13:26",
+        "asr": "16:58",
+        "maghrib": "20:06",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:08",
+        "sunrise": "06:35",
+        "dhuhr": "13:26",
+        "asr": "16:58",
+        "maghrib": "20:07",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:07",
+        "sunrise": "06:35",
+        "dhuhr": "13:26",
+        "asr": "16:58",
+        "maghrib": "20:07",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:06",
+        "sunrise": "06:34",
+        "dhuhr": "13:25",
+        "asr": "16:58",
+        "maghrib": "20:08",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:05",
+        "sunrise": "06:33",
+        "dhuhr": "13:25",
+        "asr": "16:58",
+        "maghrib": "20:09",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:04",
+        "sunrise": "06:32",
+        "dhuhr": "13:25",
+        "asr": "16:58",
+        "maghrib": "20:09",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:03",
+        "sunrise": "06:31",
+        "dhuhr": "13:25",
+        "asr": "16:58",
+        "maghrib": "20:10",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:01",
+        "sunrise": "06:30",
+        "dhuhr": "13:25",
+        "asr": "16:58",
+        "maghrib": "20:11",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "05:00",
+        "sunrise": "06:29",
+        "dhuhr": "13:25",
+        "asr": "16:58",
+        "maghrib": "20:11",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:59",
+        "sunrise": "06:29",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:12",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:58",
+        "sunrise": "06:28",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:13",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:57",
+        "sunrise": "06:27",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:13",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:56",
+        "sunrise": "06:26",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:14",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:55",
+        "sunrise": "06:26",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:15",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:54",
+        "sunrise": "06:25",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:15",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:53",
+        "sunrise": "06:24",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:16",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:52",
+        "sunrise": "06:24",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:17",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:51",
+        "sunrise": "06:23",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:17",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:50",
+        "sunrise": "06:22",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:18",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:50",
+        "sunrise": "06:22",
+        "dhuhr": "13:25",
+        "asr": "16:57",
+        "maghrib": "20:19",
+        "isha": "21:39"
+      }
+    ]
+  },
+  {
+    "city": "Ouarzazate",
+    "country": "Morocco",
+    "latitude": 30.9335,
+    "longitude": -6.937,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (ورزازات)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=138",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=138",
+    "source_fetched": "2026-05-15T01:16:05.415Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:25",
+        "sunrise": "06:49",
+        "dhuhr": "13:32",
+        "asr": "17:04",
+        "maghrib": "20:05",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:24",
+        "sunrise": "06:48",
+        "dhuhr": "13:32",
+        "asr": "17:04",
+        "maghrib": "20:06",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:22",
+        "sunrise": "06:47",
+        "dhuhr": "13:31",
+        "asr": "17:04",
+        "maghrib": "20:07",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:21",
+        "sunrise": "06:46",
+        "dhuhr": "13:31",
+        "asr": "17:03",
+        "maghrib": "20:07",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:20",
+        "sunrise": "06:45",
+        "dhuhr": "13:31",
+        "asr": "17:03",
+        "maghrib": "20:08",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:19",
+        "sunrise": "06:44",
+        "dhuhr": "13:31",
+        "asr": "17:03",
+        "maghrib": "20:09",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:17",
+        "sunrise": "06:43",
+        "dhuhr": "13:31",
+        "asr": "17:03",
+        "maghrib": "20:09",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:16",
+        "sunrise": "06:42",
+        "dhuhr": "13:31",
+        "asr": "17:03",
+        "maghrib": "20:10",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:15",
+        "sunrise": "06:41",
+        "dhuhr": "13:30",
+        "asr": "17:03",
+        "maghrib": "20:11",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:13",
+        "sunrise": "06:40",
+        "dhuhr": "13:30",
+        "asr": "17:03",
+        "maghrib": "20:12",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:12",
+        "sunrise": "06:39",
+        "dhuhr": "13:30",
+        "asr": "17:03",
+        "maghrib": "20:12",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:11",
+        "sunrise": "06:38",
+        "dhuhr": "13:30",
+        "asr": "17:03",
+        "maghrib": "20:13",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:10",
+        "sunrise": "06:37",
+        "dhuhr": "13:30",
+        "asr": "17:03",
+        "maghrib": "20:14",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:09",
+        "sunrise": "06:36",
+        "dhuhr": "13:30",
+        "asr": "17:03",
+        "maghrib": "20:14",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:07",
+        "sunrise": "06:35",
+        "dhuhr": "13:30",
+        "asr": "17:03",
+        "maghrib": "20:15",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:06",
+        "sunrise": "06:34",
+        "dhuhr": "13:30",
+        "asr": "17:03",
+        "maghrib": "20:16",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:05",
+        "sunrise": "06:33",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:16",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:04",
+        "sunrise": "06:33",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:17",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "05:03",
+        "sunrise": "06:32",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:18",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "05:02",
+        "sunrise": "06:31",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:18",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "05:01",
+        "sunrise": "06:30",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:19",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "05:00",
+        "sunrise": "06:29",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:20",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:58",
+        "sunrise": "06:29",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:20",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:57",
+        "sunrise": "06:28",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:21",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:56",
+        "sunrise": "06:27",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:22",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:55",
+        "sunrise": "06:26",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:23",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:55",
+        "sunrise": "06:26",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:23",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:54",
+        "sunrise": "06:25",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:24",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:53",
+        "sunrise": "06:25",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:25",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:52",
+        "sunrise": "06:24",
+        "dhuhr": "13:29",
+        "asr": "17:03",
+        "maghrib": "20:25",
+        "isha": "21:45"
+      }
+    ]
+  },
+  {
+    "city": "Tinghir",
+    "country": "Morocco",
+    "latitude": 31.5141,
+    "longitude": -5.5328,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (تنغير)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=139",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=139",
+    "source_fetched": "2026-05-15T01:16:06.862Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:18",
+        "sunrise": "06:42",
+        "dhuhr": "13:26",
+        "asr": "16:59",
+        "maghrib": "20:01",
+        "isha": "21:14"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:17",
+        "sunrise": "06:41",
+        "dhuhr": "13:26",
+        "asr": "16:59",
+        "maghrib": "20:02",
+        "isha": "21:15"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:15",
+        "sunrise": "06:40",
+        "dhuhr": "13:26",
+        "asr": "16:59",
+        "maghrib": "20:02",
+        "isha": "21:16"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:14",
+        "sunrise": "06:39",
+        "dhuhr": "13:26",
+        "asr": "16:59",
+        "maghrib": "20:03",
+        "isha": "21:17"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:13",
+        "sunrise": "06:38",
+        "dhuhr": "13:25",
+        "asr": "16:59",
+        "maghrib": "20:04",
+        "isha": "21:18"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:11",
+        "sunrise": "06:37",
+        "dhuhr": "13:25",
+        "asr": "16:59",
+        "maghrib": "20:04",
+        "isha": "21:19"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:10",
+        "sunrise": "06:36",
+        "dhuhr": "13:25",
+        "asr": "16:59",
+        "maghrib": "20:05",
+        "isha": "21:20"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:09",
+        "sunrise": "06:35",
+        "dhuhr": "13:25",
+        "asr": "16:59",
+        "maghrib": "20:06",
+        "isha": "21:21"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:07",
+        "sunrise": "06:34",
+        "dhuhr": "13:25",
+        "asr": "16:58",
+        "maghrib": "20:07",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:06",
+        "sunrise": "06:33",
+        "dhuhr": "13:25",
+        "asr": "16:58",
+        "maghrib": "20:07",
+        "isha": "21:22"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:05",
+        "sunrise": "06:32",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:08",
+        "isha": "21:23"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:04",
+        "sunrise": "06:31",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:09",
+        "isha": "21:24"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:02",
+        "sunrise": "06:30",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:09",
+        "isha": "21:25"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:01",
+        "sunrise": "06:29",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:10",
+        "isha": "21:26"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:00",
+        "sunrise": "06:28",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:11",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "04:59",
+        "sunrise": "06:27",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:12",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "04:58",
+        "sunrise": "06:26",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:12",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "04:56",
+        "sunrise": "06:25",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:13",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "04:55",
+        "sunrise": "06:24",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:14",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "04:54",
+        "sunrise": "06:24",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:14",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "04:53",
+        "sunrise": "06:23",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:15",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "04:52",
+        "sunrise": "06:22",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:16",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "04:51",
+        "sunrise": "06:21",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:17",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "04:50",
+        "sunrise": "06:20",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:17",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "04:49",
+        "sunrise": "06:20",
+        "dhuhr": "13:23",
+        "asr": "16:58",
+        "maghrib": "20:18",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "04:48",
+        "sunrise": "06:19",
+        "dhuhr": "13:23",
+        "asr": "16:58",
+        "maghrib": "20:19",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "04:47",
+        "sunrise": "06:18",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:19",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "04:46",
+        "sunrise": "06:18",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:20",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "04:45",
+        "sunrise": "06:17",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:21",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "04:44",
+        "sunrise": "06:16",
+        "dhuhr": "13:24",
+        "asr": "16:58",
+        "maghrib": "20:21",
+        "isha": "21:41"
+      }
+    ]
+  },
+  {
+    "city": "Guelmim",
+    "country": "Morocco",
+    "latitude": 28.987,
+    "longitude": -10.0574,
+    "elevation": 0,
+    "timezone": "Africa/Casablanca",
+    "method": "Morocco (Habous official city table)",
+    "source": "Habous Ministry monthly table (كلميم)",
+    "source_institution": "Ministry of Habous and Islamic Affairs (Morocco)",
+    "source_method": "Official Habous city timetable; match=direct; ville=149",
+    "source_url": "https://www.habous.gov.ma/prieres/horaire_hijri_2.php?ville=149",
+    "source_fetched": "2026-05-15T01:16:08.266Z",
+    "source_hijri_month": "ذي القعدة",
+    "source_gregorian_months": "أبريل / ماي",
+    "dates": [
+      {
+        "date": "2026-04-19",
+        "fajr": "05:42",
+        "sunrise": "07:05",
+        "dhuhr": "13:44",
+        "asr": "17:14",
+        "maghrib": "20:15",
+        "isha": "21:27"
+      },
+      {
+        "date": "2026-04-20",
+        "fajr": "05:41",
+        "sunrise": "07:04",
+        "dhuhr": "13:44",
+        "asr": "17:14",
+        "maghrib": "20:15",
+        "isha": "21:28"
+      },
+      {
+        "date": "2026-04-21",
+        "fajr": "05:39",
+        "sunrise": "07:03",
+        "dhuhr": "13:44",
+        "asr": "17:14",
+        "maghrib": "20:16",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-22",
+        "fajr": "05:38",
+        "sunrise": "07:02",
+        "dhuhr": "13:44",
+        "asr": "17:14",
+        "maghrib": "20:16",
+        "isha": "21:29"
+      },
+      {
+        "date": "2026-04-23",
+        "fajr": "05:37",
+        "sunrise": "07:01",
+        "dhuhr": "13:44",
+        "asr": "17:13",
+        "maghrib": "20:17",
+        "isha": "21:30"
+      },
+      {
+        "date": "2026-04-24",
+        "fajr": "05:36",
+        "sunrise": "07:00",
+        "dhuhr": "13:43",
+        "asr": "17:13",
+        "maghrib": "20:18",
+        "isha": "21:31"
+      },
+      {
+        "date": "2026-04-25",
+        "fajr": "05:35",
+        "sunrise": "06:59",
+        "dhuhr": "13:43",
+        "asr": "17:13",
+        "maghrib": "20:18",
+        "isha": "21:32"
+      },
+      {
+        "date": "2026-04-26",
+        "fajr": "05:33",
+        "sunrise": "06:58",
+        "dhuhr": "13:43",
+        "asr": "17:13",
+        "maghrib": "20:19",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-27",
+        "fajr": "05:32",
+        "sunrise": "06:57",
+        "dhuhr": "13:43",
+        "asr": "17:13",
+        "maghrib": "20:19",
+        "isha": "21:33"
+      },
+      {
+        "date": "2026-04-28",
+        "fajr": "05:31",
+        "sunrise": "06:57",
+        "dhuhr": "13:43",
+        "asr": "17:13",
+        "maghrib": "20:20",
+        "isha": "21:34"
+      },
+      {
+        "date": "2026-04-29",
+        "fajr": "05:30",
+        "sunrise": "06:56",
+        "dhuhr": "13:43",
+        "asr": "17:13",
+        "maghrib": "20:21",
+        "isha": "21:35"
+      },
+      {
+        "date": "2026-04-30",
+        "fajr": "05:29",
+        "sunrise": "06:55",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:21",
+        "isha": "21:36"
+      },
+      {
+        "date": "2026-05-01",
+        "fajr": "05:28",
+        "sunrise": "06:54",
+        "dhuhr": "13:42",
+        "asr": "17:13",
+        "maghrib": "20:22",
+        "isha": "21:37"
+      },
+      {
+        "date": "2026-05-02",
+        "fajr": "05:27",
+        "sunrise": "06:53",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:23",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-03",
+        "fajr": "05:25",
+        "sunrise": "06:52",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:23",
+        "isha": "21:38"
+      },
+      {
+        "date": "2026-05-04",
+        "fajr": "05:24",
+        "sunrise": "06:51",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:24",
+        "isha": "21:39"
+      },
+      {
+        "date": "2026-05-05",
+        "fajr": "05:23",
+        "sunrise": "06:51",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:24",
+        "isha": "21:40"
+      },
+      {
+        "date": "2026-05-06",
+        "fajr": "05:22",
+        "sunrise": "06:50",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:25",
+        "isha": "21:41"
+      },
+      {
+        "date": "2026-05-07",
+        "fajr": "05:21",
+        "sunrise": "06:49",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:26",
+        "isha": "21:42"
+      },
+      {
+        "date": "2026-05-08",
+        "fajr": "05:20",
+        "sunrise": "06:48",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:26",
+        "isha": "21:43"
+      },
+      {
+        "date": "2026-05-09",
+        "fajr": "05:19",
+        "sunrise": "06:48",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:27",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-10",
+        "fajr": "05:18",
+        "sunrise": "06:47",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:28",
+        "isha": "21:44"
+      },
+      {
+        "date": "2026-05-11",
+        "fajr": "05:17",
+        "sunrise": "06:46",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:28",
+        "isha": "21:45"
+      },
+      {
+        "date": "2026-05-12",
+        "fajr": "05:16",
+        "sunrise": "06:45",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:29",
+        "isha": "21:46"
+      },
+      {
+        "date": "2026-05-13",
+        "fajr": "05:15",
+        "sunrise": "06:45",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:29",
+        "isha": "21:47"
+      },
+      {
+        "date": "2026-05-14",
+        "fajr": "05:14",
+        "sunrise": "06:44",
+        "dhuhr": "13:42",
+        "asr": "17:12",
+        "maghrib": "20:30",
+        "isha": "21:48"
+      },
+      {
+        "date": "2026-05-15",
+        "fajr": "05:14",
+        "sunrise": "06:44",
+        "dhuhr": "13:42",
+        "asr": "17:11",
+        "maghrib": "20:31",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-16",
+        "fajr": "05:13",
+        "sunrise": "06:43",
+        "dhuhr": "13:42",
+        "asr": "17:11",
+        "maghrib": "20:31",
+        "isha": "21:49"
+      },
+      {
+        "date": "2026-05-17",
+        "fajr": "05:12",
+        "sunrise": "06:42",
+        "dhuhr": "13:42",
+        "asr": "17:11",
+        "maghrib": "20:32",
+        "isha": "21:50"
+      },
+      {
+        "date": "2026-05-18",
+        "fajr": "05:11",
+        "sunrise": "06:42",
+        "dhuhr": "13:42",
+        "asr": "17:11",
+        "maghrib": "20:33",
+        "isha": "21:51"
+      }
+    ]
+  }
+]

--- a/test/habousMoroccoSnapshots.test.js
+++ b/test/habousMoroccoSnapshots.test.js
@@ -1,0 +1,86 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Morocco Habous source-snapshot archive checks.
+ *
+ * These snapshots are source evidence under fixtures/, not ratchet fixtures
+ * under eval/data/. This test keeps the archive structurally reviewable before
+ * any later curated promotion into the holdout corpus.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import habousMap from '../scripts/data/habous-morocco-cities.json' with { type: 'json' }
+
+const ROOT = path.resolve(import.meta.dirname, '..')
+const SNAPSHOT_DIR = path.join(ROOT, 'fixtures/habous-morocco/monthly')
+const FILENAME_RE = /^(\d{4}-\d{2}-\d{2})_to_(\d{4}-\d{2}-\d{2})\.json$/
+const HHMM_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+const PRAYERS = ['fajr', 'sunrise', 'dhuhr', 'asr', 'maghrib', 'isha']
+
+function readSnapshots() {
+  if (!existsSync(SNAPSHOT_DIR)) return []
+
+  return readdirSync(SNAPSHOT_DIR)
+    .filter(file => file.endsWith('.json'))
+    .sort()
+    .map(file => {
+      const match = file.match(FILENAME_RE)
+      if (!match) throw new Error(`Unexpected Habous snapshot filename: ${file}`)
+
+      return {
+        file,
+        start: match[1],
+        end: match[2],
+        rows: JSON.parse(readFileSync(path.join(SNAPSHOT_DIR, file), 'utf8')),
+      }
+    })
+}
+
+describe('Morocco Habous monthly source snapshots', () => {
+  it('keeps archived monthly snapshots structurally reviewable', () => {
+    const snapshots = readSnapshots()
+    const expectedCities = habousMap.mappedCities.map(row => row.fajrCity).sort()
+
+    expect(snapshots.length).toBeGreaterThanOrEqual(1)
+
+    for (const snapshot of snapshots) {
+      expect(Array.isArray(snapshot.rows), snapshot.file).toBe(true)
+      expect(snapshot.rows.length, snapshot.file).toBe(expectedCities.length)
+
+      const actualCities = snapshot.rows.map(row => row.city).sort()
+      expect(actualCities, snapshot.file).toEqual(expectedCities)
+
+      const allDates = []
+      for (const fixture of snapshot.rows) {
+        expect(fixture.country, `${snapshot.file} ${fixture.city}`).toBe('Morocco')
+        expect(fixture.timezone, `${snapshot.file} ${fixture.city}`).toBe('Africa/Casablanca')
+        expect(fixture.source_institution, `${snapshot.file} ${fixture.city}`)
+          .toBe('Ministry of Habous and Islamic Affairs (Morocco)')
+        expect(fixture.source_method, `${snapshot.file} ${fixture.city}`)
+          .toMatch(/Official Habous city timetable/)
+        expect(fixture.source_url, `${snapshot.file} ${fixture.city}`)
+          .toMatch(/^https:\/\/(www\.)?habous\.gov\.ma\/prieres\//)
+        expect(fixture.dates.length, `${snapshot.file} ${fixture.city}`).toBeGreaterThanOrEqual(29)
+        expect(fixture.dates.length, `${snapshot.file} ${fixture.city}`).toBeLessThanOrEqual(31)
+
+        const fixtureDates = fixture.dates.map(row => row.date)
+        expect(fixtureDates, `${snapshot.file} ${fixture.city}`).toEqual([...fixtureDates].sort())
+
+        for (const row of fixture.dates) {
+          allDates.push(row.date)
+          expect(row.date, `${snapshot.file} ${fixture.city}`).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+          for (const prayer of PRAYERS) {
+            expect(row[prayer], `${snapshot.file} ${fixture.city} ${row.date} ${prayer}`)
+              .toMatch(HHMM_RE)
+          }
+        }
+      }
+
+      allDates.sort()
+      expect(allDates[0], snapshot.file).toBe(snapshot.start)
+      expect(allDates.at(-1), snapshot.file).toBe(snapshot.end)
+    }
+  })
+})


### PR DESCRIPTION
Refs #92
Refs #103

## Summary
- Archives the first official Habous Morocco monthly snapshot under `fixtures/habous-morocco/monthly/2026-04-19_to_2026-05-18.json`.
- Fixes the scheduled capture workflow guard so untracked snapshot files are detected and committed instead of being skipped by `git diff --quiet`.
- Adds source-archive tests for monthly snapshot filenames, mapped-city coverage, source metadata, sorted dates, and HH:MM prayer rows.

## Snapshot
- Source: Ministry of Habous current Hijri-month city tables
- Coverage: 33 mapped Moroccan cities x 30 days
- Gregorian range: 2026-04-19 to 2026-05-18
- Dated prayer rows: 990

## Validation
- `npx vitest run test/habousMoroccoSnapshots.test.js test/habousMoroccoFixture.test.js` — 5/5 passing
- `npm test` — 415/415 passing
- `npm run validate:registry` — pass, 0 fail-class issues; 1 existing warn-class allowlist
- `git diff --check` — passed

## Notes
This stores source evidence under `fixtures/` only. It does not promote rows into `eval/data/`, does not change prayer-time calculations, and does not change runtime package size because fixtures are not in the published package files list.

— fajr-codex
