### PR TITLE
audit(geometry): source-map Egypt metro candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
   coverage, source metadata, sorted dates, and HH:MM prayer rows before any
   later promotion into `eval/data/`.
 
+### Added — Egypt geometry source-map candidates
+
+- Added audit-only WOF source-map candidates for Cairo, Giza, and 6th of
+  October. These preserve the Cairo/Giza/6th metro geometry research without
+  changing runtime bboxes.
+- Marked the Egypt rows `source-map-only` / `needs-clipping-review` because
+  the available WOF evidence is mixed: Cairo has a real locality but existing
+  runtime coverage includes New Cairo; Giza/New Cairo rows are point-like; and
+  6th of October is county-level.
+
 ## [1.9.1] — 2026-05-14
 
 ### Fixed — Sialkot/Gujranwala city-geometry overlap

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -316,6 +316,11 @@ validator warnings, or known clipping gaps:
   rows, preserving Malaysia/JAKIM provenance at city level.
 - Resolved high-risk overlap: Sialkot/Gujranwala. Sialkot now has a reviewed
   WOF source-map row and no longer shadows Gujranwala's north-east edge.
+- Source-mapped but not runtime-safe yet: Cairo/Giza/6th of October. WOF has a
+  real Cairo locality, point-like Giza/New Cairo localities, and split
+  county-level Giza/6th-of-October candidates. These rows are now preserved as
+  source leads, but runtime bboxes should wait for a reviewed clipping design
+  or official Egyptian municipal geometry.
 - High-risk metro/border clusters: Cairo/Giza/6th of October,
   Dubai/Sharjah/Ajman, Toronto/Mississauga/Laval/Montreal,
   Lahore/Gujranwala broader coverage, Basra/Ahvaz/Kuwait City,

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1,7 +1,7 @@
 {
   "$schema_doc": "Build-time source map for auditing src/data/cities.json city bboxes. This file stores stable external IDs, review state, authority IDs, and cache pointers only. Raw geometry stays outside git/npm in .cache/city-geometry.",
   "version": 1,
-  "updated": "2026-05-14",
+  "updated": "2026-05-15",
   "issue": 118,
   "cacheRoot": ".cache/city-geometry",
   "providers": {
@@ -466,6 +466,107 @@
           "matchConfidence": "candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
           "reviewStatus": "runtime-bbox-shipped"
+        }
+      ]
+    },
+    {
+      "cityKey": "Cairo|EG",
+      "priority": ["egypt-metro", "cairo-giza-6october", "source-map-only", "needs-clipping-review"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: WOF source-map candidate only. Do not tighten runtime Cairo directly from the WOF locality envelope because the shipped Cairo row intentionally covers the New Cairo/east-Cairo corridor; direct WOF copying would drop existing city provenance."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421174399",
+          "ids": { "wofId": 421174399, "repo": "whosonfirst-data-admin-eg", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "EG/cairo/wof-locality-421174399.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Real Cairo locality geometry, but not sufficient by itself for the current runtime cell because east-Cairo/New Cairo coverage needs a separate reviewed design."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421175733",
+          "ids": { "wofId": 421175733, "repo": "whosonfirst-data-admin-eg", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "EG/cairo/wof-locality-421175733.geojson",
+          "sourceConfidence": "low",
+          "matchConfidence": "point-like-related-locality-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["New Cairo is point-like in WOF and is recorded only as a source lead for the east-Cairo coverage question."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Giza|EG",
+      "priority": ["egypt-metro", "cairo-giza-6october", "source-map-only", "needs-clipping-review"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: WOF source-map candidate only. Giza has a point-like WOF locality plus split county candidates; none is safe as a direct runtime replacement for the current clipped Giza row."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421204393",
+          "ids": { "wofId": 421204393, "repo": "whosonfirst-data-admin-eg", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "EG/giza/wof-locality-421204393.geojson",
+          "sourceConfidence": "low",
+          "matchConfidence": "point-like-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:1092021173",
+          "ids": { "wofId": 1092021173, "repo": "whosonfirst-data-admin-eg", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "EG/giza/wof-county-1092021173.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:1092021203",
+          "ids": { "wofId": 1092021203, "repo": "whosonfirst-data-admin-eg", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "EG/giza/wof-county-1092021203.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "6th of October|EG",
+      "priority": ["egypt-metro", "cairo-giza-6october", "source-map-only", "needs-clipping-review"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: WOF county candidate is promising for west/north undercoverage, but the geometry needs manual review before any runtime bbox change because it is county-level and may not contain the current registry center cleanly."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:county:1092014009",
+          "ids": { "wofId": 1092014009, "repo": "whosonfirst-data-admin-eg", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "EG/6th-of-october/wof-county-1092014009.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
         }
       ]
     },

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -171,6 +171,28 @@ describe('city geometry source map', () => {
     expect(statusFor('Brazzaville|CG')).toBe('runtime-bbox-shipped')
     expect(statusFor('Kinshasa|CD')).toBe('runtime-bbox-shipped')
   })
+
+  it('keeps Egypt metro geometry as source-map-only until clipping is reviewed', () => {
+    const expected = new Map([
+      ['Cairo|EG', ['wof:locality:421174399', 'wof:locality:421175733']],
+      ['Giza|EG', ['wof:locality:421204393', 'wof:county:1092021173', 'wof:county:1092021203']],
+      ['6th of October|EG', ['wof:county:1092014009']],
+    ])
+
+    for (const [cityKey, stableIds] of expected) {
+      const entry = sourceMap.cities.find(row => row.cityKey === cityKey)
+      expect(entry, cityKey).toBeTruthy()
+      expect(entry.review.status, cityKey).toBe('candidate')
+      expect(entry.priority, cityKey).toContain('source-map-only')
+      expect(entry.priority, cityKey).toContain('needs-clipping-review')
+
+      for (const stableId of stableIds) {
+        const geometry = entry.geometries.find(row => row.stableId === stableId)
+        expect(geometry, `${cityKey} ${stableId}`).toBeTruthy()
+        expect(geometry.reviewStatus, `${cityKey} ${stableId}`).toBe('candidate')
+      }
+    }
+  })
 })
 
 function slug(city) {


### PR DESCRIPTION
Refs #118

## Summary
- Adds audit-only WOF source-map candidates for `Cairo|EG`, `Giza|EG`, and `6th of October|EG`.
- Documents why these Egypt rows are `source-map-only` / `needs-clipping-review` rather than runtime bbox changes.
- Extends the geometry source-map test so Egypt metro candidates stay candidate-only until clipping or official municipal geometry is reviewed.

## Findings
- `Cairo|EG` has a real WOF locality (`wof:locality:421174399`), but directly tightening Cairo would drop existing east-Cairo/New Cairo coverage.
- `Giza|EG` WOF locality is point-like, and usable Giza evidence is split across county-level rows.
- `6th of October|EG` has a promising county-level candidate, but the audit flags center/geometry review before it can drive runtime.

## Validation
- `jq empty scripts/data/city-geometry-sources.json`
- `npx vitest run test/geometrySourceMap.test.js` — 9/9 passing
- `node scripts/fetch-city-geometry-cache.js --provider wof --city Cairo --format json` — 2/2 fetched locally
- `node scripts/fetch-city-geometry-cache.js --provider wof --city Giza --format json` — 3/3 fetched locally
- `node scripts/fetch-city-geometry-cache.js --provider wof --city "6th of October" --format json` — 1/1 fetched locally
- `node scripts/audit-city-geometry.js --format json` — 51 source-map cities, 68 rows, 67 checked, 0 missing cache files, 1 intentional no-geometry row
- `npm test` — 416/416 passing
- `npm run validate:registry` — pass, 0 fail-class issues; 1 existing warn-class allowlist
- `npm pack --dry-run` — 146.9 kB packed / 539.1 kB unpacked / 21 files
- `git diff --check` — passed

## Runtime/package impact
No runtime bbox, prayer-time math, public API, eval data, or package payload changed. Raw WOF GeoJSON remains local cache only and is not committed.

— fajr-codex
