### PR TITLE
audit: align shipped WOF source status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 
 ## [Unreleased]
 
+### Fixed — Geometry source-map status alignment
+
+- Marked the Basel and Mulhouse WOF locality rows as row-level
+  `runtime-bbox-shipped`, matching the already-shipped city-level runtime bbox
+  status from the geometry audit.
+- Added a source-map test so future direct WOF-backed runtime bboxes keep at
+  least one row-level WOF geometry marked as shipped.
+
 ### Changed — Asr convention wording in hand-curated docs
 
 - Cleaned `docs/paper.md` and `docs/calibration-recipe.md` so they describe

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1302,9 +1302,9 @@
           "ids": { "wofId": 101748459, "repo": "whosonfirst-data-admin-ch", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "CH/basel/wof-locality-101748459.geojson",
           "sourceConfidence": "high",
-          "matchConfidence": "candidate",
+          "matchConfidence": "runtime-bbox",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate",
+          "reviewStatus": "runtime-bbox-shipped",
           "notes": ["WOF SQLite admin-ch latest lists this as the current locality row for Basel; bbox aligns with the OSM municipal envelope."]
         }
       ]
@@ -1333,9 +1333,9 @@
           "ids": { "wofId": 101749573, "repo": "whosonfirst-data-admin-fr", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "FR/mulhouse/wof-locality-101749573.geojson",
           "sourceConfidence": "high",
-          "matchConfidence": "candidate",
+          "matchConfidence": "runtime-bbox",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
-          "reviewStatus": "candidate",
+          "reviewStatus": "runtime-bbox-shipped",
           "notes": ["WOF SQLite admin-fr latest lists this as the current locality row for Mulhouse; bbox aligns with the OSM municipal envelope."]
         }
       ]

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -172,6 +172,25 @@ describe('city geometry source map', () => {
     expect(statusFor('Kinshasa|CD')).toBe('runtime-bbox-shipped')
   })
 
+  it('marks the WOF row-level source as shipped for direct WOF runtime bboxes', () => {
+    const clippedRuntimeRows = new Set([
+      // Dubai uses a clipped lookup cell from the WOF lead, not the full WOF
+      // envelope, so the geometry row remains a candidate by design.
+      'Dubai|AE',
+    ])
+
+    for (const entry of sourceMap.cities) {
+      if (entry.review.status !== 'runtime-bbox-shipped') continue
+      if (clippedRuntimeRows.has(entry.cityKey)) continue
+
+      const shippedWofRows = (entry.geometries || [])
+        .filter(geometry => geometry.provider === 'wof')
+        .filter(geometry => geometry.reviewStatus === 'runtime-bbox-shipped')
+
+      expect(shippedWofRows.length, entry.cityKey).toBeGreaterThan(0)
+    }
+  })
+
   it('keeps Egypt metro geometry as source-map-only until clipping is reviewed', () => {
     const expected = new Map([
       ['Cairo|EG', ['wof:locality:421174399', 'wof:locality:421175733']],


### PR DESCRIPTION
## Summary

- Marks the Basel and Mulhouse WOF locality rows as row-level `runtime-bbox-shipped`, matching their already-shipped city-level geometry status.
- Adds a source-map regression test so direct WOF-backed runtime bbox rows keep at least one shipped WOF source row.
- Records the audit metadata cleanup in `CHANGELOG.md`.

## Scope

Audit metadata only. No runtime bbox, city registry, prayer math, method dispatch, package-size, or public API change.

## Verification

- `jq empty scripts/data/city-geometry-sources.json`
- `npx vitest run test/geometrySourceMap.test.js` — 10/10
- `npm test` — 417/417
- `npm run validate:registry` — pass, 0 fail-class issues
- `git diff --check`

Refs #118.
