### PR TITLE
fix(geometry): route Al Buraimi to Oman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 
 ## [Unreleased]
 
+### Fixed — Al Buraimi / Al Ain border routing
+
+- Added a conservative `Al Buraimi|OM` city-centre guardrail so Al Buraimi no
+  longer resolves to UAE / Al Ain city provenance.
+- Added an Oman guardrail in country detection ahead of the broad UAE rectangle,
+  preserving Al Ain routing while returning Oman defaults and `Asia/Muscat` for
+  Al Buraimi centre coordinates.
+- No prayer-time math, public API, or regional method policy changed beyond
+  correcting the country/city provenance for this border case.
+
 ### Fixed — Geometry source-map status alignment
 
 - Marked the Basel and Mulhouse WOF locality rows as row-level

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -1,6 +1,6 @@
 # City Geometry Audit
 
-Last refreshed: 2026-05-14
+Last refreshed: 2026-05-15
 
 `detectLocation()` intentionally ships a compact offline bbox registry rather
 than raw municipal polygons. The bbox layer is fast and small enough for
@@ -34,14 +34,15 @@ human review. It must not mutate the runtime registry automatically.
 
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
-41 high-priority rows: 15 Morocco/Habous phase-1 rows, 5 UAE metro rows, 10
-Turkey large-city rows, 1 Detroit/Windsor border row, 3 Geneva border rows, 2
-Strasbourg/Kehl border rows, and 5 existing registry warning rows. It carries
-17 OSM relation rows plus 37 WOF
-rows across reviewed locality/county candidates. Morocco rows with WOF-backed
-runtime status are separated from OSM-only audit candidates; Jerusalem
-intentionally remains without a geometry candidate until a human routing
-decision is available.
+52 high-priority rows: 15 Morocco/Habous phase-1 rows, 3 Egypt metro
+source-map rows, 5 UAE metro rows, 1 Oman/UAE border row, 10 Turkey large-city
+rows, 2 Singapore/Johor rows, 4 Klang Valley rows, 1 Pakistan overlap row, 1
+Detroit/Windsor border row, 3 Geneva border rows, 2 Strasbourg/Kehl border
+rows, 2 Congo River rows, and 3 carry-over registry-warning rows. It carries 17
+OSM relation rows plus 52 WOF rows across reviewed locality/county candidates.
+Morocco rows with WOF-backed runtime status are separated from OSM-only audit
+candidates; Jerusalem intentionally remains without a geometry candidate until
+a human routing decision is available.
 
 ```json
 {
@@ -118,11 +119,17 @@ county/prefecture bboxes or OSM alone. Either find a reviewed WOF locality
 polygon, verify an official/commune-level source with compatible licensing, or
 leave the row as a documented audit gap.
 
-The first UAE pass shows a different pattern:
+The first UAE/Oman pass shows a different pattern:
 
-- Abu Dhabi and Al Ain have current WOF locality envelopes that expand the
-  shipped city lookup cells without colliding with neighboring fajr rows, so
-  they are runtime-ready.
+- Abu Dhabi has a current WOF locality envelope that expands the shipped city
+  lookup cell without colliding with neighboring fajr rows, so it is
+  runtime-ready as-is. Al Ain's WOF envelope is usable only after clipping its
+  east edge at the Oman seam.
+- Al Buraimi, Oman sits inside Al Ain's broad source envelope. Its WOF locality
+  row is point-like and deprecated, while the current WOF county row is too
+  broad for city routing. The runtime therefore uses a small city-centre
+  guardrail and an Oman-before-UAE country-detection check rather than copying
+  either raw envelope.
 - Dubai, Sharjah, and Ajman also have current WOF locality envelopes, but their
   rectangular envelopes overlap heavily. Dubai, Sharjah, and Ajman now use
   explicit clipped runtime cells: Dubai's northern edge meets Sharjah's

--- a/docs/positions.md
+++ b/docs/positions.md
@@ -1,6 +1,6 @@
 # fajr Position Registry
 
-Last refreshed: 2026-05-14
+Last refreshed: 2026-05-15
 
 This is the compact product-doctrine layer for fajr. It answers the question:
 when a user gives coordinates, what prayer-time position does fajr apply, and
@@ -123,6 +123,7 @@ the log entry's date + evidence-source SHA answer it mechanically.
 | UK | MoonsightingCommittee / local city overrides where present. | C | London Mawaqit residual remains an open Path A candidate (#70). | "UK defaults are practical but locally variable; show method and allow override." |
 | France | France/UOIF-style high-latitude accommodation where dispatched. | B | Mawaqit France yearly corpus improves support; regional practice is still mosque-specific. | "France default follows common local convention; confirm mosque if it differs." |
 | UAE | UAE/Dubai method plus elevation disclosure for high-rise contexts. | B | IACAD/Burj Khalifa precedent supports floor/elevation distinction; full automated source ingestion remains future work. | "UAE default; high-rise elevation may matter for Shuruq and Maghrib." |
+| Oman / Gulf fallback states | Kuwait/Gulf regional method where no stronger city authority is bundled. Al Buraimi is explicitly routed to Oman rather than neighboring UAE / Al Ain. | C | Regional method dispatch is documented; Al Buraimi routing is backed by reviewed WOF point/county context, but no Oman official timetable corpus is promoted yet. | "Gulf regional default. Verify local ministry or mosque timetable when exact local practice matters." |
 | Egypt | Egyptian method. | C | Formal method is established, but Cairo/Alexandria residuals remain open in #69 pending stronger local/institutional corpus. | "Egyptian method default; current validation gap is known." |
 | Iran / Shia Iraqi city overrides | Tehran/Jafari-style method where city/community override is documented. | B | Tehran Institute method and Sistani-aligned Iraqi city overrides are documented; broader fixture depth still needs work. | "Local Shia institutional method where known; country defaults may not represent every community." |
 | High latitudes | Established high-latitude adjustment rules plus validity warnings. | C | Fiqh necessity is clear, but local practice differs sharply by city/council. | "High-latitude rule applied; consult local mosque/council and show warnings." |

--- a/scripts/build-city-registry.js
+++ b/scripts/build-city-registry.js
@@ -501,6 +501,9 @@ const MUSLIM_POPULATION_CENTERS = [
   { name: 'Fujairah',   nameLocal: 'الفجيرة', countryISO: 'AE', adminRegion: 'Fujairah Emirate', lat: 25.1288, lon: 56.3265, elevation: 18, timezone: 'Asia/Dubai', population: 86000 },
   { name: 'Al Ain',     nameLocal: 'العين', countryISO: 'AE', adminRegion: 'Abu Dhabi Emirate', lat: 24.2075, lon: 55.7447, elevation: 295, timezone: 'Asia/Dubai', population: 766000 },
 
+  // ─── v1.9.2 #118 — Oman/UAE border guardrail ───────────────────────────
+  { name: 'Al Buraimi', countryISO: 'OM', adminRegion: 'Al Buraimi Governorate', lat: 24.25088, lon: 55.79312, elevation: 299, timezone: 'Asia/Muscat', population: 117000 },
+
   // ─── v1.7.18 Tier A — Asia: Egypt additional cities ──────────────────────
   { name: 'Port Said',  nameLocal: 'بورسعيد', countryISO: 'EG', adminRegion: 'Port Said', lat: 31.2653, lon: 32.3019, elevation: 2, timezone: 'Africa/Cairo', population: 760000 },
   { name: 'Suez',       nameLocal: 'السويس', countryISO: 'EG', adminRegion: 'Suez', lat: 29.9737, lon: 32.5263, elevation: 9, timezone: 'Africa/Cairo', population: 744000 },
@@ -1008,12 +1011,17 @@ const BBOX_OVERRIDES = {
   'Sharjah|AE':         [25.30, 25.398821, 55.30, 55.678456],
   'Ajman|AE':           [25.398821, 25.45088, 55.423316, 55.630065],
 
-  // v1.8.0 #118: WOF current locality envelopes improve UAE city coverage
-  // without colliding with neighboring lookup cells. Dubai/Sharjah/Ajman use
-  // the clipped runtime cells above because their WOF envelopes overlap
-  // heavily.
+  // v1.8.0 #118: WOF current locality envelopes improve UAE city coverage.
+  // Dubai/Sharjah/Ajman use clipped runtime cells above because their WOF
+  // envelopes overlap heavily. Al Ain is clipped east of the Al Buraimi
+  // guardrail because the raw WOF envelope crosses the Oman/UAE twin-city seam.
   'Abu Dhabi|AE':       [24.195888, 24.590696, 54.254076, 54.841984],
-  'Al Ain|AE':          [24.013749, 24.414416, 55.464609, 56.018126],
+  'Al Ain|AE':          [24.013749, 24.414416, 55.464609, 55.7699],
+
+  // v1.9.2 #118: Al Buraimi OM is anchored by a point-like WOF locality row
+  // and a broader WOF county context row. Ship a small centre guardrail, not
+  // either raw WOF envelope, so Al Buraimi does not inherit UAE/Al Ain routing.
+  'Al Buraimi|OM':      [24.22, 24.29, 55.77, 55.84],
 
   // v1.8.0 #118: reviewed WOF current locality envelopes for large Turkish
   // city lookup cells. Ambiguous/point-like rows (Diyarbakir, Eskisehir,

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -593,12 +593,18 @@
     },
     {
       "cityKey": "Al Ain|AE",
-      "priority": ["uae-metro", "wof-locality-runtime-bbox"],
+      "priority": ["uae-metro", "wof-locality-runtime-bbox", "clipped"],
       "review": {
         "status": "runtime-bbox-shipped",
         "issue": 118,
-        "notes": ["2026-05-14: runtime bbox updated to reviewed WOF current locality envelope; no neighboring UAE city bbox collision."]
+        "notes": [
+          "2026-05-14: runtime bbox updated from reviewed WOF current locality envelope.",
+          "2026-05-15: east edge clipped before the Al Buraimi guardrail because the raw WOF envelope crosses the Oman/UAE twin-city seam."
+        ]
       },
+      "neighborRelations": [
+        { "cityKey": "Al Buraimi|OM", "kind": "cross-border-twin-city", "status": "Al Ain runtime cell is clipped west of the Al Buraimi guardrail" }
+      ],
       "geometries": [
         {
           "provider": "wof",
@@ -606,9 +612,47 @@
           "ids": { "wofId": 421168687, "repo": "whosonfirst-data-admin-ae", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
           "cacheFile": "AE/al-ain/wof-locality-421168687.geojson",
           "sourceConfidence": "high",
-          "matchConfidence": "candidate",
+          "matchConfidence": "clipped-runtime-bbox",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
           "reviewStatus": "runtime-bbox-shipped"
+        }
+      ]
+    },
+    {
+      "cityKey": "Al Buraimi|OM",
+      "priority": ["oman-uae-border", "al-ain-buraimi-seam", "city-center-guardrail"],
+      "review": {
+        "status": "runtime-bbox-shipped",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: added a clipped city-centre guardrail cell so Al Buraimi does not resolve to UAE/Al Ain. WOF has a point-like locality row plus a broader county row; neither is copied directly as a full city polygon."
+        ]
+      },
+      "neighborRelations": [
+        { "cityKey": "Al Ain|AE", "kind": "cross-border-twin-city", "status": "runtime cells intentionally overlap at source-envelope level but the Al Buraimi guardrail is smaller and country-detected as Oman" }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421177367",
+          "ids": { "wofId": 421177367, "repo": "whosonfirst-data-admin-om", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": -1 },
+          "cacheFile": "OM/al-buraimi/wof-locality-421177367.geojson",
+          "sourceConfidence": "low",
+          "matchConfidence": "point-like-runtime-guardrail",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "runtime-bbox-shipped",
+          "notes": ["Point-like WOF locality row anchors the city centre only; runtime bbox is a conservative guardrail cell, not the full city extent."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:421184225",
+          "ids": { "wofId": 421184225, "repo": "whosonfirst-data-admin-om", "placetype": "county", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "OM/al-buraimi/wof-county-421184225.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["County row confirms the Omani side of the seam but is too broad to copy into the runtime city registry."]
         }
       ]
     },

--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -1,6 +1,6 @@
 {
   "version": "1.7.0-alpha.0",
-  "generated": "2026-05-14T22:12:36.873Z",
+  "generated": "2026-05-15T01:53:23.386Z",
   "license": {
     "world-cities": "Capital data from UN Statistics Division and Wikipedia (public-domain reference, MIT-aligned)",
     "mawaqit-slugs": "Curated metadata derived from public Mawaqit profile pages (slugs only)",
@@ -8,7 +8,7 @@
     "population-centers": "Manual, sourced from UN World Cities + World Population Review 2024-2025"
   },
   "notes": "Cities sorted by bbox area ascending. detectLocation() linear-scans this array and returns the first bbox that contains (lat, lon) — smallest match wins. Each city carries an institutional `source` (mawaqit | national-authority | inherited) so apps can attribute timetable provenance to users. Method overrides are city-level institutional decisions documented in scripts/data/city-method-overrides.json with citation strings.",
-  "total": 483,
+  "total": 484,
   "cities": [
     {"name":"Alburikent (Dagestan)","countryISO":"RU","lat":42.9234,"lon":47.5089,"bbox":[42.92,42.94,47.5,47.52],"timezone":"Europe/Moscow","adminRegion":"Dagestan","population":11000,"elevation":50,"source":{"type":"mawaqit","slug":"alburkent-dzhuma-mechet-alburikent-367026-russia"}},
     {"name":"Isa Town","countryISO":"BH","lat":26.1762,"lon":50.5495,"bbox":[26.16,26.19,50.53,50.56],"timezone":"Asia/Bahrain","population":38000,"elevation":21,"source":{"type":"mawaqit","slug":"masjid-madina-issa-south-810-issa-town-bahrain"}},
@@ -20,6 +20,7 @@
     {"name":"Geneva","countryISO":"CH","lat":46.2044,"lon":6.1432,"bbox":[46.177774,46.234248,6.110233,6.175845],"timezone":"Europe/Zurich","adminRegion":"Geneva Canton","population":203000,"elevation":375,"source":{"type":"mawaqit","slug":"fondation-culturelle-islamique-de-geneve-geneve-1209-switzerland"}},
     {"name":"Berrechid","countryISO":"MA","lat":33.2659,"lon":-7.5867,"bbox":[33.230306,33.299095,-7.613623,-7.545455],"timezone":"Africa/Casablanca","population":136000,"elevation":175,"source":{"type":"mawaqit","slug":"mosquee-brahimm-lkhlalil-berrchid-26100-morocco"}},
     {"name":"Mamoudzou","countryISO":"YT","lat":-12.7806,"lon":45.2278,"bbox":[-12.81,-12.74,45.2,45.27],"timezone":"Indian/Mayotte","population":71000,"elevation":14,"source":{"type":"inherited","from":"Mayotte"}},
+    {"name":"Al Buraimi","countryISO":"OM","lat":24.2509,"lon":55.7931,"bbox":[24.22,24.29,55.77,55.84],"timezone":"Asia/Muscat","adminRegion":"Al Buraimi Governorate","population":117000,"elevation":299,"source":{"type":"inherited","from":"Oman"}},
     {"name":"Mulhouse","countryISO":"FR","lat":47.7508,"lon":7.3359,"bbox":[47.721942,47.783092,7.282525,7.368264],"timezone":"Europe/Paris","population":109000,"elevation":240,"source":{"type":"mawaqit","slug":"association-des-musulmans-des-coteaux-mulhouse"}},
     {"name":"Samsun","countryISO":"TR","lat":41.2867,"lon":36.33,"bbox":[41.256092,41.314632,36.290671,36.3846],"timezone":"Europe/Istanbul","adminRegion":"Samsun Province","population":1356000,"elevation":4,"source":{"type":"inherited","from":"Turkey"}},
     {"name":"Basel","countryISO":"CH","lat":47.5596,"lon":7.5886,"bbox":[47.519297,47.589902,7.554659,7.634148],"timezone":"Europe/Zurich","population":173000,"elevation":260,"source":{"type":"mawaqit","slug":"masjid-arrahma-bale-4057-switzerland"}},
@@ -298,6 +299,7 @@
     {"name":"Johannesburg","countryISO":"ZA","lat":-26.2041,"lon":28.0473,"bbox":[-26.4,-25.95,27.95,28.2],"timezone":"Africa/Johannesburg","adminRegion":"Gauteng","population":5783000,"elevation":1753,"source":{"type":"inherited","from":"SouthAfrica"}},
     {"name":"Giza","countryISO":"EG","lat":30.0131,"lon":31.2089,"bbox":[29.6131,30.1,30.98,31.22],"timezone":"Africa/Cairo","nameLocal":"الجيزة","adminRegion":"Giza","population":9200000,"elevation":30,"source":{"type":"inherited","from":"Egypt"}},
     {"name":"Rawalpindi","countryISO":"PK","lat":33.5651,"lon":73.0169,"bbox":[33.3,33.6,72.8,73.2],"timezone":"Asia/Karachi","nameLocal":"راولپنڈی","adminRegion":"Punjab","population":2099000,"elevation":508,"source":{"type":"inherited","from":"Pakistan"}},
+    {"name":"Al Ain","countryISO":"AE","lat":24.2075,"lon":55.7447,"bbox":[24.013749,24.414416,55.464609,55.7699],"timezone":"Asia/Dubai","nameLocal":"العين","adminRegion":"Abu Dhabi Emirate","population":766000,"elevation":295,"source":{"type":"inherited","from":"UAE"}},
     {"name":"Kinshasa","countryISO":"CD","lat":-4.4419,"lon":15.2663,"bbox":[-4.647148,-4.36,15.130611,15.566205],"timezone":"Africa/Kinshasa","elevation":280,"source":{"type":"inherited","from":"DRCongo"}},
     {"name":"Cairo","countryISO":"EG","lat":30.0444,"lon":31.2357,"bbox":[29.84,30.24,31.22,31.56],"timezone":"Africa/Cairo","nameLocal":"القاهرة","population":10100000,"elevation":23,"source":{"type":"mawaqit","slug":"msjd-l-lm-lnf-nouveau-caire-4710001-egypt"}},
     {"name":"Singapore","countryISO":"SG","lat":1.3521,"lon":103.8198,"bbox":[1.158699,1.4499,103.605701,104.088483],"timezone":"Asia/Singapore","population":5454000,"elevation":15,"source":{"type":"mawaqit","slug":"al-khair-mosque-darul-tafsir-choa-chu-kang-688847-singapore"}},
@@ -373,7 +375,6 @@
     {"name":"Rajshahi","countryISO":"BD","lat":24.3636,"lon":88.6241,"bbox":[24.1636,24.5636,88.4241,88.8241],"timezone":"Asia/Dhaka","nameLocal":"রাজশাহী","adminRegion":"Rajshahi Division","population":760000,"elevation":18,"source":{"type":"inherited","from":"Bangladesh"}},
     {"name":"Bahawalpur","countryISO":"PK","lat":29.3956,"lon":71.6722,"bbox":[29.1956,29.5956,71.4722,71.8722],"timezone":"Asia/Karachi","nameLocal":"بہاولپور","adminRegion":"Punjab","population":762000,"elevation":116,"source":{"type":"inherited","from":"Pakistan"}},
     {"name":"Dubai","countryISO":"AE","lat":25.2048,"lon":55.2708,"bbox":[24.9,25.3,55.05,55.5],"timezone":"Asia/Dubai","nameLocal":"دبي","adminRegion":"Dubai Emirate","population":3604000,"elevation":5,"source":{"type":"inherited","from":"UAE"}},
-    {"name":"Al Ain","countryISO":"AE","lat":24.2075,"lon":55.7447,"bbox":[24.013749,24.414416,55.464609,56.018126],"timezone":"Asia/Dubai","nameLocal":"العين","adminRegion":"Abu Dhabi Emirate","population":766000,"elevation":295,"source":{"type":"inherited","from":"UAE"}},
     {"name":"Hong Kong","countryISO":"HK","lat":22.3193,"lon":114.1694,"bbox":[22.16,22.55,113.85,114.43],"timezone":"Asia/Hong_Kong","population":7482000,"elevation":50,"source":{"type":"inherited","from":"HongKong"}},
     {"name":"Abu Dhabi","countryISO":"AE","lat":24.4539,"lon":54.3773,"bbox":[24.195888,24.590696,54.254076,54.841984],"timezone":"Asia/Dubai","elevation":27,"source":{"type":"national-authority","institution":"Umm al-Qura University"}},
     {"name":"Lahore","countryISO":"PK","lat":31.5497,"lon":74.3436,"bbox":[31.25,31.85,74.04,74.5],"timezone":"Asia/Karachi","nameLocal":"لاہور","adminRegion":"Punjab","population":13096000,"elevation":217,"source":{"type":"mawaqit","slug":"masjid-khatim-ul-nabiyyeen-lahore-54000-pakistan"}},

--- a/src/engine.js
+++ b/src/engine.js
@@ -57,6 +57,10 @@ function detectCountry(lat, lon) {
   if (lat >= 25.5 && lat <= 26.5 && lon >= 50.4 && lon <= 50.85) return 'Bahrain'
   if (lat >= 24   && lat <= 26.5 && lon >= 50.5 && lon <= 51.7) return 'Qatar'
   if (lat >= 28.5 && lat <= 30.2 && lon >= 46.5 && lon <= 48.5) return 'Kuwait'
+  // v1.9.2 (#118): Al Buraimi OM is a twin-city border case immediately east
+  // of Al Ain. Keep this Oman guardrail before the broad UAE rectangle so the
+  // Omani city centre does not inherit UAE/Al Ain provenance.
+  if (lat >= 24.22 && lat <= 24.29 && lon >= 55.77 && lon <= 55.84) return 'Oman'
   if (lat >= 22   && lat <= 26.5 && lon >= 51   && lon <= 56.5) return 'UAE'
   if (lat >= 16   && lat <= 26.5 && lon >= 51.7 && lon <= 60)   return 'Oman'
   // v1.7.5: Yemen's western lon tightened from 42 to 42.5 — swallowed

--- a/test/detectLocation.test.js
+++ b/test/detectLocation.test.js
@@ -298,6 +298,27 @@ describe('detectLocation — Mawaqit institutional source', () => {
     }
   })
 
+  it('Al Ain/Al Buraimi seam keeps the Omani twin-city centre out of UAE routing', () => {
+    const alAin = detectLocation(24.2075, 55.7447)
+    expect(alAin.city).not.toBeNull()
+    expect(alAin.city.name).toBe('Al Ain')
+    expect(alAin.city.countryISO).toBe('AE')
+    expect(alAin.country).toBe('UAE')
+    expect(alAin.timezone).toBe('Asia/Dubai')
+    expect(alAin.recommendedMethod).toBe('UmmAlQura')
+
+    const alBuraimi = detectLocation(24.2509, 55.7931)
+    expect(alBuraimi.city).not.toBeNull()
+    expect(alBuraimi.city.name).toBe('Al Buraimi')
+    expect(alBuraimi.city.countryISO).toBe('OM')
+    expect(alBuraimi.country).toBe('Oman')
+    expect(alBuraimi.timezone).toBe('Asia/Muscat')
+    expect(alBuraimi.recommendedMethod).toBe('Kuwait')
+    expect(alBuraimi.methodSource).toBe('country-default')
+    expect(alBuraimi.source.type).toBe('inherited')
+    expect(alBuraimi.source.from).toBe('Oman')
+  })
+
   it('UAE clipped WOF cells expand Sharjah/Ajman eastward without stealing Dubai', () => {
     const rows = [
       ['Sharjah', 25.3463, 55.4209, 25.35, 55.65],

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -142,6 +142,7 @@ describe('city geometry source map', () => {
     expect(statusFor('Oujda|MA')).toBe('runtime-bbox-shipped')
     expect(statusFor('Abu Dhabi|AE')).toBe('runtime-bbox-shipped')
     expect(statusFor('Al Ain|AE')).toBe('runtime-bbox-shipped')
+    expect(statusFor('Al Buraimi|OM')).toBe('runtime-bbox-shipped')
     expect(statusFor('Dubai|AE')).toBe('runtime-bbox-shipped')
     expect(statusFor('Sharjah|AE')).toBe('runtime-bbox-shipped')
     expect(statusFor('Ajman|AE')).toBe('runtime-bbox-shipped')
@@ -172,7 +173,41 @@ describe('city geometry source map', () => {
     expect(statusFor('Kinshasa|CD')).toBe('runtime-bbox-shipped')
   })
 
-  it('marks the WOF row-level source as shipped for direct WOF runtime bboxes', () => {
+  it('documents the Al Buraimi guardrail as WOF-supported but clipped to city centre', () => {
+    const entry = sourceMap.cities.find(row => row.cityKey === 'Al Buraimi|OM')
+    expect(entry).toBeTruthy()
+    expect(entry.review.status).toBe('runtime-bbox-shipped')
+    expect(entry.priority).toContain('al-ain-buraimi-seam')
+    expect(entry.neighborRelations).toEqual([
+      expect.objectContaining({
+        cityKey: 'Al Ain|AE',
+        kind: 'cross-border-twin-city',
+      }),
+    ])
+
+    const locality = entry.geometries.find(row => row.stableId === 'wof:locality:421177367')
+    expect(locality).toMatchObject({
+      provider: 'wof',
+      sourceConfidence: 'low',
+      matchConfidence: 'point-like-runtime-guardrail',
+      reviewStatus: 'runtime-bbox-shipped',
+    })
+    expect(locality.ids).toMatchObject({
+      repo: 'whosonfirst-data-admin-om',
+      placetype: 'locality',
+      mzIsCurrent: -1,
+    })
+
+    const county = entry.geometries.find(row => row.stableId === 'wof:county:421184225')
+    expect(county).toMatchObject({
+      provider: 'wof',
+      sourceConfidence: 'medium',
+      matchConfidence: 'placetype-mismatch-context',
+      reviewStatus: 'candidate',
+    })
+  })
+
+  it('marks the WOF row-level source as shipped for WOF-supported runtime bboxes', () => {
     const clippedRuntimeRows = new Set([
       // Dubai uses a clipped lookup cell from the WOF lead, not the full WOF
       // envelope, so the geometry row remains a candidate by design.


### PR DESCRIPTION
## Summary
- Add an Al Buraimi, Oman city-centre guardrail so the twin-city centre no longer resolves to UAE / Al Ain provenance.
- Clip Al Ain east of the Oman guardrail and keep the generator/source-map/docs aligned.
- Add detectLocation and geometry-source-map regression tests for the Oman/UAE border case.

## Validation
- `npx vitest run test/detectLocation.test.js test/geometrySourceMap.test.js`
- `npm run validate:registry`
- `node scripts/build-city-registry.js --check`
- `npm test`
- `npm run build:charts`
- `node scripts/fetch-city-geometry-cache.js --provider wof --city "Al Buraimi"`
- `node scripts/audit-city-geometry.js --format json`
- `npm pack --dry-run`
- `git diff --check`

Refs #118