### PR TITLE
docs(readme): sync v1.9.2 city count

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![npm version](https://img.shields.io/npm/v/@tawfeeqmartin/fajr.svg)](https://www.npmjs.com/package/@tawfeeqmartin/fajr)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-Last refreshed: 2026-05-14
+Last refreshed: 2026-05-15
 
 `fajr` is an offline JavaScript library for Islamic prayer times, qibla, Hijri dates, and hilal visibility. It builds on [`adhan.js`](https://github.com/batoulapps/adhan-js), then adds:
 
-- GPS-aware method dispatch across 168 countries and 481 city boxes.
+- GPS-aware method dispatch across 168 countries and 488 city boxes.
 - Provenance fields that explain which method, elevation, and Asr convention were used.
 - Per-prayer ihtiyat-aware rounding and an explicit `imsak` field.
 - Three-criterion hilal visibility: Odeh 2004, Yallop 1997, and Shaukat 2002.


### PR DESCRIPTION
## Summary
- updates README refresh date to 2026-05-15
- aligns the headline city-box count with the generated v1.9.2 registry/SCOREBOARD count of 488 cities

## Verification
- git diff --check
- npm test (423/423)

No source, eval, package, or runtime behavior changed.