### PR TITLE
chore(geometry): add Egypt geoBoundaries source rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 
 ## [Unreleased]
 
+### Added — Egypt geoBoundaries source-map candidates
+
+- Added geoBoundaries gbOpen EGY ADM2 source-map rows for the Cairo/Giza/6th
+  of October metro cluster, using CAPMAS/OCHA/HDX metadata under CC BY 3.0 IGO.
+- Extended `scripts/fetch-city-geometry-cache.js` so reviewed geoBoundaries
+  rows can hydrate single-feature local cache files by `shapeID`, matching the
+  existing WOF cache workflow.
+- Kept all Egypt rows source-map-only; no runtime bbox, country/method
+  dispatch, prayer-time math, public API, or npm package data changed.
+
 ## [1.9.2] — 2026-05-15
 
 ### Fixed — Al Buraimi / Al Ain border routing

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -39,8 +39,8 @@ source-map rows, 5 UAE metro rows, 4 Oman/UAE border rows, 10 Turkey large-city
 rows, 1 Hong Kong/Shenzhen border row, 2 Singapore/Johor rows, 4 Klang Valley
 rows, 1 Pakistan overlap row, 1 Detroit/Windsor border row, 3 Geneva border
 rows, 2 Strasbourg/Kehl border rows, 2 Congo River rows, and 3 carry-over
-registry-warning rows. It carries 17 OSM relation rows plus 58 WOF rows and 1
-geoBoundaries row across reviewed locality/county candidates. Morocco rows with
+registry-warning rows. It carries 17 OSM relation rows plus 58 WOF rows and 14
+geoBoundaries rows across reviewed locality/county/admin candidates. Morocco rows with
 WOF-backed runtime status are separated from OSM-only audit candidates;
 Jerusalem intentionally remains without a geometry candidate until a human
 routing decision is available.
@@ -230,6 +230,8 @@ Reference URLs checked in this pass:
   `https://knowledge.base.unocha.org/wiki/spaces/imtoolbox/pages/2557378679/`
 - geoBoundaries API:
   `https://www.geoboundaries.org/api.html`
+- geoBoundaries EGY ADM2 metadata (CAPMAS/OCHA via HDX, CC BY 3.0 IGO):
+  `https://www.geoboundaries.org/api/current/gbOpen/EGY/ADM2/`
 - SIG-Maroc administrative boundaries:
   `https://www.sig-maroc.com/donnees/limites-administratives-maroc`
 - SIG-Maroc RGPH 2024 commune joins:
@@ -302,6 +304,7 @@ With reviewed IDs and cached GeoJSON present:
 ```bash
 node scripts/fetch-city-geometry-cache.js --provider wof --dry-run
 node scripts/fetch-city-geometry-cache.js --provider wof
+node scripts/fetch-city-geometry-cache.js --provider geoboundaries --city Cairo
 node scripts/audit-city-geometry.js
 node scripts/audit-city-geometry.js --format json
 node scripts/audit-city-geometry.js --sources scripts/data/city-geometry-sources.json --cache-dir .cache/city-geometry
@@ -312,10 +315,11 @@ and prints a setup message. If the source map exists but cached GeoJSON is
 absent, the report lists `cache-file-not-found`; that is expected until a
 reviewer fetches raw geometry into `.cache/city-geometry/`.
 
-`fetch-city-geometry-cache.js` currently hydrates WOF candidates only. It uses
-the explicit WOF repository metadata in the source map, writes raw GeoJSON to
-`.cache/city-geometry/`, and leaves OSM/Overture/official fetch paths to
-separate reviewed workflows because their terms and APIs differ.
+`fetch-city-geometry-cache.js` currently hydrates WOF candidates and reviewed
+geoBoundaries source-map rows. WOF uses explicit repository metadata in the
+source map. geoBoundaries uses the provider API, then extracts exactly one
+reviewed `shapeID` into the local cache. OSM/Overture/other official fetch
+paths remain separate reviewed workflows because their terms and APIs differ.
 
 ## First Audit Targets
 
@@ -340,9 +344,10 @@ validator warnings, or known clipping gaps:
   WOF source-map row and no longer shadows Gujranwala's north-east edge.
 - Source-mapped but not runtime-safe yet: Cairo/Giza/6th of October. WOF has a
   real Cairo locality, point-like Giza/New Cairo localities, and split
-  county-level Giza/6th-of-October candidates. These rows are now preserved as
-  source leads, but runtime bboxes should wait for a reviewed clipping design
-  or official Egyptian municipal geometry.
+  county-level Giza/6th-of-October candidates. geoBoundaries gbOpen EGY ADM2
+  now adds CAPMAS/OCHA district geometry for central Cairo, New Cairo, Giza,
+  and 6th-of-October/Sheikh Zayed context under CC BY 3.0 IGO. These rows are
+  source leads only; runtime bboxes should wait for a reviewed clipping design.
 - High-risk metro/border clusters: Cairo/Giza/6th of October,
   Dubai/Sharjah/Ajman, Toronto/Mississauga/Laval/Montreal,
   Lahore/Gujranwala broader coverage, Basra/Ahvaz/Kuwait City,

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -24,6 +24,16 @@
         "Each WOF candidate must store ids.repo so fetch-city-geometry-cache.js can hydrate the local raw-geometry cache deterministically."
       ]
     },
+    "geoboundaries": {
+      "name": "geoBoundaries gbOpen administrative boundary",
+      "stableIdFormat": "geoboundaries:{boundaryId}:{shapeId}",
+      "license": "row-level boundaryLicense / licenseSource metadata",
+      "defaultUse": "audit-and-reviewed-bbox-proposal",
+      "notes": [
+        "Each geoBoundaries candidate must store boundaryId, shapeId, releaseType, and boundaryType so fetch-city-geometry-cache.js can hydrate one reviewed feature into the local raw-geometry cache.",
+        "Check boundarySource and boundaryLicense before deriving any runtime bbox; geoBoundaries republishes multiple source/license families."
+      ]
+    },
     "official": {
       "name": "Official local or national boundary source",
       "stableIdFormat": "provider-specific",
@@ -476,7 +486,8 @@
         "status": "candidate",
         "issue": 118,
         "notes": [
-          "2026-05-15: WOF source-map candidate only. Do not tighten runtime Cairo directly from the WOF locality envelope because the shipped Cairo row intentionally covers the New Cairo/east-Cairo corridor; direct WOF copying would drop existing city provenance."
+          "2026-05-15: WOF source-map candidate only. Do not tighten runtime Cairo directly from the WOF locality envelope because the shipped Cairo row intentionally covers the New Cairo/east-Cairo corridor; direct WOF copying would drop existing city provenance.",
+          "2026-05-15: added geoBoundaries gbOpen EGY ADM2 rows sourced to OCHA ROMENA/HDX and CAPMAS under CC BY 3.0 IGO. These official district rows are source-map-only until a Cairo/Giza/6th clipping design is reviewed."
         ]
       },
       "geometries": [
@@ -501,6 +512,57 @@
           "licenseUse": "audit-and-reviewed-bbox-proposal",
           "reviewStatus": "candidate",
           "notes": ["New Cairo is point-like in WOF and is recorded only as a source lead for the east-Cairo coverage question."]
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B52731964573716",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B52731964573716", "shapeName": "Qasr Al-Nile", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/cairo/geoboundaries-egy-adm2-qasr-al-nile.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["geoBoundaries EGY ADM2 metadata cites OCHA ROMENA/HDX and CAPMAS, CC BY 3.0 IGO. This row anchors central Cairo / Tahrir context."]
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B64528254011318",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B64528254011318", "shapeName": "Nasr City", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/cairo/geoboundaries-egy-adm2-nasr-city.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B99181648743437",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B99181648743437", "shapeName": "New Cairo-1", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/cairo/geoboundaries-egy-adm2-new-cairo-1.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B58056872224952",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B58056872224952", "shapeName": "New Cairo-2", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/cairo/geoboundaries-egy-adm2-new-cairo-2.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B49811870233448",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B49811870233448", "shapeName": "New Cairo-3", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/cairo/geoboundaries-egy-adm2-new-cairo-3.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
         }
       ]
     },
@@ -511,7 +573,8 @@
         "status": "candidate",
         "issue": 118,
         "notes": [
-          "2026-05-15: WOF source-map candidate only. Giza has a point-like WOF locality plus split county candidates; none is safe as a direct runtime replacement for the current clipped Giza row."
+          "2026-05-15: WOF source-map candidate only. Giza has a point-like WOF locality plus split county candidates; none is safe as a direct runtime replacement for the current clipped Giza row.",
+          "2026-05-15: added geoBoundaries gbOpen EGY ADM2 rows sourced to OCHA ROMENA/HDX and CAPMAS under CC BY 3.0 IGO. These official district rows are source-map-only until a Cairo/Giza/6th clipping design is reviewed."
         ]
       },
       "geometries": [
@@ -544,6 +607,56 @@
           "matchConfidence": "placetype-mismatch-candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
           "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B55829024150134",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B55829024150134", "shapeName": "Giza", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/giza/geoboundaries-egy-adm2-giza-1.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B59036266241246",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B59036266241246", "shapeName": "Giza", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/giza/geoboundaries-egy-adm2-giza-2.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B9687639154335",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B9687639154335", "shapeName": "Al-Ahram", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/giza/geoboundaries-egy-adm2-al-ahram.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B56780050438943",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B56780050438943", "shapeName": "Al-Aguza", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/giza/geoboundaries-egy-adm2-al-aguza.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B46347292779018",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B46347292779018", "shapeName": "DuqqI", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/giza/geoboundaries-egy-adm2-duqqi.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
         }
       ]
     },
@@ -554,7 +667,8 @@
         "status": "candidate",
         "issue": 118,
         "notes": [
-          "2026-05-15: WOF county candidate is promising for west/north undercoverage, but the geometry needs manual review before any runtime bbox change because it is county-level and may not contain the current registry center cleanly."
+          "2026-05-15: WOF county candidate is promising for west/north undercoverage, but the geometry needs manual review before any runtime bbox change because it is county-level and may not contain the current registry center cleanly.",
+          "2026-05-15: added geoBoundaries gbOpen EGY ADM2 rows sourced to OCHA ROMENA/HDX and CAPMAS under CC BY 3.0 IGO. These official district rows are source-map-only until a Cairo/Giza/6th clipping design is reviewed."
         ]
       },
       "geometries": [
@@ -567,6 +681,37 @@
           "matchConfidence": "placetype-mismatch-candidate",
           "licenseUse": "audit-and-reviewed-bbox-proposal",
           "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B48784531357995",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B48784531357995", "shapeName": "6 October-1", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/6th-of-october/geoboundaries-egy-adm2-6-october-1.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B57962000824705",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B57962000824705", "shapeName": "6 October-2", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/6th-of-october/geoboundaries-egy-adm2-6-october-2.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:EGY-ADM2-37247803:37247803B86158206640686",
+          "ids": { "boundaryId": "EGY-ADM2-37247803", "shapeId": "37247803B86158206640686", "shapeName": "Shaykh Zayed", "releaseType": "gbOpen", "boundaryType": "ADM2", "boundaryYearRepresented": "2020" },
+          "cacheFile": "EG/6th-of-october/geoboundaries-egy-adm2-shaykh-zayed.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "split-adm2-related-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Related west-Giza/6th-of-October metro geometry lead; not a direct city replacement by itself."]
         }
       ]
     },

--- a/scripts/fetch-city-geometry-cache.js
+++ b/scripts/fetch-city-geometry-cache.js
@@ -10,6 +10,7 @@
  * Usage:
  *   node scripts/fetch-city-geometry-cache.js --provider wof --dry-run
  *   node scripts/fetch-city-geometry-cache.js --provider wof --city Rabat
+ *   node scripts/fetch-city-geometry-cache.js --provider geoboundaries --city Cairo
  *   node scripts/fetch-city-geometry-cache.js --provider wof --format json
  */
 
@@ -17,7 +18,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
+  geoboundariesApiUrl,
   geometryEntries,
+  geoBoundariesFeatureCollection,
+  parseGeoBoundariesStableId,
   safeCachePath,
   wofRawUrl,
 } from './lib/city-geometry-cache.js'
@@ -36,8 +40,8 @@ const format = args.format || 'text'
 const dryRun = Boolean(args.dryRun)
 const overwrite = Boolean(args.overwrite)
 
-if (provider !== 'wof') {
-  console.error('Usage error: only --provider wof is currently supported.')
+if (!['wof', 'geoboundaries'].includes(provider)) {
+  console.error('Usage error: --provider must be wof or geoboundaries.')
   process.exit(2)
 }
 
@@ -45,7 +49,7 @@ const rows = []
 const entries = geometryEntries(sourceMap, { provider, city: args.city })
 for (const { entry, geometry } of entries) {
   const target = safeCachePath(cacheDir, geometry.cacheFile)
-  const url = wofRawUrl(geometry, { branch })
+  const url = sourceUrl(geometry, { branch, provider })
   const row = {
     cityKey: entry.cityKey,
     provider: geometry.provider,
@@ -67,7 +71,9 @@ for (const { entry, geometry } of entries) {
   }
 
   try {
-    const geojson = await fetchGeojson(url)
+    const geojson = provider === 'geoboundaries'
+      ? await fetchGeoBoundariesFeature(geometry)
+      : await fetchGeojson(url)
     fs.mkdirSync(path.dirname(target), { recursive: true })
     fs.writeFileSync(target, `${JSON.stringify(geojson, null, 2)}\n`)
     rows.push({ ...row, status: 'fetched' })
@@ -101,7 +107,30 @@ if (format === 'json') {
 
 if (report.summary.errors) process.exit(1)
 
+function sourceUrl(geometry, { branch, provider }) {
+  if (provider === 'geoboundaries') return geoboundariesApiUrl(geometry)
+  return wofRawUrl(geometry, { branch })
+}
+
+async function fetchGeoBoundariesFeature(geometry) {
+  const parsed = parseGeoBoundariesStableId(geometry.stableId)
+  const metadataUrl = geoboundariesApiUrl(geometry)
+  const metadata = await fetchJson(metadataUrl)
+  const url = metadata.gjDownloadURL || metadata.simplifiedGeometryGeoJSON
+  if (!url) throw new Error(`geoBoundaries metadata lacks GeoJSON download URL: ${metadataUrl}`)
+  const geojson = await fetchGeojson(url)
+  return geoBoundariesFeatureCollection(geojson, geometry.ids?.shapeId || parsed.shapeId)
+}
+
 async function fetchGeojson(url) {
+  const geojson = await fetchJson(url)
+  if (!geojson || typeof geojson !== 'object' || !geojson.type) {
+    throw new Error(`Invalid GeoJSON from ${url}`)
+  }
+  return geojson
+}
+
+async function fetchJson(url) {
   const res = await fetch(url, {
     headers: {
       'User-Agent': 'fajr-city-geometry-cache/1.0 (https://github.com/tawfeeqmartin/fajr/issues/118)',
@@ -109,11 +138,7 @@ async function fetchGeojson(url) {
     },
   })
   if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`)
-  const geojson = await res.json()
-  if (!geojson || typeof geojson !== 'object' || !geojson.type) {
-    throw new Error(`Invalid GeoJSON from ${url}`)
-  }
-  return geojson
+  return res.json()
 }
 
 function parseArgs(argv) {

--- a/scripts/lib/city-geometry-cache.js
+++ b/scripts/lib/city-geometry-cache.js
@@ -33,6 +33,31 @@ export function wofRawUrl(geometry, { branch = 'master' } = {}) {
   return `https://raw.githubusercontent.com/whosonfirst-data/${repo}/${branch}/data/${wofDataPath(wofId)}/${wofId}.geojson`
 }
 
+export function geoboundariesApiUrl(geometry, { version = 'current' } = {}) {
+  const ids = geometry.ids || {}
+  const parsed = parseGeoBoundariesStableId(geometry.stableId)
+  const boundaryId = ids.boundaryId || parsed.boundaryId
+  const match = /^([A-Z]{3})-(ADM\d+)-/.exec(boundaryId)
+  if (!match) throw new Error(`${geometry.stableId || boundaryId}: invalid geoBoundaries boundaryId`)
+  const iso = ids.boundaryISO || ids.boundaryIso || match[1]
+  const boundaryType = ids.boundaryType || match[2]
+  const releaseType = ids.releaseType || 'gbOpen'
+  return `https://www.geoboundaries.org/api/${version}/${releaseType}/${iso}/${boundaryType}/`
+}
+
+export function geoBoundariesFeatureCollection(geojson, shapeId) {
+  if (!shapeId) throw new Error('Missing geoBoundaries shapeId')
+  if (!geojson || geojson.type !== 'FeatureCollection' || !Array.isArray(geojson.features)) {
+    throw new Error('geoBoundaries download must be a FeatureCollection')
+  }
+  const features = geojson.features.filter(feature => feature.properties?.shapeID === shapeId)
+  if (!features.length) throw new Error(`geoBoundaries shapeID not found: ${shapeId}`)
+  return {
+    type: 'FeatureCollection',
+    features,
+  }
+}
+
 export function safeCachePath(cacheDir, cacheFile) {
   if (!cacheFile) throw new Error('Missing cacheFile')
   const root = path.resolve(cacheDir)
@@ -47,6 +72,12 @@ export function parseWofStableId(stableId) {
   const match = /^wof:([a-z]+):(\d+)$/.exec(String(stableId || ''))
   if (!match) throw new Error(`Invalid WOF stableId: ${stableId}`)
   return { placetype: match[1], id: match[2] }
+}
+
+export function parseGeoBoundariesStableId(stableId) {
+  const match = /^geoboundaries:([A-Z]{3}-ADM\d+-\d+):([A-Za-z0-9]+)$/.exec(String(stableId || ''))
+  if (!match) throw new Error(`Invalid geoBoundaries stableId: ${stableId}`)
+  return { boundaryId: match[1], shapeId: match[2] }
 }
 
 function matchesCity(cityKey, filter) {

--- a/test/geometryCacheFetcher.test.js
+++ b/test/geometryCacheFetcher.test.js
@@ -7,7 +7,9 @@ import path from 'node:path'
 import { execFileSync } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  geoboundariesApiUrl,
   geometryEntries,
+  geoBoundariesFeatureCollection,
   safeCachePath,
   wofDataPath,
   wofRawUrl,
@@ -35,6 +37,30 @@ describe('city geometry cache fetch helpers', () => {
       stableId: 'wof:locality:421190103',
       ids: { repo: 'whosonfirst-data-admin-ma' },
     })).toBe('https://raw.githubusercontent.com/whosonfirst-data/whosonfirst-data-admin-ma/master/data/421/190/103/421190103.geojson')
+  })
+
+  it('builds geoBoundaries API URLs from stable boundary metadata', () => {
+    expect(geoboundariesApiUrl({
+      stableId: 'geoboundaries:EGY-ADM2-37247803:37247803B52731964573716',
+      ids: { releaseType: 'gbOpen' },
+    })).toBe('https://www.geoboundaries.org/api/current/gbOpen/EGY/ADM2/')
+  })
+
+  it('extracts one geoBoundaries feature by shapeID', () => {
+    const collection = geoBoundariesFeatureCollection({
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', properties: { shapeID: 'keep' }, geometry: { type: 'Point', coordinates: [1, 2] } },
+        { type: 'Feature', properties: { shapeID: 'skip' }, geometry: { type: 'Point', coordinates: [3, 4] } },
+      ],
+    }, 'keep')
+
+    expect(collection).toEqual({
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', properties: { shapeID: 'keep' }, geometry: { type: 'Point', coordinates: [1, 2] } },
+      ],
+    })
   })
 
   it('filters source-map entries by provider and city', () => {
@@ -75,6 +101,32 @@ describe('city geometry cache fetch helpers', () => {
     expect(report.rows[0].url).toContain('/whosonfirst-data-admin-ma/master/data/421/190/103/421190103.geojson')
     expect(fs.existsSync(cacheDir)).toBe(false)
   })
+
+  it('prints geoBoundaries dry-run JSON without fetching network data', () => {
+    const dir = tempDir()
+    const sourcePath = path.join(dir, 'sources.json')
+    const cacheDir = path.join(dir, 'cache')
+    writeJson(sourcePath, sampleSourceMap())
+
+    const report = JSON.parse(execFileSync(process.execPath, [
+      SCRIPT,
+      '--sources', sourcePath,
+      '--cache-dir', cacheDir,
+      '--provider', 'geoboundaries',
+      '--dry-run',
+      '--format', 'json',
+    ], { cwd: ROOT, encoding: 'utf8' }))
+
+    expect(report.summary).toMatchObject({
+      rows: 1,
+      fetched: 0,
+      skippedExisting: 0,
+      wouldFetch: 1,
+      errors: 0,
+    })
+    expect(report.rows[0].url).toBe('https://www.geoboundaries.org/api/current/gbOpen/EGY/ADM2/')
+    expect(fs.existsSync(cacheDir)).toBe(false)
+  })
 })
 
 function sampleSourceMap() {
@@ -109,6 +161,23 @@ function sampleSourceMap() {
             stableId: 'osm:relation:2801066',
             cacheFile: 'MA/sale/osm-relation-2801066.geojson',
             licenseUse: 'audit-only-until-license-review',
+          },
+        ],
+      },
+      {
+        cityKey: 'Cairo|EG',
+        geometries: [
+          {
+            provider: 'geoboundaries',
+            stableId: 'geoboundaries:EGY-ADM2-37247803:37247803B52731964573716',
+            ids: {
+              boundaryId: 'EGY-ADM2-37247803',
+              shapeId: '37247803B52731964573716',
+              releaseType: 'gbOpen',
+              boundaryType: 'ADM2',
+            },
+            cacheFile: 'EG/cairo/geoboundaries-egy-adm2-qasr-al-nile.geojson',
+            licenseUse: 'audit-and-reviewed-bbox-proposal',
           },
         ],
       },

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -50,6 +50,14 @@ describe('city geometry source map', () => {
             expect(geometry.matchConfidence).toContain('placetype-mismatch')
           }
         }
+        if (geometry.provider === 'geoboundaries') {
+          expect(geometry.stableId).toMatch(/^geoboundaries:[A-Z]{3}-ADM\d+-\d+:[A-Za-z0-9]+$/)
+          expect(geometry.ids?.boundaryId, geometry.stableId).toMatch(/^[A-Z]{3}-ADM\d+-\d+$/)
+          expect(geometry.ids?.shapeId, geometry.stableId).toBeTruthy()
+          expect(geometry.ids?.releaseType, geometry.stableId).toBeTruthy()
+          expect(geometry.ids?.boundaryType, geometry.stableId).toMatch(/^ADM\d+$/)
+          expect(geometry.licenseUse).toBe('audit-and-reviewed-bbox-proposal')
+        }
       }
     }
   })
@@ -301,9 +309,31 @@ describe('city geometry source map', () => {
 
   it('keeps Egypt metro geometry as source-map-only until clipping is reviewed', () => {
     const expected = new Map([
-      ['Cairo|EG', ['wof:locality:421174399', 'wof:locality:421175733']],
-      ['Giza|EG', ['wof:locality:421204393', 'wof:county:1092021173', 'wof:county:1092021203']],
-      ['6th of October|EG', ['wof:county:1092014009']],
+      ['Cairo|EG', [
+        'wof:locality:421174399',
+        'wof:locality:421175733',
+        'geoboundaries:EGY-ADM2-37247803:37247803B52731964573716',
+        'geoboundaries:EGY-ADM2-37247803:37247803B64528254011318',
+        'geoboundaries:EGY-ADM2-37247803:37247803B99181648743437',
+        'geoboundaries:EGY-ADM2-37247803:37247803B58056872224952',
+        'geoboundaries:EGY-ADM2-37247803:37247803B49811870233448',
+      ]],
+      ['Giza|EG', [
+        'wof:locality:421204393',
+        'wof:county:1092021173',
+        'wof:county:1092021203',
+        'geoboundaries:EGY-ADM2-37247803:37247803B55829024150134',
+        'geoboundaries:EGY-ADM2-37247803:37247803B59036266241246',
+        'geoboundaries:EGY-ADM2-37247803:37247803B9687639154335',
+        'geoboundaries:EGY-ADM2-37247803:37247803B56780050438943',
+        'geoboundaries:EGY-ADM2-37247803:37247803B46347292779018',
+      ]],
+      ['6th of October|EG', [
+        'wof:county:1092014009',
+        'geoboundaries:EGY-ADM2-37247803:37247803B48784531357995',
+        'geoboundaries:EGY-ADM2-37247803:37247803B57962000824705',
+        'geoboundaries:EGY-ADM2-37247803:37247803B86158206640686',
+      ]],
     ])
 
     for (const [cityKey, stableIds] of expected) {
@@ -317,6 +347,19 @@ describe('city geometry source map', () => {
         const geometry = entry.geometries.find(row => row.stableId === stableId)
         expect(geometry, `${cityKey} ${stableId}`).toBeTruthy()
         expect(geometry.reviewStatus, `${cityKey} ${stableId}`).toBe('candidate')
+      }
+
+      const officialRows = entry.geometries.filter(row => row.provider === 'geoboundaries')
+      expect(officialRows.length, cityKey).toBeGreaterThan(0)
+      for (const row of officialRows) {
+        expect(row.sourceConfidence, `${cityKey} ${row.stableId}`).toBe('high')
+        expect(row.matchConfidence, `${cityKey} ${row.stableId}`).toContain('adm2')
+        expect(row.ids).toMatchObject({
+          boundaryId: 'EGY-ADM2-37247803',
+          releaseType: 'gbOpen',
+          boundaryType: 'ADM2',
+          boundaryYearRepresented: '2020',
+        })
       }
     }
   })


### PR DESCRIPTION
## Summary
- adds geoBoundaries gbOpen EGY ADM2 metadata rows for Cairo, Giza, and 6th of October source-map review
- extends the geometry cache hydrator to fetch reviewed geoBoundaries rows and extract a single cached feature by shapeID
- documents that Egypt remains source-map-only pending a reviewed clipping design; no runtime bbox or prayer-time behavior changes

## Source / licensing note
- geoBoundaries EGY ADM2 metadata reports OCHA ROMENA/HDX + CAPMAS and CC BY 3.0 IGO for the layer.
- Raw GeoJSON remains local-only under .cache/city-geometry and is not committed or bundled.

## Verification
- jq empty scripts/data/city-geometry-sources.json
- npx vitest run test/geometryCacheFetcher.test.js test/geometrySourceMap.test.js (21/21)
- npm test (426/426)
- npm run validate:registry (0 fail-class issues)
- node scripts/build-city-registry.js --check
- node scripts/fetch-city-geometry-cache.js --provider geoboundaries --city Cairo --format json (5 fetched)
- node scripts/fetch-city-geometry-cache.js --provider geoboundaries --city Giza --format json (5 fetched)
- node scripts/fetch-city-geometry-cache.js --provider geoboundaries --city "6th of October" --format json (3 fetched)
- node scripts/audit-city-geometry.js --format json (56 source-map cities, 90 rows, 89 checked, 0 missing cache files, 1 intentional no-geometry row)
- npm pack --dry-run (147.6 kB packed / 541.5 kB unpacked)
- git diff --check

Refs #118

[positions: no-change-required] geometry cache/source-map plumbing only; no docs/positions.md regional default, confidence grade, method dispatch, city registry, eval, or prayer-time behavior changes.
