### PR TITLE
chore(geometry): add Canada metro source rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Kept all Egypt rows source-map-only; no runtime bbox, country/method
   dispatch, prayer-time math, public API, or npm package data changed.
 
+### Added — Canada metro geometry source-map candidates
+
+- Added audit-only WOF source-map candidates for Toronto, Mississauga,
+  Montreal, and Laval so the Canada metro seam can be reviewed without changing
+  runtime city bboxes.
+- Preserved WOF locality rows where available and Statistics Canada-derived WOF
+  county/context rows for Toronto, Montreal, and Laval.
+
 ## [1.9.2] — 2026-05-15
 
 ### Fixed — Al Buraimi / Al Ain border routing

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -34,12 +34,13 @@ human review. It must not mutate the runtime registry automatically.
 
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
-56 high-priority rows: 15 Morocco/Habous phase-1 rows, 3 Egypt metro
+60 high-priority rows: 15 Morocco/Habous phase-1 rows, 3 Egypt metro
 source-map rows, 5 UAE metro rows, 4 Oman/UAE border rows, 10 Turkey large-city
 rows, 1 Hong Kong/Shenzhen border row, 2 Singapore/Johor rows, 4 Klang Valley
-rows, 1 Pakistan overlap row, 1 Detroit/Windsor border row, 3 Geneva border
-rows, 2 Strasbourg/Kehl border rows, 2 Congo River rows, and 3 carry-over
-registry-warning rows. It carries 17 OSM relation rows plus 58 WOF rows and 14
+rows, 1 Pakistan overlap row, 4 Toronto/Montreal Canada metro rows,
+1 Detroit/Windsor border row, 3 Geneva border rows, 2 Strasbourg/Kehl border
+rows, 2 Congo River rows, and 3 carry-over registry-warning rows. It carries
+17 OSM relation rows plus 64 WOF rows and 14
 geoBoundaries rows across reviewed locality/county/admin candidates. Morocco rows with
 WOF-backed runtime status are separated from OSM-only audit candidates;
 Jerusalem intentionally remains without a geometry candidate until a human
@@ -342,6 +343,11 @@ validator warnings, or known clipping gaps:
   rows, preserving Malaysia/JAKIM provenance at city level.
 - Resolved high-risk overlap: Sialkot/Gujranwala. Sialkot now has a reviewed
   WOF source-map row and no longer shadows Gujranwala's north-east edge.
+- Source-mapped but not runtime-safe yet: Toronto/Mississauga and
+  Montreal/Laval. WOF has current locality rows for Toronto, Mississauga, and
+  Laval, plus Statistics Canada-derived county/context rows for Toronto,
+  Montreal, and Laval. These rows are preserved as source leads; runtime bboxes
+  should wait for paired metro-seam clipping review.
 - Source-mapped but not runtime-safe yet: Cairo/Giza/6th of October. WOF has a
   real Cairo locality, point-like Giza/New Cairo localities, and split
   county-level Giza/6th-of-October candidates. geoBoundaries gbOpen EGY ADM2
@@ -349,8 +355,7 @@ validator warnings, or known clipping gaps:
   and 6th-of-October/Sheikh Zayed context under CC BY 3.0 IGO. These rows are
   source leads only; runtime bboxes should wait for a reviewed clipping design.
 - High-risk metro/border clusters: Cairo/Giza/6th of October,
-  Dubai/Sharjah/Ajman, Toronto/Mississauga/Laval/Montreal,
-  Lahore/Gujranwala broader coverage, Basra/Ahvaz/Kuwait City,
+  Dubai/Sharjah/Ajman, Lahore/Gujranwala broader coverage, Basra/Ahvaz/Kuwait City,
   Damascus/Homs/Gaziantep.
 - Large heuristic bboxes such as Karachi, Istanbul, Jakarta, Bangalore, Dhaka,
   Tokyo, Seoul, Moscow, Melbourne, Sydney, Shanghai, Lagos, London, New York.

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1396,6 +1396,133 @@
       ]
     },
     {
+      "cityKey": "Toronto|CA",
+      "priority": ["canada-metro", "toronto-mississauga", "source-map-only", "americas-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Toronto and Mississauga already have hand-clipped runtime boxes; record reviewed WOF locality/county context before proposing any bbox changes."
+        ]
+      },
+      "neighborRelations": [
+        { "cityKey": "Mississauga|CA", "kind": "same-metro-neighbor", "status": "Runtime boxes are already hand-clipped; source-map rows preserve evidence for later review." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101735835",
+          "ids": { "wofId": 101735835, "repo": "whosonfirst-data-admin-ca", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "CA/toronto/wof-locality-101735835.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:890457465",
+          "ids": { "wofId": 890457465, "repo": "whosonfirst-data-admin-ca", "placetype": "county", "srcGeom": "statcan", "mzIsCurrent": 1 },
+          "cacheFile": "CA/toronto/wof-county-890457465.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Statistics Canada-derived county/context row; not a direct city-locality replacement."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Mississauga|CA",
+      "priority": ["canada-metro", "toronto-mississauga", "source-map-only", "americas-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Mississauga sits inside the Toronto metro seam and needs a paired clipping review before any runtime bbox change."
+        ]
+      },
+      "neighborRelations": [
+        { "cityKey": "Toronto|CA", "kind": "same-metro-neighbor", "status": "Runtime boxes are already hand-clipped; source-map rows preserve evidence for later review." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101735893",
+          "ids": { "wofId": 101735893, "repo": "whosonfirst-data-admin-ca", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "CA/mississauga/wof-locality-101735893.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Montreal|CA",
+      "priority": ["canada-metro", "montreal-laval", "source-map-only", "americas-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. WOF search surfaced a current Statistics Canada-derived county row for Montreal; keep it as context until a locality/official municipal source is reviewed."
+        ]
+      },
+      "neighborRelations": [
+        { "cityKey": "Laval|CA", "kind": "same-metro-neighbor", "status": "Runtime boxes are already hand-clipped; source-map rows preserve evidence for later review." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:county:890458661",
+          "ids": { "wofId": 890458661, "repo": "whosonfirst-data-admin-ca", "placetype": "county", "srcGeom": "statcan", "mzIsCurrent": 1 },
+          "cacheFile": "CA/montreal/wof-county-890458661.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Statistics Canada-derived county/context row; not a direct city-locality replacement."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Laval|CA",
+      "priority": ["canada-metro", "montreal-laval", "source-map-only", "americas-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Laval sits inside the Montreal metro seam and needs a paired clipping review before any runtime bbox change."
+        ]
+      },
+      "neighborRelations": [
+        { "cityKey": "Montreal|CA", "kind": "same-metro-neighbor", "status": "Runtime boxes are already hand-clipped; source-map rows preserve evidence for later review." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:101737759",
+          "ids": { "wofId": 101737759, "repo": "whosonfirst-data-admin-ca", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
+          "cacheFile": "CA/laval/wof-locality-101737759.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:890457693",
+          "ids": { "wofId": 890457693, "repo": "whosonfirst-data-admin-ca", "placetype": "county", "srcGeom": "statcan", "mzIsCurrent": 1 },
+          "cacheFile": "CA/laval/wof-county-890457693.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Statistics Canada-derived county/context row; not a direct city-locality replacement."]
+        }
+      ]
+    },
+    {
       "cityKey": "Geneva|CH",
       "priority": ["geneva-border", "wof-locality-runtime-bbox", "europe-p0"],
       "review": {

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -112,6 +112,9 @@ describe('city geometry source map', () => {
       ['Petaling Jaya|MY', 'wof:locality:102023395'],
       ['Kuala Lumpur|MY', 'wof:locality:102023407'],
       ['Sialkot|PK', 'wof:locality:421175525'],
+      ['Toronto|CA', 'wof:locality:101735835'],
+      ['Mississauga|CA', 'wof:locality:101735893'],
+      ['Laval|CA', 'wof:locality:101737759'],
       ['Windsor|CA', 'wof:locality:101735855'],
       ['Geneva|CH', 'wof:locality:101748445'],
       ['Annemasse|FR', 'wof:locality:101757307'],
@@ -360,6 +363,29 @@ describe('city geometry source map', () => {
           boundaryType: 'ADM2',
           boundaryYearRepresented: '2020',
         })
+      }
+    }
+  })
+
+  it('keeps Canada metro geometry as source-map-only until seams are reviewed', () => {
+    const expected = new Map([
+      ['Toronto|CA', ['wof:locality:101735835', 'wof:county:890457465']],
+      ['Mississauga|CA', ['wof:locality:101735893']],
+      ['Montreal|CA', ['wof:county:890458661']],
+      ['Laval|CA', ['wof:locality:101737759', 'wof:county:890457693']],
+    ])
+
+    for (const [cityKey, stableIds] of expected) {
+      const entry = sourceMap.cities.find(row => row.cityKey === cityKey)
+      expect(entry, cityKey).toBeTruthy()
+      expect(entry.review.status, cityKey).toBe('candidate')
+      expect(entry.priority, cityKey).toContain('canada-metro')
+      expect(entry.priority, cityKey).toContain('source-map-only')
+
+      for (const stableId of stableIds) {
+        const geometry = entry.geometries.find(row => row.stableId === stableId)
+        expect(geometry, `${cityKey} ${stableId}`).toBeTruthy()
+        expect(geometry.reviewStatus, `${cityKey} ${stableId}`).toBe('candidate')
       }
     }
   })


### PR DESCRIPTION
## Summary
- adds source-map-only WOF candidates for Toronto, Mississauga, Montreal, and Laval
- preserves current WOF locality rows where available and Statistics Canada-derived WOF county/context rows for Toronto, Montreal, and Laval
- documents that Canada metro seams remain candidate-only pending a paired clipping review

## Runtime impact
- No runtime bbox changes.
- No city registry, country/method dispatch, public API, package data, or prayer-time behavior changes.

[positions: no-change-required] source-map metadata only; no regional default, confidence grade, method dispatch, city registry, eval, or prayer-time behavior changes.

## Verification
- jq empty scripts/data/city-geometry-sources.json
- npx vitest run test/geometrySourceMap.test.js (14/14)
- npm test (427/427)
- npm run validate:registry (0 fail-class issues)
- node scripts/fetch-city-geometry-cache.js --provider wof --city Toronto --format json (2 fetched)
- node scripts/fetch-city-geometry-cache.js --provider wof --city Mississauga --format json (1 fetched)
- node scripts/fetch-city-geometry-cache.js --provider wof --city Montreal --format json (1 fetched)
- node scripts/fetch-city-geometry-cache.js --provider wof --city Laval --format json (2 fetched)
- node scripts/audit-city-geometry.js --format json (60 source-map cities, 96 rows, 95 checked, 0 missing cache files, 1 intentional no-geometry row)
- npm pack --dry-run (147.6 kB packed / 541.5 kB unpacked)
- git diff --check

Refs #118