### PR TITLE
chore(geometry): add Detroit Dearborn source rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Preserved WOF locality rows where available and Statistics Canada-derived WOF
   county/context rows for Toronto, Montreal, and Laval.
 
+### Added — Detroit/Dearborn geometry source-map candidates
+
+- Added audit-only US Census-backed WOF locality/localadmin candidates for
+  Detroit and Dearborn, completing the source-map evidence around the already
+  shipped Windsor river-seam guardrail.
+- Kept the rows source-map-only; no runtime bbox, country/method dispatch,
+  city-institutional override, public API, package data, or prayer-time
+  behavior changed.
+
 ## [1.9.2] — 2026-05-15
 
 ### Fixed — Al Buraimi / Al Ain border routing

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -34,13 +34,13 @@ human review. It must not mutate the runtime registry automatically.
 
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
-60 high-priority rows: 15 Morocco/Habous phase-1 rows, 3 Egypt metro
+62 high-priority rows: 15 Morocco/Habous phase-1 rows, 3 Egypt metro
 source-map rows, 5 UAE metro rows, 4 Oman/UAE border rows, 10 Turkey large-city
 rows, 1 Hong Kong/Shenzhen border row, 2 Singapore/Johor rows, 4 Klang Valley
 rows, 1 Pakistan overlap row, 4 Toronto/Montreal Canada metro rows,
-1 Detroit/Windsor border row, 3 Geneva border rows, 2 Strasbourg/Kehl border
+3 Detroit/Dearborn/Windsor border rows, 3 Geneva border rows, 2 Strasbourg/Kehl border
 rows, 2 Congo River rows, and 3 carry-over registry-warning rows. It carries
-17 OSM relation rows plus 64 WOF rows and 14
+17 OSM relation rows plus 68 WOF rows and 14
 geoBoundaries rows across reviewed locality/county/admin candidates. Morocco rows with
 WOF-backed runtime status are separated from OSM-only audit candidates;
 Jerusalem intentionally remains without a geometry candidate until a human
@@ -157,6 +157,9 @@ The Detroit/Windsor border seam needs clipping rather than direct WOF copying:
   envelope crosses the Detroit River into Detroit/Dearborn. The runtime cell is
   clipped at the river seam while Detroit and Dearborn are clipped north of the
   same seam.
+- Detroit and Dearborn now have US Census-backed WOF locality/localadmin rows
+  preserved as source-map-only candidates. They document the evidence around
+  the shipped seam but do not replace the current hand-clipped runtime cells.
 
 The Geneva/French-border seam is cleaner with WOF locality rows:
 

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1396,6 +1396,84 @@
       ]
     },
     {
+      "cityKey": "Detroit|US",
+      "priority": ["detroit-windsor-border", "detroit-dearborn", "source-map-only", "americas-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Detroit is already hand-clipped against Windsor and Dearborn at runtime; preserve US Census-backed WOF evidence before any future paired bbox review."
+        ]
+      },
+      "neighborRelations": [
+        { "cityKey": "Windsor|CA", "kind": "runtime-edge-touch", "status": "Windsor runtime bbox clips north to 42.3199; Detroit starts at lat 42.32." },
+        { "cityKey": "Dearborn|US", "kind": "runtime-edge-touch", "status": "Detroit and Dearborn runtime boxes touch at lon -83.08 without area overlap." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:85951091",
+          "ids": { "wofId": 85951091, "repo": "whosonfirst-data-admin-us", "placetype": "locality", "srcGeom": "uscensus", "mzIsCurrent": 1 },
+          "cacheFile": "US/detroit/wof-locality-85951091.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["US Census-backed WOF locality row. The current runtime bbox is an intentionally clipped lookup cell, not this full envelope."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:localadmin:404506393",
+          "ids": { "wofId": 404506393, "repo": "whosonfirst-data-admin-us", "placetype": "localadmin", "srcGeom": "uscensus", "mzIsCurrent": 1 },
+          "cacheFile": "US/detroit/wof-localadmin-404506393.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["US Census-backed WOF localadmin row with the same reviewed envelope as the locality row; context only, not a direct locality replacement."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Dearborn|US",
+      "priority": ["detroit-windsor-border", "detroit-dearborn", "source-map-only", "americas-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Dearborn has a city-institutional method override, so keep geometry provenance explicit before any future bbox clipping review."
+        ]
+      },
+      "neighborRelations": [
+        { "cityKey": "Windsor|CA", "kind": "runtime-separated", "status": "Windsor runtime bbox clips north to 42.3199; Dearborn starts at lat 42.32." },
+        { "cityKey": "Detroit|US", "kind": "runtime-edge-touch", "status": "Dearborn and Detroit runtime boxes touch at lon -83.08 without area overlap." }
+      ],
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:85951061",
+          "ids": { "wofId": 85951061, "repo": "whosonfirst-data-admin-us", "placetype": "locality", "srcGeom": "uscensus", "mzIsCurrent": 1 },
+          "cacheFile": "US/dearborn/wof-locality-85951061.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["US Census-backed WOF locality row. Runtime remains a hand-clipped guardrail around the city-institutional Dearborn lookup cell."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:localadmin:404508577",
+          "ids": { "wofId": 404508577, "repo": "whosonfirst-data-admin-us", "placetype": "localadmin", "srcGeom": "uscensus", "mzIsCurrent": 1 },
+          "cacheFile": "US/dearborn/wof-localadmin-404508577.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["US Census-backed WOF localadmin row with the same reviewed envelope as the locality row; context only, not a direct locality replacement."]
+        }
+      ]
+    },
+    {
       "cityKey": "Toronto|CA",
       "priority": ["canada-metro", "toronto-mississauga", "source-map-only", "americas-p0"],
       "review": {

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -116,6 +116,8 @@ describe('city geometry source map', () => {
       ['Mississauga|CA', 'wof:locality:101735893'],
       ['Laval|CA', 'wof:locality:101737759'],
       ['Windsor|CA', 'wof:locality:101735855'],
+      ['Detroit|US', 'wof:locality:85951091'],
+      ['Dearborn|US', 'wof:locality:85951061'],
       ['Geneva|CH', 'wof:locality:101748445'],
       ['Annemasse|FR', 'wof:locality:101757307'],
       ['Ferney-Voltaire|FR', 'wof:locality:101753277'],
@@ -385,6 +387,30 @@ describe('city geometry source map', () => {
       for (const stableId of stableIds) {
         const geometry = entry.geometries.find(row => row.stableId === stableId)
         expect(geometry, `${cityKey} ${stableId}`).toBeTruthy()
+        expect(geometry.reviewStatus, `${cityKey} ${stableId}`).toBe('candidate')
+      }
+    }
+  })
+
+  it('keeps Detroit/Dearborn geometry source-map-only around the shipped Windsor seam', () => {
+    const expected = new Map([
+      ['Detroit|US', ['wof:locality:85951091', 'wof:localadmin:404506393']],
+      ['Dearborn|US', ['wof:locality:85951061', 'wof:localadmin:404508577']],
+    ])
+
+    for (const [cityKey, stableIds] of expected) {
+      const entry = sourceMap.cities.find(row => row.cityKey === cityKey)
+      expect(entry, cityKey).toBeTruthy()
+      expect(entry.review.status, cityKey).toBe('candidate')
+      expect(entry.priority, cityKey).toContain('detroit-windsor-border')
+      expect(entry.priority, cityKey).toContain('source-map-only')
+
+      for (const stableId of stableIds) {
+        const geometry = entry.geometries.find(row => row.stableId === stableId)
+        expect(geometry, `${cityKey} ${stableId}`).toBeTruthy()
+        expect(geometry.ids.repo, `${cityKey} ${stableId}`).toBe('whosonfirst-data-admin-us')
+        expect(geometry.ids.srcGeom, `${cityKey} ${stableId}`).toBe('uscensus')
+        expect(geometry.ids.mzIsCurrent, `${cityKey} ${stableId}`).toBe(1)
         expect(geometry.reviewStatus, `${cityKey} ${stableId}`).toBe('candidate')
       }
     }


### PR DESCRIPTION
## Summary
- add source-map-only WOF rows for Detroit and Dearborn around the already-shipped Windsor river-seam guardrail
- preserve both US Census-backed WOF locality and localadmin context rows for each city
- update the geometry audit doc, source-map tests, and changelog

Refs #118

## Audit facts
- Detroit WOF rows: `wof:locality:85951091`, `wof:localadmin:404506393` (`srcGeom: uscensus`)
- Dearborn WOF rows: `wof:locality:85951061`, `wof:localadmin:404508577` (`srcGeom: uscensus`)
- Local geometry audit now reports 62 source-map cities, 100 reported source rows, 99 checked, 0 missing cache files, and 1 intentional no-geometry row
- Detroit/Dearborn both audit as `undercoverage-review`, which is useful future evidence but not enough to change runtime routing in this PR

## Verification
- `jq empty scripts/data/city-geometry-sources.json`
- `node scripts/fetch-city-geometry-cache.js --provider wof --city Detroit`
- `node scripts/fetch-city-geometry-cache.js --provider wof --city Dearborn`
- `npx vitest run test/geometrySourceMap.test.js` (15/15)
- `npm run validate:registry` (0 fail-class issues)
- `node scripts/build-city-registry.js --check`
- `node scripts/audit-city-geometry.js --format json` (62 source-map cities, 100 rows, 99 checked, 0 missing cache files)
- `npm test` (22 files, 428 tests passed)
- `npm pack --dry-run` (147.7 kB packed / 541.9 kB unpacked)
- `git diff --check`

## Non-goals
- No runtime bbox change
- No country/method dispatch change
- No city-institutional Dearborn override change
- No public API/package data/prayer-time behavior change