### PR TITLE
chore(geometry): fix Windsor source provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
   city-institutional override, public API, package data, or prayer-time
   behavior changed.
 
+### Fixed — Windsor geometry source-map provenance
+
+- Corrected the `Windsor|CA` WOF source-map row to record the raw WOF
+  `src:geom` value as `quattroshapes`.
+- Added a source-map test so the Windsor row stays aligned with the raw WOF
+  provenance while retaining its `runtime-bbox-shipped` status.
+
 ## [1.9.2] — 2026-05-15
 
 ### Fixed — Al Buraimi / Al Ain border routing

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1385,7 +1385,7 @@
         {
           "provider": "wof",
           "stableId": "wof:locality:101735855",
-          "ids": { "wofId": 101735855, "repo": "whosonfirst-data-admin-ca", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "ids": { "wofId": 101735855, "repo": "whosonfirst-data-admin-ca", "placetype": "locality", "srcGeom": "quattroshapes", "mzIsCurrent": 1 },
           "cacheFile": "CA/windsor/wof-locality-101735855.geojson",
           "sourceConfidence": "high",
           "matchConfidence": "candidate",

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -392,6 +392,19 @@ describe('city geometry source map', () => {
     }
   })
 
+  it('keeps Windsor source provenance aligned with the raw WOF record', () => {
+    const entry = sourceMap.cities.find(row => row.cityKey === 'Windsor|CA')
+    const geometry = entry?.geometries?.find(row => row.stableId === 'wof:locality:101735855')
+    expect(geometry).toBeTruthy()
+    expect(geometry.ids).toMatchObject({
+      repo: 'whosonfirst-data-admin-ca',
+      placetype: 'locality',
+      srcGeom: 'quattroshapes',
+      mzIsCurrent: 1,
+    })
+    expect(geometry.reviewStatus).toBe('runtime-bbox-shipped')
+  })
+
   it('keeps Detroit/Dearborn geometry source-map-only around the shipped Windsor seam', () => {
     const expected = new Map([
       ['Detroit|US', ['wof:locality:85951091', 'wof:localadmin:404506393']],


### PR DESCRIPTION
## Summary
- correct the Windsor WOF source-map row from `srcGeom: whosonfirst` to `srcGeom: quattroshapes`, matching the raw WOF record
- add a source-map assertion so the Windsor row keeps the raw-WOF provenance while remaining `runtime-bbox-shipped`
- document the metadata-only correction in CHANGELOG.md

Refs #118

## Verification
- raw WOF record `wof:locality:101735855` reports `src:geom = quattroshapes`
- local cached WOF record reports `src:geom = quattroshapes`
- `jq empty scripts/data/city-geometry-sources.json`
- `npx vitest run test/geometrySourceMap.test.js` (16/16)
- `npm run validate:registry` (0 fail-class issues)
- `npm test` (22 files, 429 tests passed)
- `git diff --check`

## Notes
- Metadata only: no runtime bbox, package data, public API, country/method dispatch, or prayer-time behavior changes.