### PR TITLE
chore(geometry): add South Asia source rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,17 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Added a source-map test so the Windsor row stays aligned with the raw WOF
   provenance while retaining its `runtime-bbox-shipped` status.
 
+### Added — South Asia large-city geometry source-map candidates
+
+- Added source-map-only geometry rows for broad South Asia heuristic city boxes:
+  Karachi, Hyderabad PK, Mumbai, Ahmedabad, Bangalore, Chennai, Hyderabad IN,
+  and Dhaka.
+- Preserved current WOF locality rows where available, WOF county/context rows
+  where useful, and geoBoundaries BGD ADM2 Dhaka district context as
+  official/permissive district evidence.
+- Kept all rows source-map-only; no runtime bbox, country/method dispatch,
+  public API, package data, or prayer-time behavior changed.
+
 ## [1.9.2] — 2026-05-15
 
 ### Fixed — Al Buraimi / Al Ain border routing

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -34,13 +34,14 @@ human review. It must not mutate the runtime registry automatically.
 
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
-62 high-priority rows: 15 Morocco/Habous phase-1 rows, 3 Egypt metro
+70 high-priority rows: 15 Morocco/Habous phase-1 rows, 3 Egypt metro
 source-map rows, 5 UAE metro rows, 4 Oman/UAE border rows, 10 Turkey large-city
 rows, 1 Hong Kong/Shenzhen border row, 2 Singapore/Johor rows, 4 Klang Valley
-rows, 1 Pakistan overlap row, 4 Toronto/Montreal Canada metro rows,
+rows, 1 Pakistan overlap row, 8 South Asia large-city source-map rows,
+4 Toronto/Montreal Canada metro rows,
 3 Detroit/Dearborn/Windsor border rows, 3 Geneva border rows, 2 Strasbourg/Kehl border
 rows, 2 Congo River rows, and 3 carry-over registry-warning rows. It carries
-17 OSM relation rows plus 68 WOF rows and 14
+17 OSM relation rows plus 81 WOF rows and 15
 geoBoundaries rows across reviewed locality/county/admin candidates. Morocco rows with
 WOF-backed runtime status are separated from OSM-only audit candidates;
 Jerusalem intentionally remains without a geometry candidate until a human
@@ -150,6 +151,18 @@ The first Turkey pass is cleaner:
   and Eskisehir use superseding rows marked `mz:is_current = -1`, Kayseri is
   point-like, and Mersin did not surface a clean city locality row in the WOF
   scan.
+
+The South Asia large-city pass is source-map-only:
+
+- Karachi, Hyderabad PK, Mumbai, Ahmedabad, Bangalore, Chennai, Hyderabad IN,
+  and Dhaka have current WOF locality rows. Several also have county/context
+  rows.
+- Dhaka also keeps geoBoundaries BGD ADM2 Dhaka district context because the
+  official district layer is useful evidence but not a municipal city polygon.
+- These rows are not runtime-safe yet: the current registry cells are broad
+  heuristic boxes, and tightening them needs paired neighbor review for dense
+  metros such as Karachi/Sindh, Mumbai/Navi Mumbai/Thane, Bangalore/Bengaluru
+  metro, and Dhaka district/city boundaries.
 
 The Detroit/Windsor border seam needs clipping rather than direct WOF copying:
 

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1370,6 +1370,266 @@
       ]
     },
     {
+      "cityKey": "Karachi|PK",
+      "priority": ["south-asia-mega-city", "heuristic-bbox", "source-map-only", "apac-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Karachi has a broad population-radius runtime box; use reviewed locality/county evidence before any paired Sindh metro clipping."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421191101",
+          "ids": { "wofId": 421191101, "repo": "whosonfirst-data-admin-pk", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "PK/karachi/wof-locality-421191101.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:1108692233",
+          "ids": { "wofId": 1108692233, "repo": "whosonfirst-data-admin-pk", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "PK/karachi/wof-county-1108692233.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["County/context row only; not a direct replacement for the Karachi city lookup cell."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Hyderabad|PK",
+      "priority": ["south-asia-city", "pakistan-sindh", "heuristic-bbox", "source-map-only"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Hyderabad PK uses a broad heuristic runtime box and should be reviewed with Karachi/Sindh neighbors before any bbox change."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421168813",
+          "ids": { "wofId": 421168813, "repo": "whosonfirst-data-admin-pk", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "PK/hyderabad/wof-locality-421168813.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Mumbai|IN",
+      "priority": ["south-asia-mega-city", "heuristic-bbox", "source-map-only", "apac-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Mumbai's runtime box is a broad metro heuristic and should be reviewed with Navi Mumbai/Thane context before any bbox change."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:102030609",
+          "ids": { "wofId": 102030609, "repo": "whosonfirst-data-admin-in", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "IN/mumbai/wof-locality-102030609.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:890509223",
+          "ids": { "wofId": 890509223, "repo": "whosonfirst-data-admin-in", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "IN/mumbai/wof-county-890509223.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["County/context row only; not a direct replacement for the Mumbai city lookup cell."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Ahmedabad|IN",
+      "priority": ["south-asia-mega-city", "heuristic-bbox", "source-map-only", "apac-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Ahmedabad uses a broad heuristic runtime box and is also close to the Pakistan country-bbox guardrail documented in engine comments."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:102031017",
+          "ids": { "wofId": 102031017, "repo": "whosonfirst-data-admin-in", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "IN/ahmedabad/wof-locality-102031017.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        }
+      ]
+    },
+    {
+      "cityKey": "Bangalore|IN",
+      "priority": ["south-asia-mega-city", "heuristic-bbox", "source-map-only", "apac-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Bangalore has a broad runtime box and should be reviewed with Bengaluru metro/county context before any bbox tightening."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:102030819",
+          "ids": { "wofId": 102030819, "repo": "whosonfirst-data-admin-in", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "IN/bangalore/wof-locality-102030819.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:890511315",
+          "ids": { "wofId": 890511315, "repo": "whosonfirst-data-admin-in", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "IN/bangalore/wof-county-890511315.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["County/context row only; not a direct replacement for the Bangalore city lookup cell."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Chennai|IN",
+      "priority": ["south-asia-mega-city", "heuristic-bbox", "source-map-only", "apac-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Chennai has a broad runtime box; WOF locality/county rows agree on the same envelope but still need neighbor review before runtime adoption."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:102029537",
+          "ids": { "wofId": 102029537, "repo": "whosonfirst-data-admin-in", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "IN/chennai/wof-locality-102029537.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:890505403",
+          "ids": { "wofId": 890505403, "repo": "whosonfirst-data-admin-in", "placetype": "county", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "IN/chennai/wof-county-890505403.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["County/context row only; not a direct replacement for the Chennai city lookup cell."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Hyderabad|IN",
+      "priority": ["south-asia-mega-city", "heuristic-bbox", "source-map-only", "apac-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Hyderabad IN has a broad runtime box and WOF reports a current locality row superseding older neighborhood/locality records."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:102030059",
+          "ids": { "wofId": 102030059, "repo": "whosonfirst-data-admin-in", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "IN/hyderabad/wof-locality-102030059.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Current WOF locality row supersedes older Hyderabad neighborhood/locality rows 85904069 and 1125994633."]
+        }
+      ]
+    },
+    {
+      "cityKey": "Dhaka|BD",
+      "priority": ["south-asia-mega-city", "heuristic-bbox", "source-map-only", "apac-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. Dhaka has current WOF locality/county rows plus geoBoundaries ADM2 district context; retain all as evidence before any city/district clipping review."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:locality:421181477",
+          "ids": { "wofId": 421181477, "repo": "whosonfirst-data-admin-bd", "placetype": "locality", "srcGeom": "whosonfirst", "mzIsCurrent": 1 },
+          "cacheFile": "BD/dhaka/wof-locality-421181477.geojson",
+          "sourceConfidence": "high",
+          "matchConfidence": "candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate"
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:421187803",
+          "ids": { "wofId": 421187803, "repo": "whosonfirst-data-admin-bd", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "BD/dhaka/wof-county-421187803.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["County/context row only; not a direct replacement for the Dhaka city lookup cell."]
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:BGD-ADM2-16705992:16705992B90744549146712",
+          "ids": {
+            "boundaryId": "BGD-ADM2-16705992",
+            "boundaryISO": "BGD",
+            "shapeId": "16705992B90744549146712",
+            "releaseType": "gbOpen",
+            "boundaryType": "ADM2",
+            "boundaryYearRepresented": "2020",
+            "boundarySource": "Bangladesh Bureau of Statistics (BBS), OCHA ROAP",
+            "boundaryLicense": "Creative Commons Attribution 3.0 Intergovernmental Organisations (CC BY 3.0 IGO)"
+          },
+          "cacheFile": "BD/dhaka/geoboundaries-bgd-adm2-16705992-dhaka.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "adm2-context-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["ADM2 district context only; not a direct city-locality replacement."]
+        }
+      ]
+    },
+    {
       "cityKey": "Windsor|CA",
       "priority": ["detroit-windsor-border", "wof-locality-runtime-bbox", "clipped"],
       "review": {

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -112,6 +112,13 @@ describe('city geometry source map', () => {
       ['Petaling Jaya|MY', 'wof:locality:102023395'],
       ['Kuala Lumpur|MY', 'wof:locality:102023407'],
       ['Sialkot|PK', 'wof:locality:421175525'],
+      ['Karachi|PK', 'wof:locality:421191101'],
+      ['Hyderabad|PK', 'wof:locality:421168813'],
+      ['Mumbai|IN', 'wof:locality:102030609'],
+      ['Ahmedabad|IN', 'wof:locality:102031017'],
+      ['Bangalore|IN', 'wof:locality:102030819'],
+      ['Chennai|IN', 'wof:locality:102029537'],
+      ['Hyderabad|IN', 'wof:locality:102030059'],
       ['Toronto|CA', 'wof:locality:101735835'],
       ['Mississauga|CA', 'wof:locality:101735893'],
       ['Laval|CA', 'wof:locality:101737759'],
@@ -390,6 +397,48 @@ describe('city geometry source map', () => {
         expect(geometry.reviewStatus, `${cityKey} ${stableId}`).toBe('candidate')
       }
     }
+  })
+
+  it('keeps South Asia mega-city geometry as source-map-only until metro seams are reviewed', () => {
+    const expected = new Map([
+      ['Karachi|PK', ['wof:locality:421191101', 'wof:county:1108692233']],
+      ['Hyderabad|PK', ['wof:locality:421168813']],
+      ['Mumbai|IN', ['wof:locality:102030609', 'wof:county:890509223']],
+      ['Ahmedabad|IN', ['wof:locality:102031017']],
+      ['Bangalore|IN', ['wof:locality:102030819', 'wof:county:890511315']],
+      ['Chennai|IN', ['wof:locality:102029537', 'wof:county:890505403']],
+      ['Hyderabad|IN', ['wof:locality:102030059']],
+      ['Dhaka|BD', [
+        'wof:locality:421181477',
+        'wof:county:421187803',
+        'geoboundaries:BGD-ADM2-16705992:16705992B90744549146712',
+      ]],
+    ])
+
+    for (const [cityKey, stableIds] of expected) {
+      const entry = sourceMap.cities.find(row => row.cityKey === cityKey)
+      expect(entry, cityKey).toBeTruthy()
+      expect(entry.review.status, cityKey).toBe('candidate')
+      expect(entry.priority, cityKey).toContain('source-map-only')
+      expect(entry.priority, cityKey).toContain('heuristic-bbox')
+
+      for (const stableId of stableIds) {
+        const geometry = entry.geometries.find(row => row.stableId === stableId)
+        expect(geometry, `${cityKey} ${stableId}`).toBeTruthy()
+        expect(geometry.reviewStatus, `${cityKey} ${stableId}`).toBe('candidate')
+      }
+    }
+
+    const dhaka = sourceMap.cities.find(row => row.cityKey === 'Dhaka|BD')
+    const dhakaGeometry = dhaka.geometries.find(row => row.provider === 'geoboundaries')
+    expect(dhakaGeometry.matchConfidence).toBe('adm2-context-candidate')
+    expect(dhakaGeometry.ids).toMatchObject({
+      boundaryId: 'BGD-ADM2-16705992',
+      shapeId: '16705992B90744549146712',
+      releaseType: 'gbOpen',
+      boundaryType: 'ADM2',
+      boundaryYearRepresented: '2020',
+    })
   })
 
   it('keeps Windsor source provenance aligned with the raw WOF record', () => {


### PR DESCRIPTION
## Summary
- add source-map-only geometry evidence for broad South Asia heuristic city boxes: Karachi, Hyderabad PK, Mumbai, Ahmedabad, Bangalore, Chennai, Hyderabad IN, and Dhaka
- preserve current WOF locality rows, WOF county/context rows where useful, and geoBoundaries BGD ADM2 Dhaka district context
- update geometry source-map tests, docs/city-geometry-audit.md, and CHANGELOG.md

Refs #118

## Audit facts
- Local audit summary: 70 source-map cities, 114 reported rows, 113 checked, 0 missing cache files, 1 intentional no-geometry row
- New South Asia rows are all candidate/source-map-only
- Most WOF locality rows triage as `tighten-review`, which confirms the existing runtime cells are broad heuristic boxes
- Karachi county context triages as `undercoverage-review`
- Mumbai county context triages as `center-geometry-review`, so it is explicitly context-only and not runtime input
- Dhaka has WOF locality/county evidence plus geoBoundaries ADM2 district context; none is treated as a direct municipal bbox

## Verification
- `jq empty scripts/data/city-geometry-sources.json`
- WOF cache hydration for Karachi, Hyderabad PK, Mumbai, Ahmedabad, Bangalore, Chennai, Hyderabad IN, Dhaka
- geoBoundaries cache hydration for Dhaka
- `npx vitest run test/geometrySourceMap.test.js test/geometryCacheFetcher.test.js` (25/25)
- `npm run validate:registry` (488 cities, 0 fail-class issues)
- `node scripts/build-city-registry.js --check`
- `node scripts/audit-city-geometry.js --format json` (70 source-map cities, 114 rows, 113 checked, 0 missing cache files)
- `npm test` (22 files, 430 tests passed)
- `npm pack --dry-run` (147.7 kB packed / 541.9 kB unpacked)
- `git diff --check`

## Non-goals
- No runtime bbox change
- No country/method dispatch change
- No public API/package data/prayer-time behavior change