### PR TITLE
chore(geometry): add Jakarta source rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Kept all rows source-map-only; no runtime bbox, country/method dispatch,
   public API, package data, or prayer-time behavior changed.
 
+### Added — Jakarta geometry source-map candidates
+
+- Added source-map-only geometry rows for the broad Jakarta heuristic city box:
+  current WOF Jakarta Raya region/county context plus geoBoundaries BPS/OCHA
+  ADM2 municipality rows.
+- Kept Jakarta source-map-only because the old WOF locality rows are not
+  current and a runtime fix needs a paired Jabodetabek design with neighboring
+  cities.
+
 ## [1.9.2] — 2026-05-15
 
 ### Fixed — Al Buraimi / Al Ain border routing

--- a/docs/city-geometry-audit.md
+++ b/docs/city-geometry-audit.md
@@ -34,14 +34,15 @@ human review. It must not mutate the runtime registry automatically.
 
 Reviewed external IDs belong in `scripts/data/city-geometry-sources.json`.
 The source map stores metadata and cache pointers only. The current seed covers
-70 high-priority rows: 15 Morocco/Habous phase-1 rows, 3 Egypt metro
+71 high-priority rows: 15 Morocco/Habous phase-1 rows, 3 Egypt metro
 source-map rows, 5 UAE metro rows, 4 Oman/UAE border rows, 10 Turkey large-city
 rows, 1 Hong Kong/Shenzhen border row, 2 Singapore/Johor rows, 4 Klang Valley
 rows, 1 Pakistan overlap row, 8 South Asia large-city source-map rows,
+1 Jakarta/Jabodetabek source-map row,
 4 Toronto/Montreal Canada metro rows,
 3 Detroit/Dearborn/Windsor border rows, 3 Geneva border rows, 2 Strasbourg/Kehl border
 rows, 2 Congo River rows, and 3 carry-over registry-warning rows. It carries
-17 OSM relation rows plus 81 WOF rows and 15
+17 OSM relation rows plus 87 WOF rows and 20
 geoBoundaries rows across reviewed locality/county/admin candidates. Morocco rows with
 WOF-backed runtime status are separated from OSM-only audit candidates;
 Jerusalem intentionally remains without a geometry candidate until a human
@@ -163,6 +164,15 @@ The South Asia large-city pass is source-map-only:
   heuristic boxes, and tightening them needs paired neighbor review for dense
   metros such as Karachi/Sindh, Mumbai/Navi Mumbai/Thane, Bangalore/Bengaluru
   metro, and Dhaka district/city boundaries.
+
+The Jakarta/Jabodetabek pass is also source-map-only:
+
+- The old WOF Jakarta locality rows are not current. The source map instead
+  records the current WOF Jakarta Raya region row, five current WOF county
+  rows, and five geoBoundaries/BPS/OCHA ADM2 municipality rows.
+- Runtime remains a single broad `Jakarta|ID` lookup cell until Bekasi, Depok,
+  Tangerang, South Tangerang, and internal DKI municipality routing can be
+  reviewed as a paired metro design.
 
 The Detroit/Windsor border seam needs clipping rather than direct WOF copying:
 

--- a/scripts/data/city-geometry-sources.json
+++ b/scripts/data/city-geometry-sources.json
@@ -1630,6 +1630,185 @@
       ]
     },
     {
+      "cityKey": "Jakarta|ID",
+      "priority": ["jakarta-jabodetabek", "heuristic-bbox", "source-map-only", "apac-p0"],
+      "review": {
+        "status": "candidate",
+        "issue": 118,
+        "notes": [
+          "2026-05-15: source-map candidate only. The old WOF locality rows for Jakarta are not current; preserve the current WOF region/county rows and geoBoundaries ADM2 municipalities before any Jabodetabek clipping review."
+        ]
+      },
+      "geometries": [
+        {
+          "provider": "wof",
+          "stableId": "wof:region:85672001",
+          "ids": { "wofId": 85672001, "repo": "whosonfirst-data-admin-id", "placetype": "region", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "ID/jakarta/wof-region-85672001.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Current WOF Jakarta Raya region row; context only, not a direct city-locality replacement."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:102072841",
+          "ids": { "wofId": 102072841, "repo": "whosonfirst-data-admin-id", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "ID/jakarta/wof-county-102072841-jakarta-barat.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Current WOF Jakarta Barat row; context only."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:102073177",
+          "ids": { "wofId": 102073177, "repo": "whosonfirst-data-admin-id", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "ID/jakarta/wof-county-102073177-jakarta-pusat.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Current WOF Jakarta Pusat row; context only."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:102072667",
+          "ids": { "wofId": 102072667, "repo": "whosonfirst-data-admin-id", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "ID/jakarta/wof-county-102072667-jakarta-selatan.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Current WOF Jakarta Selatan row; context only."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:102073493",
+          "ids": { "wofId": 102073493, "repo": "whosonfirst-data-admin-id", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "ID/jakarta/wof-county-102073493-jakarta-timur.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Current WOF Jakarta Timur row; context only."]
+        },
+        {
+          "provider": "wof",
+          "stableId": "wof:county:102073125",
+          "ids": { "wofId": 102073125, "repo": "whosonfirst-data-admin-id", "placetype": "county", "srcGeom": "meso", "mzIsCurrent": 1 },
+          "cacheFile": "ID/jakarta/wof-county-102073125-jakarta-utara.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "placetype-mismatch-context",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["Current WOF Jakarta Utara row; context only."]
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:IDN-ADM2-22746128:22746128B58252967349746",
+          "ids": {
+            "boundaryId": "IDN-ADM2-22746128",
+            "boundaryISO": "IDN",
+            "shapeId": "22746128B58252967349746",
+            "releaseType": "gbOpen",
+            "boundaryType": "ADM2",
+            "boundaryYearRepresented": "2020",
+            "boundarySource": "Badan Pusat Statistik (BPS - Statistics Indonesia), World Food Programme, OCHA ROAP",
+            "boundaryLicense": "Creative Commons Attribution 3.0 Intergovernmental Organisations (CC BY 3.0 IGO)"
+          },
+          "cacheFile": "ID/jakarta/geoboundaries-idn-adm2-22746128-jakarta-barat.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "adm2-context-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["ADM2 municipality context only; not a direct city-locality replacement."]
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:IDN-ADM2-22746128:22746128B21128962092426",
+          "ids": {
+            "boundaryId": "IDN-ADM2-22746128",
+            "boundaryISO": "IDN",
+            "shapeId": "22746128B21128962092426",
+            "releaseType": "gbOpen",
+            "boundaryType": "ADM2",
+            "boundaryYearRepresented": "2020",
+            "boundarySource": "Badan Pusat Statistik (BPS - Statistics Indonesia), World Food Programme, OCHA ROAP",
+            "boundaryLicense": "Creative Commons Attribution 3.0 Intergovernmental Organisations (CC BY 3.0 IGO)"
+          },
+          "cacheFile": "ID/jakarta/geoboundaries-idn-adm2-22746128-jakarta-pusat.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "adm2-context-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["ADM2 municipality context only; not a direct city-locality replacement."]
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:IDN-ADM2-22746128:22746128B93686700937380",
+          "ids": {
+            "boundaryId": "IDN-ADM2-22746128",
+            "boundaryISO": "IDN",
+            "shapeId": "22746128B93686700937380",
+            "releaseType": "gbOpen",
+            "boundaryType": "ADM2",
+            "boundaryYearRepresented": "2020",
+            "boundarySource": "Badan Pusat Statistik (BPS - Statistics Indonesia), World Food Programme, OCHA ROAP",
+            "boundaryLicense": "Creative Commons Attribution 3.0 Intergovernmental Organisations (CC BY 3.0 IGO)"
+          },
+          "cacheFile": "ID/jakarta/geoboundaries-idn-adm2-22746128-jakarta-selatan.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "adm2-context-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["ADM2 municipality context only; not a direct city-locality replacement."]
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:IDN-ADM2-22746128:22746128B5353616278909",
+          "ids": {
+            "boundaryId": "IDN-ADM2-22746128",
+            "boundaryISO": "IDN",
+            "shapeId": "22746128B5353616278909",
+            "releaseType": "gbOpen",
+            "boundaryType": "ADM2",
+            "boundaryYearRepresented": "2020",
+            "boundarySource": "Badan Pusat Statistik (BPS - Statistics Indonesia), World Food Programme, OCHA ROAP",
+            "boundaryLicense": "Creative Commons Attribution 3.0 Intergovernmental Organisations (CC BY 3.0 IGO)"
+          },
+          "cacheFile": "ID/jakarta/geoboundaries-idn-adm2-22746128-jakarta-timur.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "adm2-context-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["ADM2 municipality context only; not a direct city-locality replacement."]
+        },
+        {
+          "provider": "geoboundaries",
+          "stableId": "geoboundaries:IDN-ADM2-22746128:22746128B85966169947265",
+          "ids": {
+            "boundaryId": "IDN-ADM2-22746128",
+            "boundaryISO": "IDN",
+            "shapeId": "22746128B85966169947265",
+            "releaseType": "gbOpen",
+            "boundaryType": "ADM2",
+            "boundaryYearRepresented": "2020",
+            "boundarySource": "Badan Pusat Statistik (BPS - Statistics Indonesia), World Food Programme, OCHA ROAP",
+            "boundaryLicense": "Creative Commons Attribution 3.0 Intergovernmental Organisations (CC BY 3.0 IGO)"
+          },
+          "cacheFile": "ID/jakarta/geoboundaries-idn-adm2-22746128-jakarta-utara.geojson",
+          "sourceConfidence": "medium",
+          "matchConfidence": "adm2-context-candidate",
+          "licenseUse": "audit-and-reviewed-bbox-proposal",
+          "reviewStatus": "candidate",
+          "notes": ["ADM2 municipality context only; not a direct city-locality replacement."]
+        }
+      ]
+    },
+    {
       "cityKey": "Windsor|CA",
       "priority": ["detroit-windsor-border", "wof-locality-runtime-bbox", "clipped"],
       "review": {

--- a/test/geometrySourceMap.test.js
+++ b/test/geometrySourceMap.test.js
@@ -441,6 +441,51 @@ describe('city geometry source map', () => {
     })
   })
 
+  it('keeps Jakarta/Jabodetabek geometry as source-map-only until neighbor cells exist', () => {
+    const entry = sourceMap.cities.find(row => row.cityKey === 'Jakarta|ID')
+    expect(entry).toBeTruthy()
+    expect(entry.review.status).toBe('candidate')
+    expect(entry.priority).toContain('jakarta-jabodetabek')
+    expect(entry.priority).toContain('source-map-only')
+
+    const wofRows = entry.geometries.filter(row => row.provider === 'wof')
+    expect(wofRows.map(row => row.stableId)).toEqual([
+      'wof:region:85672001',
+      'wof:county:102072841',
+      'wof:county:102073177',
+      'wof:county:102072667',
+      'wof:county:102073493',
+      'wof:county:102073125',
+    ])
+    for (const row of wofRows) {
+      expect(row.ids.repo).toBe('whosonfirst-data-admin-id')
+      expect(row.ids.srcGeom).toBe('meso')
+      expect(row.ids.mzIsCurrent).toBe(1)
+      expect(row.matchConfidence).toBe('placetype-mismatch-context')
+      expect(row.reviewStatus).toBe('candidate')
+    }
+
+    const officialRows = entry.geometries.filter(row => row.provider === 'geoboundaries')
+    expect(officialRows.map(row => row.ids.shapeId)).toEqual([
+      '22746128B58252967349746',
+      '22746128B21128962092426',
+      '22746128B93686700937380',
+      '22746128B5353616278909',
+      '22746128B85966169947265',
+    ])
+    for (const row of officialRows) {
+      expect(row.ids).toMatchObject({
+        boundaryId: 'IDN-ADM2-22746128',
+        boundaryISO: 'IDN',
+        releaseType: 'gbOpen',
+        boundaryType: 'ADM2',
+        boundaryYearRepresented: '2020',
+      })
+      expect(row.matchConfidence).toBe('adm2-context-candidate')
+      expect(row.reviewStatus).toBe('candidate')
+    }
+  })
+
   it('keeps Windsor source provenance aligned with the raw WOF record', () => {
     const entry = sourceMap.cities.find(row => row.cityKey === 'Windsor|CA')
     const geometry = entry?.geometries?.find(row => row.stableId === 'wof:locality:101735855')


### PR DESCRIPTION
## Summary
- add source-map-only geometry evidence for the broad Jakarta runtime cell
- preserve current WOF Jakarta Raya region/county context rows and geoBoundaries BPS/OCHA ADM2 municipality rows
- update geometry source-map tests, docs/city-geometry-audit.md, and CHANGELOG.md

Refs #118

## Audit facts
- Old WOF Jakarta locality rows are not current, so this PR does not use them as direct city candidates
- Local audit summary: 71 source-map cities, 125 reported rows, 124 checked, 0 missing cache files, 1 intentional no-geometry row
- The WOF Jakarta Raya region row triages as `tighten-review`
- The individual Jakarta municipality rows often triage as `center-geometry-review`, which confirms they are context-only rows for a future split-cell design

## Verification
- `jq empty scripts/data/city-geometry-sources.json`
- WOF cache hydration for Jakarta (6/6)
- geoBoundaries cache hydration for Jakarta (5/5)
- `npx vitest run test/geometrySourceMap.test.js test/geometryCacheFetcher.test.js` (26/26)
- `npm run validate:registry` (488 cities, 0 fail-class issues)
- `node scripts/build-city-registry.js --check`
- `node scripts/audit-city-geometry.js --format json` (71 source-map cities, 125 rows, 124 checked, 0 missing cache files)
- `npm test` (22 files, 431 tests passed)
- `npm pack --dry-run` (147.7 kB packed / 541.9 kB unpacked)
- `git diff --check`

## Non-goals
- No runtime bbox change
- No country/method dispatch change
- No public API/package data/prayer-time behavior change