### PR TITLE
chore: add release preflight QA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm test
+      - name: Run release preflight
+        run: npm run preflight:release
 
       - name: Verify tag matches package.json version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 
 ## [Unreleased]
 
+### Added — release preflight QA
+
+- Added `npm run preflight:release`, a reusable maintainer release gate that
+  runs diff whitespace checks, the Vitest suite, the deterministic city
+  registry validator, generated registry sync verification, and
+  `npm pack --dry-run`.
+- Wired the npm publish workflow to run the same preflight command before
+  publishing a release tag.
+- Added `docs/qa-process.md` and linked it from the README so issue #49 has a
+  concrete release-process artifact alongside the downstream app playbook.
+
 ### Added — downstream app integration playbook
 
 - Added `docs/downstream-apps.md`, capturing agiftoftime-derived patterns for

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Core docs:
 - [docs/city-geometry-audit.md](docs/city-geometry-audit.md) - build-time QA plan for reverse-geolocation bboxes.
 - [examples/agiftoftime/INTEGRATION.md](examples/agiftoftime/INTEGRATION.md) - app-side integration guide for [A Gift of Time](https://agiftoftime.app).
 - [docs/downstream-apps.md](docs/downstream-apps.md) - downstream app UX, QA, and release-handoff patterns.
+- [docs/qa-process.md](docs/qa-process.md) - maintainer release preflight and QA handoff checklist.
 
 ## Install
 
@@ -323,6 +324,7 @@ Hilal output is astronomical possibility, not a religious ruling. See [docs/hila
 | Generated eval dashboard | [docs/progress.md](docs/progress.md) |
 | Integration in A Gift of Time | [examples/agiftoftime/INTEGRATION.md](examples/agiftoftime/INTEGRATION.md) |
 | Downstream app playbook | [docs/downstream-apps.md](docs/downstream-apps.md) |
+| Maintainer QA process | [docs/qa-process.md](docs/qa-process.md) |
 | Source inventory | [docs/data-sources.md](docs/data-sources.md) |
 | City bbox geometry audit | [docs/city-geometry-audit.md](docs/city-geometry-audit.md) |
 | Scholarly review brief | [docs/scholar-review-brief.md](docs/scholar-review-brief.md) |

--- a/docs/qa-process.md
+++ b/docs/qa-process.md
@@ -1,0 +1,69 @@
+# QA Process
+
+Last refreshed: 2026-05-15
+
+This page documents the maintainer-side checks that should run before a fajr
+release is tagged or published. It complements the PR review layers in
+`AGENTS.md` and the downstream app handoff guidance in
+[`docs/downstream-apps.md`](downstream-apps.md).
+
+## Release Preflight
+
+Run this from the repository root before creating a release tag:
+
+```bash
+npm run preflight:release
+```
+
+The npm publish workflow also runs the same command before publishing a `v*`
+tag to npm. A release should not ship if this command fails.
+
+The preflight currently checks:
+
+- `git diff --check HEAD --` for whitespace and conflict-marker style diff
+  errors.
+- `npm test` for the Vitest suite covering public API behavior, prayer-time
+  contracts, city registry behavior, geometry source-map invariants, Hijri,
+  hilal, qibla, and documentation-facing metadata.
+- `npm run validate:registry` for the full deterministic city
+  reverse-geolocation validator.
+- `node scripts/build-city-registry.js --check` to prove the checked-in runtime
+  city registry still matches its generator inputs.
+- `npm pack --dry-run` to show the package shape npm would publish.
+
+## What Preflight Does Not Replace
+
+Accuracy changes still require the autoresearch ratchet:
+
+```bash
+node eval/eval.js
+npm run compare
+```
+
+Any accepted accuracy change must also include an `autoresearch/logs/` entry
+with before/after train and holdout WMAE, per-region deltas, signed-bias
+deltas, verdict, and scholarly classification. The preflight command is a
+release sanity gate; it is not an eval ratchet and should not be used as proof
+that a calculation change is better.
+
+Downstream app validation is also separate. Before bumping fajr inside
+agiftoftime, the downstream agent should run its own app-level tests and UI
+provenance checks as described in
+[`docs/downstream-apps.md`](downstream-apps.md) and
+[`examples/agiftoftime/INTEGRATION.md`](../examples/agiftoftime/INTEGRATION.md).
+
+## Release Handoff
+
+For every npm release that changes provenance, location routing, defaults,
+Hijri output, hilal output, or return-shape semantics:
+
+1. Run `npm run preflight:release`.
+2. Tag and publish only after the preflight passes.
+3. Open an agiftoftime issue with the package version, release link, exact
+   coordinates or dates to test, expected metadata changes, and whether app
+   code changes are expected.
+4. Keep the fajr issue open until downstream compatibility validation has
+   passed or the downstream agent has explicitly deferred it.
+
+This makes release quality inspectable by maintainers, review agents, and the
+reference downstream app.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "compare": "node eval/compare.js",
+    "preflight:release": "node scripts/preflight-release.js",
     "validate:aabed": "node scripts/validate-against-aabed-2015.js",
     "validate:hilal": "node scripts/validate-hilal.js",
     "validate:lunar-jpl": "node scripts/validate-lunar-against-jpl.js",

--- a/scripts/preflight-release.js
+++ b/scripts/preflight-release.js
@@ -1,0 +1,112 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Release preflight for npm publishing.
+ *
+ * This is the reproducible version of the manual checks maintainers were
+ * already running before release tags. It intentionally avoids eval ratchet
+ * commands because accuracy PRs still need their own autoresearch log and
+ * `node eval/eval.js && npm run compare` result before merge.
+ */
+
+import { spawnSync } from 'node:child_process'
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const nodeCommand = process.execPath
+
+const STEPS = [
+  {
+    id: 'diff-whitespace',
+    title: 'Diff whitespace check',
+    command: 'git',
+    args: ['diff', '--check', 'HEAD', '--'],
+    note: 'Catches trailing whitespace and conflict-marker style diff errors before a tag.',
+  },
+  {
+    id: 'unit-tests',
+    title: 'Unit and integration tests',
+    command: npmCommand,
+    args: ['test'],
+    note: 'Runs the Vitest suite that guards API, registry, geometry-source, Hijri, hilal, and engine behavior.',
+  },
+  {
+    id: 'registry-validation',
+    title: 'City registry validator',
+    command: npmCommand,
+    args: ['run', 'validate:registry'],
+    note: 'Runs the full reverse-geolocation registry validator with deterministic bbox samples.',
+  },
+  {
+    id: 'registry-build-sync',
+    title: 'Generated city registry sync',
+    command: nodeCommand,
+    args: ['scripts/build-city-registry.js', '--check'],
+    note: 'Verifies src/data/cities.json still matches the checked-in generator inputs.',
+  },
+  {
+    id: 'package-dry-run',
+    title: 'npm package dry run',
+    command: npmCommand,
+    args: ['pack', '--dry-run'],
+    note: 'Shows the exact files npm would publish without creating a release.',
+  },
+]
+
+if (process.argv.includes('--list-json')) {
+  console.log(JSON.stringify(STEPS.map(publicStep), null, 2))
+  process.exit(0)
+}
+
+console.log('# fajr release preflight')
+console.log('')
+console.log('These checks must pass before tagging or publishing an npm release.')
+
+for (let i = 0; i < STEPS.length; i++) {
+  const step = STEPS[i]
+  console.log('')
+  console.log(`[${i + 1}/${STEPS.length}] ${step.title}`)
+  console.log(`$ ${formatCommand(step)}`)
+  console.log(step.note)
+
+  const started = Date.now()
+  const result = spawnSync(step.command, step.args, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'inherit',
+  })
+
+  if (result.error) {
+    console.error('')
+    console.error(`preflight failed: could not run ${formatCommand(step)}`)
+    console.error(result.error.message)
+    process.exit(1)
+  }
+
+  if (result.status !== 0) {
+    const suffix = result.signal ? `signal ${result.signal}` : `exit ${result.status}`
+    console.error('')
+    console.error(`preflight failed at "${step.title}" (${suffix})`)
+    process.exit(result.status || 1)
+  }
+
+  const elapsedSec = ((Date.now() - started) / 1000).toFixed(1)
+  console.log(`ok: ${step.title} (${elapsedSec}s)`)
+}
+
+console.log('')
+console.log('Release preflight passed.')
+
+function publicStep(step) {
+  return {
+    id: step.id,
+    title: step.title,
+    command: step.command === nodeCommand ? 'node' : step.command.replace(/\.cmd$/, ''),
+    args: step.args,
+    note: step.note,
+  }
+}
+
+function formatCommand(step) {
+  const command = step.command === nodeCommand ? 'node' : step.command.replace(/\.cmd$/, '')
+  return [command, ...step.args].join(' ')
+}

--- a/test/preflightRelease.test.js
+++ b/test/preflightRelease.test.js
@@ -1,0 +1,34 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, '..')
+
+describe('release preflight script', () => {
+  it('lists the release gate checks without executing them', () => {
+    const output = execFileSync(
+      process.execPath,
+      ['scripts/preflight-release.js', '--list-json'],
+      { cwd: ROOT, encoding: 'utf8' }
+    )
+    const steps = JSON.parse(output)
+
+    expect(steps.map(step => step.id)).toEqual([
+      'diff-whitespace',
+      'unit-tests',
+      'registry-validation',
+      'registry-build-sync',
+      'package-dry-run',
+    ])
+    expect(steps.find(step => step.id === 'package-dry-run')).toMatchObject({
+      command: 'npm',
+      args: ['pack', '--dry-run'],
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add `npm run preflight:release` as a reusable release gate for whitespace checks, Vitest, city-registry validation, generated registry sync, and `npm pack --dry-run`
- wire the npm publish workflow to run the preflight before publishing release tags
- document the maintainer QA process and link it from the README

## Validation
- `node --check scripts/preflight-release.js`
- `node scripts/preflight-release.js --list-json`
- `npm run preflight:release` (432/432 tests, registry validator 0 fail-class issues, package dry-run 147.7 kB)

Refs #49

## Notes
- This does not replace the autoresearch eval ratchet for accuracy changes; docs explicitly keep `node eval/eval.js` + `npm run compare` separate.
- No prayer-time math, city data, public API, package exports, dependencies, or version changed.