### PR TITLE
fix(mawaqit): add opt-in clock normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ proposals live in [`autoresearch/proposals/`](autoresearch/proposals/).
 - Kept all rows source-map-only; no runtime bbox, country/method dispatch,
   public API, package data, or prayer-time behavior changed.
 
+### Added — Mawaqit yearly clock-normalization tooling
+
+- Added an opt-in `--source-clock-timezone UTC --target-timezone <IANA>` path
+  to `scripts/fetch-mawaqit-yearly.js` so GMT-year-round embedded calendars
+  can be converted to local clock before future fixture review.
+- Documented the UK `Europe/London` re-fetch command for issue #70 without
+  mutating `eval/data/`.
+
 ### Added — downstream app integration playbook
 
 - Added `docs/downstream-apps.md`, capturing agiftoftime-derived patterns for

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -243,6 +243,21 @@ Raw/source locations:
 - `scripts/fetch-mawaqit.js`
 - `scripts/fetch-mawaqit-yearly.js`
 
+For the UK yearly corpus, the existing fixture is known to contain a
+GMT/BST clock-encoding artifact. Re-fetch with explicit source-clock
+normalization before using it for calibration:
+
+```bash
+node scripts/fetch-mawaqit-yearly.js \
+  --country "United Kingdom" \
+  --source-clock-timezone UTC \
+  --target-timezone Europe/London \
+  --out eval/data/test/mawaqit-uk-yearly.json
+```
+
+Do not commit a regenerated eval fixture from an autoresearch/script cleanup
+PR; fixture replacement needs a separate corpus-quality review.
+
 ## Institutional References Not Yet Fully Fixture-Backed
 
 These sources are important for citation and future ingestion, but a named

--- a/scripts/fetch-mawaqit-yearly.js
+++ b/scripts/fetch-mawaqit-yearly.js
@@ -26,6 +26,8 @@
  *   node scripts/fetch-mawaqit-yearly.js --limit 5            # first N slugs
  *   node scripts/fetch-mawaqit-yearly.js --out <path>         # custom output path
  *   node scripts/fetch-mawaqit-yearly.js --year 2025          # tag the calendar's year
+ *   node scripts/fetch-mawaqit-yearly.js --country "United Kingdom" \
+ *     --source-clock-timezone UTC --target-timezone Europe/London
  *
  * Rate limits: 2 sec between requests to mawaqit.net (be polite to a
  * free institutional resource that the global Muslim community
@@ -38,6 +40,7 @@
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
 import { dirname } from 'node:path'
+import { normalizeClockTimeForZone } from './lib/timezone-clock.js'
 
 const REGISTRY_PATH = new URL('./data/mawaqit-mosques.json', import.meta.url).pathname
 const DEFAULT_OUT = new URL('../eval/data/test/mawaqit-yearly.json', import.meta.url).pathname
@@ -71,11 +74,12 @@ async function main() {
         failures.push({ slug: m.slug, reason: 'no-calendar' })
         continue
       }
-      const dates = calendarToDates(fetched.calendar, targetYear, fetched.iqamaCalendar)
       // Coord priority: mosque-page embed > registry > 0 fallback.
       const latitude = fetched.latitude ?? m.lat ?? m.latitude ?? 0
       const longitude = fetched.longitude ?? m.lng ?? m.longitude ?? 0
       const mosqueName = fetched.name || m.name
+      const clockNormalization = clockNormalizationFor(m)
+      const dates = calendarToDates(fetched.calendar, targetYear, fetched.iqamaCalendar, clockNormalization)
       records.push({
         city: m.city || m.cityName || 'unknown',
         country: m.country || 'unknown',
@@ -90,6 +94,10 @@ async function main() {
         source_url: `https://mawaqit.net/en/m/${m.slug}`,
         source_fetched: new Date().toISOString(),
         source_year: targetYear,
+        ...(clockNormalization ? {
+          source_clock_timezone: clockNormalization.sourceTimeZone,
+          clock_normalized_to_timezone: clockNormalization.targetTimeZone,
+        } : {}),
         dates,
       })
       console.log(`OK (${dates.length} days, ${latitude.toFixed(2)}/${longitude.toFixed(2)})`)
@@ -178,7 +186,7 @@ function extractBalancedArray(html, start) {
   return null
 }
 
-function calendarToDates(calendar, year, iqamaCalendar = null) {
+function calendarToDates(calendar, year, iqamaCalendar = null, clockNormalization = null) {
   if (!Array.isArray(calendar)) return []
   const out = []
   for (let monthIdx = 0; monthIdx < calendar.length; monthIdx++) {
@@ -219,10 +227,34 @@ function calendarToDates(calendar, year, iqamaCalendar = null) {
           fajr: iq[0], dhuhr: iq[1], asr: iq[2], maghrib: iq[3], isha: iq[4],
         }
       }
-      out.push(row)
+      out.push(normalizeRowClock(row, clockNormalization))
     }
   }
   return out
+}
+
+function clockNormalizationFor(mosque) {
+  const sourceTimeZone = args['source-clock-timezone']
+  if (!sourceTimeZone) return null
+  return {
+    sourceTimeZone,
+    targetTimeZone: args['target-timezone'] || mosque.timezone || 'UTC',
+  }
+}
+
+function normalizeRowClock(row, clockNormalization) {
+  if (!clockNormalization) return row
+
+  const normalized = { ...row }
+  for (const key of ['fajr', 'sunrise', 'shuruq', 'dhuhr', 'asr', 'maghrib', 'isha']) {
+    if (!normalized[key]) continue
+    normalized[key] = normalizeClockTimeForZone({
+      date: row.date,
+      time: normalized[key],
+      ...clockNormalization,
+    })
+  }
+  return normalized
 }
 
 function parseArgs(argv) {

--- a/scripts/lib/timezone-clock.js
+++ b/scripts/lib/timezone-clock.js
@@ -1,0 +1,57 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+
+/**
+ * Convert a clock time recorded in one zone into the local clock shown in
+ * another zone for the same instant. This intentionally supports UTC/GMT
+ * source clocks first, because the known Mawaqit UK yearly artifact is a
+ * GMT-year-round embedded calendar being compared as Europe/London local time.
+ */
+
+const UTC_ZONE_NAMES = new Set(['UTC', 'Etc/UTC', 'GMT', 'Etc/GMT', 'Zulu'])
+
+export function normalizeClockTimeForZone({ date, time, sourceTimeZone, targetTimeZone }) {
+  if (!sourceTimeZone || !targetTimeZone || sourceTimeZone === targetTimeZone) return time
+  if (!UTC_ZONE_NAMES.has(sourceTimeZone)) {
+    throw new Error(`Unsupported source clock timezone: ${sourceTimeZone}; only UTC/GMT source clocks are supported`)
+  }
+
+  const parsed = parseDateAndTime(date, time)
+  if (!parsed) return time
+  const instant = new Date(Date.UTC(
+    parsed.year,
+    parsed.month - 1,
+    parsed.day,
+    parsed.hour,
+    parsed.minute,
+    0,
+  ))
+  return formatClockInZone(instant, targetTimeZone)
+}
+
+function parseDateAndTime(date, time) {
+  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(date))
+  const timeMatch = /^(\d{1,2}):(\d{2})$/.exec(String(time))
+  if (!dateMatch || !timeMatch) return null
+
+  const year = Number(dateMatch[1])
+  const month = Number(dateMatch[2])
+  const day = Number(dateMatch[3])
+  const hour = Number(timeMatch[1])
+  const minute = Number(timeMatch[2])
+  if (hour > 23 || minute > 59) return null
+  return { year, month, day, hour, minute }
+}
+
+function formatClockInZone(date, timeZone) {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    hourCycle: 'h23',
+  }).formatToParts(date)
+  const out = Object.fromEntries(parts.map(part => [part.type, part.value]))
+  const hour = String(Number(out.hour) % 24).padStart(2, '0')
+  return `${hour}:${out.minute}`
+}

--- a/test/timezoneClock.test.js
+++ b/test/timezoneClock.test.js
@@ -1,0 +1,34 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+
+import { describe, expect, it } from 'vitest'
+import { normalizeClockTimeForZone } from '../scripts/lib/timezone-clock.js'
+
+describe('timezone clock normalization', () => {
+  it('keeps GMT winter clocks unchanged for Europe/London', () => {
+    expect(normalizeClockTimeForZone({
+      date: '2026-01-15',
+      time: '16:24',
+      sourceTimeZone: 'UTC',
+      targetTimeZone: 'Europe/London',
+    })).toBe('16:24')
+  })
+
+  it('adds the BST hour when a GMT-year-round source is compared as London local clock', () => {
+    expect(normalizeClockTimeForZone({
+      date: '2026-07-15',
+      time: '20:15',
+      sourceTimeZone: 'UTC',
+      targetTimeZone: 'Europe/London',
+    })).toBe('21:15')
+  })
+
+  it('leaves non-clock strings untouched', () => {
+    expect(normalizeClockTimeForZone({
+      date: '2026-07-15',
+      time: '+20',
+      sourceTimeZone: 'UTC',
+      targetTimeZone: 'Europe/London',
+    })).toBe('+20')
+  })
+})


### PR DESCRIPTION
## Summary
- add a UTC/GMT-source clock normalizer for Mawaqit yearly fixture refreshes
- wire `scripts/fetch-mawaqit-yearly.js` with `--source-clock-timezone UTC --target-timezone <IANA>` metadata and conversion
- document the UK `Europe/London` re-fetch command without mutating `eval/data/`

## Validation
- `node --check scripts/fetch-mawaqit-yearly.js`
- `node --check scripts/lib/timezone-clock.js`
- `npx vitest run test/timezoneClock.test.js`: 3/3
- London one-mosque smoke fetch to `/tmp`: Jan Maghrib stayed `16:24`, July normalized to `21:15`
- `npm run preflight:release`: 435/435 tests, registry validator 0 fail-class issues, package dry-run 147.7 kB / 542.1 kB

Refs #70

## Notes
- Does not touch `eval/data/`; the actual UK fixture replacement still needs a separate corpus-quality PR/review.
- No prayer-time engine behavior, public API, package data, dependencies, or package version changed.
- [positions: no-change-required] tooling-only fetcher change; no region default, confidence grade, fixture evidence, or institutional position changes in this PR.