### PR TITLE
fix: speed up hilal altitude crossing search

### DIFF
--- a/autoresearch/logs/2026-05-15-18-31.md
+++ b/autoresearch/logs/2026-05-15-18-31.md
@@ -1,0 +1,63 @@
+# AutoResearch Run — 2026-05-15 18:31 UTC
+
+## Hypothesis
+`hilalVisibility()` is the slowest public API path because sunset/moonset search scans 12-24 hour windows at one-minute resolution before bisection. A coarser bracket scan should reduce repeated ephemeris calls while preserving bisection-refined event times.
+
+## Wiki sources consulted
+- `knowledge/wiki/astronomy/hilal.md` — hilal computation uses sunset, moonset, best time, and Odeh/Yallop/Shaukat criteria; this run changes only event-search performance, not criterion semantics.
+
+## Profiling
+CPU profile over 60,000 mixed `hilalVisibility()` calls before the change:
+
+| Function | Sample share |
+|---|---:|
+| `solarPosition` | 25.2% |
+| `lunarPosition` | 24.9% |
+| `mod360` | 20.9% |
+| `solarAltitude` | 17.3% |
+| `findAltitudeCrossing` | 1.6% |
+
+The hotspot was repeated ephemeris evaluation from the altitude-crossing scan, not the final visibility criteria.
+
+## Change made
+In `src/hilal.js`, changed `findAltitudeCrossing()` from a one-minute coarse scan to a five-minute bracket scan, then kept the existing 25-iteration bisection refinement. Also added representative regression tests in `test/engine.test.js` asserting known sunset/moonset outputs stay within one second.
+
+## Benchmark
+Worst cases from an 8-location x 12-Hijri-month `hilalVisibility()` sweep:
+
+| Case | Before | After |
+|---|---:|---:|
+| Slowest observed case | 910.75 us/op | 219.10 us/op |
+| Sydney 1447-12 | 910.75 us/op | 219.10 us/op |
+| Oslo 1447-04 | 898.28 us/op | 215.96 us/op |
+| London 1447-06 | 884.10 us/op | 214.56 us/op |
+
+Representative public API post-change benchmark:
+
+| API | Time |
+|---|---:|
+| `qibla()` | 0.02 us/op |
+| `hijri()` | 0.63 us/op |
+| `prayerTimes()` London | 10.81 us/op |
+| `dayTimes()` London | 22.21 us/op |
+| `hilalVisibility()` London-month sweep | 122.68 us/op |
+
+## Before WMAE
+Train WMAE baseline from existing `eval/results/runs.jsonl`: 0.9757. Holdout WMAE baseline: 7.3646.
+
+## After WMAE
+`node eval/eval.js`: train WMAE 0.9757, holdout WMAE 7.3646. No prayer-time engine files were changed.
+
+## Verification
+- `npm test` — 24 files / 436 tests passed
+- `npm run validate:hilal` — astronomical accuracy 5/5
+- `npm run build:criterion-isolines` — regenerated with no working-tree diff
+- `npm run analyze:hilal-historical` — regenerated with no working-tree diff
+- representative `hilalVisibility()` outputs unchanged for Cairo Ramadan 1446, Dubai Ramadan 1445, Riyadh Shawwal 1444, and Sydney 1447-12
+- compared old `master` vs candidate across 96 hilal cases (8 locations x 12 months): 0 mismatches, max timestamp drift 0 ms
+
+## Verdict
+ACCEPTED — worst observed `hilalVisibility()` cases improved from about 0.91 ms/op to about 0.22 ms/op, with unchanged public hilal outputs and unchanged prayer-time WMAE.
+
+## Scholarly classification
+🟡 Limited precedent unchanged — this is an implementation-performance change inside the existing hilal module. It does not add or alter any visibility criterion, threshold, or fiqh-facing behavior.

--- a/src/hilal.js
+++ b/src/hilal.js
@@ -52,6 +52,7 @@ function hijriToJd(year, month, day) {
 
 const SUN_HORIZON_DEG  = -0.8333   // standard refraction + solar radius
 const MOON_HORIZON_DEG = -0.5833   // standard refraction; lunar parallax handled by topocentric()
+const ALTITUDE_CROSSING_SCAN_STEP_DAYS = 5 / 1440  // 5-minute bracket scan, refined by bisection
 
 // Find the JD where solar topocentric altitude crosses the given threshold,
 // going downward — i.e., sunset on the Gregorian day enclosing the supplied
@@ -95,11 +96,16 @@ function solarAltitude(sun, lat, lon, jd) {
 // Bisection to find the JD where altitudeFn(jd) crosses `threshold` going downward.
 // Returns null if no downward crossing within [jdLo, jdHi].
 function findAltitudeCrossing(altitudeFn, threshold, jdLo, jdHi) {
-  // Coarse scan
-  const STEP = 1 / 1440  // 1-minute steps
+  if (jdHi <= jdLo) return null
+
+  // Coarse scan to bracket the setting event. Solar/lunar apparent altitude is
+  // smooth at horizon scale; once bracketed, bisection recovers sub-second
+  // crossing precision without sampling every minute of a 12-24h search window.
+  const step = Math.min(ALTITUDE_CROSSING_SCAN_STEP_DAYS, jdHi - jdLo)
   let prevJd = jdLo
   let prevAlt = altitudeFn(prevJd) - threshold
-  for (let jd = jdLo + STEP; jd <= jdHi; jd += STEP) {
+  while (prevJd < jdHi) {
+    const jd = Math.min(prevJd + step, jdHi)
     const alt = altitudeFn(jd) - threshold
     if (prevAlt > 0 && alt <= 0) {
       // bracketed — refine via bisection

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -20,6 +20,10 @@ import { applyElevationCorrection } from '../src/engine.js'
 const TEST_DATE = new Date('2026-04-15T12:00:00Z')
 const PRAYERS = ['fajr', 'shuruq', 'dhuhr', 'asr', 'maghrib', 'isha']
 
+function expectIsoWithinSeconds(actual, expected, seconds = 1) {
+  expect(Math.abs(Date.parse(actual) - Date.parse(expected))).toBeLessThanOrEqual(seconds * 1000)
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Region detection (via the methodName label that prayerTimes returns)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -366,6 +370,32 @@ describe('hilalVisibility', () => {
     expect(r.shaukat).toHaveProperty('lagMinutes')
     // Agreement flag
     expect(typeof r.criteriaAgree).toBe('boolean')
+  })
+
+  it('keeps sunset and moonset crossings stable for representative hilal cases', () => {
+    const cases = [
+      [
+        { year: 1446, month: 9, latitude: 30.04, longitude: 31.24 },
+        '2025-02-28T15:53:25.284Z',
+        '2025-02-28T16:28:28.273Z',
+      ],
+      [
+        { year: 1445, month: 9, latitude: 25.20, longitude: 55.27 },
+        '2024-03-10T14:25:37.146Z',
+        '2024-03-10T14:34:14.609Z',
+      ],
+      [
+        { year: 1444, month: 10, latitude: 24.71, longitude: 46.68 },
+        '2023-04-20T15:17:36.145Z',
+        '2023-04-20T15:39:36.612Z',
+      ],
+    ]
+
+    for (const [params, sunsetUTC, moonsetUTC] of cases) {
+      const r = hilalVisibility(params)
+      expectIsoWithinSeconds(r.sunsetUTC, sunsetUTC)
+      expectIsoWithinSeconds(r.moonsetUTC, moonsetUTC)
+    }
   })
 
   it('classifies Ramadan 1444 (Riyadh, age 22h) as visible', () => {


### PR DESCRIPTION
## Summary
- speed up hilal sunset/moonset bracketing by scanning 5-minute brackets before the existing bisection refinement
- add regression coverage for representative hilal sunset/moonset timestamps
- log the benchmark/profiling run in autoresearch logs

## Profiling / benchmark
- CPU profile before: repeated `solarPosition`, `lunarPosition`, and `mod360` calls dominated `hilalVisibility()` via `findAltitudeCrossing()`
- worst observed 8-city x 12-month hilal case improved from 910.75 us/op to 219.10 us/op
- representative outputs for Cairo Ramadan 1446, Dubai Ramadan 1445, Riyadh Shawwal 1444, and Sydney 1447-12 were unchanged

## Verification
- `npm test` — 24 files / 436 tests passed
- `npm run validate:hilal` — astronomical accuracy 5/5
- `npm run build:criterion-isolines` — no generated diff
- `npm run analyze:hilal-historical` — no generated diff
- `node eval/eval.js` — train WMAE 0.9757, holdout WMAE 7.3646 (unchanged; no prayer-time engine files touched)

## Notes
`eval/compare.js` is intentionally not a meaningful gate for this PR because the change is a pure hilal performance optimization and produces a WMAE wash by design. The post-change eval was still run to confirm no prayer-time accuracy drift.
