### PR TITLE
docs: define Morocco evidence boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Core docs:
 - [SCOREBOARD.md](SCOREBOARD.md) - generated release health, WMAE, coverage, and open-issue snapshot.
 - [docs/progress.md](docs/progress.md) - generated WMAE dashboard and trend charts.
 - [docs/data-sources.md](docs/data-sources.md) - source inventory and fixture-refresh status.
+- [docs/morocco-evidence.md](docs/morocco-evidence.md) - Morocco public-claim boundaries and Habous/Mawaqit evidence.
 - [docs/city-geometry-audit.md](docs/city-geometry-audit.md) - build-time QA plan for reverse-geolocation bboxes.
 - [examples/agiftoftime/INTEGRATION.md](examples/agiftoftime/INTEGRATION.md) - app-side integration guide for [A Gift of Time](https://agiftoftime.app).
 - [docs/downstream-apps.md](docs/downstream-apps.md) - downstream app UX, QA, and release-handoff patterns.

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -111,6 +111,9 @@ for Morocco unless a caller explicitly passes a non-zero `elevation` or
 Habous/Mawaqit city tables; apps can still opt into observer-elevation horizon
 correction when a local mosque or use case requires it.
 
+For the public-claim boundary around this evidence, see
+[`docs/morocco-evidence.md`](morocco-evidence.md).
+
 Snapshot tooling:
 
 - [`scripts/fetch-habous-morocco-month.js`](../scripts/fetch-habous-morocco-month.js)

--- a/docs/morocco-evidence.md
+++ b/docs/morocco-evidence.md
@@ -1,0 +1,90 @@
+# Morocco Evidence Boundary
+
+Last refreshed: 2026-05-15
+
+This page defines what fajr can currently claim about Morocco and what remains
+post-launch calibration work. It exists so public replies to Moroccan testers
+are precise rather than overconfident.
+
+## Current Product Position
+
+fajr uses one canonical Morocco official-timetable default.
+
+- Method: Morocco 19/17 community calibration with +5 min Dhuhr and +5 min
+  Maghrib Path A buffers.
+- Elevation stance: official uniform city/region timetable by default.
+- Public API signal: `location.elevationSource === 'country-uniform-timetable'`
+  and `location.elevation === 0` unless the caller explicitly passes elevation.
+- Override path: users or mosques that intentionally follow observer-elevation
+  horizon correction can pass `elevation` / `override.elevation`.
+
+The old question "Habous vs Mawaqit stance?" is not a shipped public split.
+The evidence currently supports one Morocco stance, while preserving source
+evidence for future review.
+
+## What Is Strong Enough Today
+
+| Evidence | Scope | Result | Use |
+|---|---:|---|---|
+| Published v1.9.3 no-options path | Current package / npm / esm.sh | Morocco no longer auto-applies city-registry elevation by default. | Public tester sharing. |
+| Live Habous check on 2026-05-15 | 33 mapped cities, current-day official endpoint | Five prayer times within 3 min; Shuruq within 10 min source sanity. | Release evidence for v1.9.3. |
+| Official Habous monthly holdout fixture | 33 cities x 30 days = 990 dated rows | Five-prayer MAE 0.74 min, max abs 3 min; Sunrise MAE 4.41 min and max 8 min, tracked separately. | CI regression signal, not train ratchet. |
+| Habous monthly source snapshot | `fixtures/habous-morocco/monthly/2026-04-19_to_2026-05-18.json` | Official source artifact archived outside `eval/data/`. | Source evidence for future promotion. |
+| Habous vs Mawaqit empirical diff | 31 cities x 30 days matched; 5,760 prayer cells | Five-prayer WMAE excluding Sunrise 0.576 min; collapse recommendation. | Supports one canonical Morocco stance. |
+| Multi-season Habous recovery | 150 valid historical day-rows across winter/summer samples | Fajr/Maghrib/Isha mean abs bias each under 1 min; winter Casablanca Fajr exact. | Seasonal sanity, not dense enough for a new calibration. |
+| Mawaqit Morocco yearly corpus | 42 mosques x 366 days before filtering | Dhuhr mean bias -0.15 min; Maghrib mean bias +0.76 min; outliers are source/mosque-quality leads. | Seasonal diagnostic and source-quality work. |
+
+## What This Allows Us To Say
+
+For targeted public testing:
+
+> fajr v1.9.3 follows Morocco's official Habous/Mawaqit city-region timetable
+> stance by default. Please compare against your local Habous city or mosque
+> table and report the city, date, and prayer if it differs.
+
+For app UI:
+
+> Morocco official timetable calibration. Verify the mapped city if your local
+> mosque follows a different Habous region. Use explicit elevation only when
+> your mosque intentionally follows observer-elevation correction.
+
+Do not say:
+
+- "fajr exactly reproduces every Morocco mosque."
+- "Habous and Mawaqit are separate selectable calculations."
+- "Shuruq is a strict Morocco calibration target."
+- "Elevation is missing for Morocco." The `country-uniform-timetable` source is
+  intentional.
+
+## What Remains Open
+
+| Track | Status | Why it stays open |
+|---|---|---|
+| #92 Habous fixture promotion | Open | The archived monthly source snapshot is source evidence. Promoting future months into `eval/data/test` needs curated review. |
+| #103 rigorous calibration | Open | The existing evidence supports the current stance, but not a new Morocco calculation change. More non-overlapping months should accumulate before tuning. |
+| Ramadan DST / GMT+0 handling | Separate engineering concern | Historical Wayback analysis surfaced a Ramadan clock-policy artifact. It should be investigated separately from the Habous-vs-Mawaqit stance question. |
+| Per-mosque outliers | Open source-quality work | Zagora, Sidi Kacem, Errachidia, Fquih Ben Salah, and Guelmim need mosque/source review before any per-city rule. |
+
+## Decision
+
+For the current public-release path, #92 and #103 are post-launch calibration
+tracks, not blockers.
+
+The blocker would re-open only if a fresh Morocco tester report gives a
+specific city/date/prayer mismatch that exceeds the current envelope:
+
+- five prayer times: more than 3 minutes from the official Habous city table;
+- Shuruq: more than 10 minutes from the official table;
+- wrong city/region mapping;
+- `location.elevationSource` not equal to `country-uniform-timetable` on a
+  default Morocco call.
+
+## Source Files
+
+- [docs/positions.md](positions.md)
+- [docs/data-sources.md](data-sources.md)
+- [docs/known-disagreements.md](known-disagreements.md)
+- [fixtures/habous-morocco/README.md](../fixtures/habous-morocco/README.md)
+- [eval/data/test/morocco-habous-monthly.json](../eval/data/test/morocco-habous-monthly.json)
+- [autoresearch/proposals/2026-05-05-habous-vs-mawaqit-empirical-diff.md](../autoresearch/proposals/2026-05-05-habous-vs-mawaqit-empirical-diff.md)
+- [autoresearch/proposals/2026-05-05-habous-multi-season-verification.md](../autoresearch/proposals/2026-05-05-habous-multi-season-verification.md)

--- a/docs/positions.md
+++ b/docs/positions.md
@@ -160,6 +160,7 @@ exists. A stronger position needs at least one of:
 - [Promotion log](promotion-log.md) — audit trail for confidence-grade changes
 - [CALIBRATION.md](../CALIBRATION.md)
 - [Data sources](data-sources.md)
+- [Morocco evidence boundary](morocco-evidence.md)
 - [Elevation correction](../knowledge/wiki/corrections/elevation.md)
 - [A Gift of Time integration guide](../examples/agiftoftime/INTEGRATION.md)
 

--- a/docs/public-launch-bar.md
+++ b/docs/public-launch-bar.md
@@ -30,6 +30,7 @@ distribution shape, and open tracking issues should tell the same story.
 | Morocco default | v1.9.3 follows the official uniform city/region timetable stance: country default elevation is `0`, `elevationSource` is `country-uniform-timetable`, and automatic observer-elevation correction is off unless explicit. | Met |
 | Downstream app | agiftoftime PR #53 merged; app is bumped to fajr v1.9.3 and issue #52 is closed after downstream compatibility validation. | Met |
 | Architecture framing | README now separates shipped Layer 1 / Layer 4 / settings surfaces from Layer 2/3/5 research tracks. | Met |
+| Morocco evidence boundary | `docs/morocco-evidence.md` defines what can be claimed now and keeps #92/#103 as post-launch calibration tracks. | Met |
 
 ## Public-Launch Blockers
 
@@ -37,7 +38,6 @@ These are the items that should close before a broad social announcement.
 
 | Blocker | Why it matters | Tracking |
 |---|---|---|
-| Morocco fixture promotion decision | Morocco is strong enough for tester sharing, but the public accuracy claim should say exactly which Habous/Mawaqit evidence is train, holdout, monthly, or yearly. | #92, #103 |
 | Open-issue triage | Advisory issues can stay open, but each should have a current owner/next action or a clear deferral note. | SCOREBOARD open issue list |
 
 ## Non-Blockers
@@ -51,6 +51,7 @@ new critical regression appears.
 | UMD/IIFE bundle | npm ESM and esm.sh already cover the validated public/tester path. A single-file bundle remains useful for standalone-script and JavaScriptCore consumers, but should ship as a package-shape PR with maintainer review, not as a launch-path surprise. |
 | GitHub Packages dual-publish | npm remains the source of truth for the public JS package. |
 | Research leads such as London, Egypt, and Diyanet Asr | They are known accuracy opportunities, not regressions in the current shipped contract. |
+| Morocco multi-season fixture promotion | #92/#103 remain important calibration work, but the evidence boundary is now documented and the current public API matches the official uniform city/region timetable stance. |
 | Knowledgebase cleanup pages | Important for contributor sanity, but not a runtime risk unless they contradict shipped behavior. |
 | Full global bbox audit | Geometry-backed QA is valuable; it becomes a blocker only when it finds a high-risk misroute affecting real users. |
 
@@ -87,9 +88,7 @@ For now, fajr is in targeted tester share.
 
 ## Next Actions
 
-1. Convert #92/#103 into either a promoted Morocco fixture tier or a documented
-   post-launch calibration project with exact evidence boundaries.
-2. Add current deferral/owner notes to the remaining advisory issues so the
+1. Add current deferral/owner notes to the remaining advisory issues so the
    tracker reads as managed, not abandoned.
-3. Keep #46 on the distribution roadmap, but do not block the public Morocco
+2. Keep #46 on the distribution roadmap, but do not block the public Morocco
    tester path on UMD/IIFE.


### PR DESCRIPTION
## Summary

- Adds `docs/morocco-evidence.md` to define exactly what fajr can currently claim about Morocco and what remains post-launch calibration work.
- Links the evidence-boundary doc from README, data-sources, positions, and the public-launch bar.
- Moves #92/#103 out of the public-launch blocker list by documenting them as post-launch corpus/calibration tracks unless a fresh tester report exceeds the current envelope.

## Evidence captured in the doc

- v1.9.3 public default uses `country-uniform-timetable` / elevation 0 for Morocco.
- Live 2026-05-15 Habous check: 33 mapped cities, five prayer times within 3 min, Shuruq within 10 min source sanity.
- Official Habous monthly fixture: 33 cities x 30 days = 990 rows; five-prayer MAE 0.74 min, max abs 3 min; Sunrise tracked separately.
- Habous-vs-Mawaqit empirical diff and multi-season recovery support one canonical Morocco stance, while leaving #92/#103 open for more months and source-quality work.

## Validation

```bash
git diff --check
```

Docs only; no runtime behavior, fixtures, eval ratchet, package version, or API surface changed.

[positions: no-change-required] Links a new Morocco evidence-boundary doc from positions, but does not change Morocco's A-grade row or default.
[known-disagreements: no-change-required] No fiqh or institutional-disagreement position changed.

— fajr-codex
