### PR TITLE
data(egypt): recover ESA daily snapshots

### DIFF
--- a/.github/workflows/egypt-esa-snapshot.yml
+++ b/.github/workflows/egypt-esa-snapshot.yml
@@ -6,9 +6,9 @@
 # Egypt can promote C → B in the position registry organically.
 #
 # Same pattern as fajr-codex's habous-morocco-snapshot.yml workflow. Fires
-# daily; opens a review PR with the snapshot under fixtures/egypt-esa/
-# rather than writing eval/data/ directly. Promotion of a curated subset
-# into eval/data/test/ is a separate human review step.
+# daily and pushes new snapshots to a persistent review branch under
+# fixtures/egypt-esa/ rather than writing eval/data/ directly. Promotion of a
+# curated subset into eval/data/test/ is a separate human review step.
 #
 # ESA serves 77 Egyptian cities' current-day prayer times in a server-
 # rendered HTML table at https://www.esa.gov.eg/praytimes.aspx (the
@@ -95,10 +95,10 @@ jobs:
           # Re-create the empty holdout fixture from master if the move stripped
           # it. The curated holdout is updated by humans, not by this workflow.
           if ! git diff --quiet -- eval/data/test/egypt-esa.json; then
-            git checkout -- eval/data/test/egypt-esa.json
+            git restore -- eval/data/test/egypt-esa.json
           fi
 
-      - name: Open snapshot PR
+      - name: Update snapshot review branch
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -112,12 +112,18 @@ jobs:
             exit 0
           fi
 
-          branch="automation/egypt-esa-${ESA_SNAPSHOT_DATE}"
+          branch="automation/egypt-esa-daily"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git switch -c "$branch"
-          git add "$ESA_SNAPSHOT_PATH"
-          git commit -m "data(egypt): capture ESA daily snapshot ${ESA_SNAPSHOT_DATE}"
+
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            git fetch origin "$branch"
+            git restore --source="origin/$branch" -- fixtures/egypt-esa/daily || true
+          fi
+
+          git switch -C "$branch"
+          git add fixtures/egypt-esa/daily
+          git commit -m "data(egypt): capture ESA daily snapshots through ${ESA_SNAPSHOT_DATE}"
           git push --force-with-lease origin "$branch"
 
           existing="$(gh pr list --head "$branch" --json number --jq '.[0].number // empty')"
@@ -126,22 +132,4 @@ jobs:
             exit 0
           fi
 
-          cat > /tmp/esa-snapshot-pr-body.md <<EOF
-          Automated Egypt ESA daily snapshot.
-
-          - Source: Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)
-          - Date: ${ESA_SNAPSHOT_DATE}
-          - Cities: ${ESA_SNAPSHOT_CITIES} mapped Egyptian cities
-
-          [positions: no-change-required] daily capture under fixtures/egypt-esa/daily; does not touch eval/data/.
-
-          Promotion into eval/data/test/ remains a separate human review step (fajr#133 follow-up: multi-season accumulation needed for Egypt C → B promotion per docs/positions.md Promotion Criteria).
-          EOF
-
-          if ! gh pr create \
-            --base master \
-            --head "$branch" \
-            --title "data(egypt): capture ESA daily snapshot ${ESA_SNAPSHOT_DATE}" \
-            --body-file /tmp/esa-snapshot-pr-body.md; then
-            echo "::warning::Snapshot branch pushed, but GitHub Actions could not create the PR. Open it manually from https://github.com/${{ github.repository }}/pull/new/${branch}."
-          fi
+          echo "::warning::Snapshot branch pushed, but GitHub Actions cannot create pull requests in this repository. Open or reuse a manual PR from https://github.com/${{ github.repository }}/pull/new/${branch}."

--- a/fixtures/egypt-esa/README.md
+++ b/fixtures/egypt-esa/README.md
@@ -4,9 +4,10 @@ Source: Egyptian General Authority for Survey
 URL: https://www.esa.gov.eg/praytimes.aspx
 
 This directory accumulates daily institutional Imsakiyya captures from
-ESA for the 27 mapped major Egyptian cities. The capture workflow at
+ESA for the mapped major Egyptian cities. The capture workflow at
 `.github/workflows/egypt-esa-snapshot.yml` fires daily at 03:17 UTC
-(~05:17 Cairo) and opens a review PR per snapshot.
+(~05:17 Cairo) and pushes new captures to the persistent
+`automation/egypt-esa-daily` review branch.
 
 ## Daily files
 
@@ -24,7 +25,8 @@ confidence-grade promotion per `docs/positions.md` Promotion Criteria.
 
 ## Promotion rules
 
-1. Captures land here via the automated workflow.
+1. Captures land here via the automated workflow and are reviewed from
+   the persistent `automation/egypt-esa-daily` branch.
 2. After a meaningful accumulation period (≥2 months covering ≥2
    seasons), a human curator opens a separate PR to promote a curated
    subset into `eval/data/test/egypt-esa-yearly.json` (or

--- a/fixtures/egypt-esa/daily/2026-05-15.json
+++ b/fixtures/egypt-esa/daily/2026-05-15.json
@@ -1,0 +1,392 @@
+[
+  {
+    "city": "Alexandria",
+    "city_local": "الأسكندرية",
+    "country": "Egypt",
+    "latitude": 31.2001,
+    "longitude": 29.9187,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.765Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:23",
+        "sunrise": "06:04",
+        "dhuhr": "12:56",
+        "asr": "16:36",
+        "maghrib": "19:49",
+        "isha": "21:19"
+      }
+    ]
+  },
+  {
+    "city": "Tanta",
+    "city_local": "طنطا",
+    "country": "Egypt",
+    "latitude": 30.7865,
+    "longitude": 31.0004,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.765Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:21",
+        "sunrise": "06:01",
+        "dhuhr": "12:52",
+        "asr": "16:31",
+        "maghrib": "19:44",
+        "isha": "21:13"
+      }
+    ]
+  },
+  {
+    "city": "Mansoura",
+    "city_local": "المنصورة",
+    "country": "Egypt",
+    "latitude": 31.0364,
+    "longitude": 31.3807,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.765Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:18",
+        "sunrise": "05:59",
+        "dhuhr": "12:51",
+        "asr": "16:30",
+        "maghrib": "19:43",
+        "isha": "21:12"
+      }
+    ]
+  },
+  {
+    "city": "Zagazig",
+    "city_local": "الزقازيق",
+    "country": "Egypt",
+    "latitude": 30.5877,
+    "longitude": 31.5022,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.765Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:20",
+        "sunrise": "06:00",
+        "dhuhr": "12:50",
+        "asr": "16:28",
+        "maghrib": "19:42",
+        "isha": "21:10"
+      }
+    ]
+  },
+  {
+    "city": "Asyut",
+    "city_local": "أسيوط",
+    "country": "Egypt",
+    "latitude": 27.1809,
+    "longitude": 31.1837,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.765Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:32",
+        "sunrise": "06:07",
+        "dhuhr": "12:52",
+        "asr": "16:23",
+        "maghrib": "19:36",
+        "isha": "21:01"
+      }
+    ]
+  },
+  {
+    "city": "Sohag",
+    "city_local": "سوهاج",
+    "country": "Egypt",
+    "latitude": 26.5569,
+    "longitude": 31.6948,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.765Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:32",
+        "sunrise": "06:06",
+        "dhuhr": "12:50",
+        "asr": "16:19",
+        "maghrib": "19:33",
+        "isha": "20:57"
+      }
+    ]
+  },
+  {
+    "city": "Beni Suef",
+    "city_local": "بنى سويف",
+    "country": "Egypt",
+    "latitude": 29.0661,
+    "longitude": 31.0994,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.766Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:26",
+        "sunrise": "06:04",
+        "dhuhr": "12:52",
+        "asr": "16:27",
+        "maghrib": "19:40",
+        "isha": "21:07"
+      }
+    ]
+  },
+  {
+    "city": "Minya",
+    "city_local": "المنيا",
+    "country": "Egypt",
+    "latitude": 28.0871,
+    "longitude": 30.7618,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.766Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:31",
+        "sunrise": "06:07",
+        "dhuhr": "12:53",
+        "asr": "16:26",
+        "maghrib": "19:40",
+        "isha": "21:05"
+      }
+    ]
+  },
+  {
+    "city": "Qena",
+    "city_local": "قنا",
+    "country": "Egypt",
+    "latitude": 26.1551,
+    "longitude": 32.716,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.766Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:29",
+        "sunrise": "06:03",
+        "dhuhr": "12:46",
+        "asr": "16:14",
+        "maghrib": "19:28",
+        "isha": "20:52"
+      }
+    ]
+  },
+  {
+    "city": "Aswan",
+    "city_local": "أسوان",
+    "country": "Egypt",
+    "latitude": 24.0889,
+    "longitude": 32.8998,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.766Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:35",
+        "sunrise": "06:06",
+        "dhuhr": "12:45",
+        "asr": "16:08",
+        "maghrib": "19:24",
+        "isha": "20:45"
+      }
+    ]
+  },
+  {
+    "city": "Marsa Matruh",
+    "city_local": "مطروح",
+    "country": "Egypt",
+    "latitude": 31.3543,
+    "longitude": 27.2373,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.766Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:34",
+        "sunrise": "06:15",
+        "dhuhr": "13:07",
+        "asr": "16:47",
+        "maghrib": "20:00",
+        "isha": "21:30"
+      }
+    ]
+  },
+  {
+    "city": "Hurghada",
+    "city_local": "الغردقة",
+    "country": "Egypt",
+    "latitude": 27.2579,
+    "longitude": 33.8116,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.766Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:22",
+        "sunrise": "05:57",
+        "dhuhr": "12:41",
+        "asr": "16:12",
+        "maghrib": "19:26",
+        "isha": "20:50"
+      }
+    ]
+  },
+  {
+    "city": "Kharga Oasis",
+    "city_local": "الخارجة",
+    "country": "Egypt",
+    "latitude": 25.4513,
+    "longitude": 30.5429,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.766Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:41",
+        "sunrise": "06:14",
+        "dhuhr": "12:55",
+        "asr": "16:22",
+        "maghrib": "19:37",
+        "isha": "21:00"
+      }
+    ]
+  },
+  {
+    "city": "Ismailia",
+    "city_local": "الإسماعيلية",
+    "country": "Egypt",
+    "latitude": 30.5965,
+    "longitude": 32.2715,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.766Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:17",
+        "sunrise": "05:57",
+        "dhuhr": "12:47",
+        "asr": "16:25",
+        "maghrib": "19:39",
+        "isha": "21:07"
+      }
+    ]
+  },
+  {
+    "city": "Damietta",
+    "city_local": "دمياط",
+    "country": "Egypt",
+    "latitude": 31.4165,
+    "longitude": 31.8133,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-15T06:42:05.766Z",
+    "dates": [
+      {
+        "date": "2026-05-15",
+        "fajr": "04:15",
+        "sunrise": "05:57",
+        "dhuhr": "12:49",
+        "asr": "16:29",
+        "maghrib": "19:42",
+        "isha": "21:12"
+      }
+    ]
+  }
+]

--- a/fixtures/egypt-esa/daily/2026-05-16.json
+++ b/fixtures/egypt-esa/daily/2026-05-16.json
@@ -1,0 +1,392 @@
+[
+  {
+    "city": "Alexandria",
+    "city_local": "الأسكندرية",
+    "country": "Egypt",
+    "latitude": 31.2001,
+    "longitude": 29.9187,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.373Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:22",
+        "sunrise": "06:04",
+        "dhuhr": "12:57",
+        "asr": "16:36",
+        "maghrib": "19:50",
+        "isha": "21:19"
+      }
+    ]
+  },
+  {
+    "city": "Tanta",
+    "city_local": "طنطا",
+    "country": "Egypt",
+    "latitude": 30.7865,
+    "longitude": 31.0004,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:20",
+        "sunrise": "06:01",
+        "dhuhr": "12:52",
+        "asr": "16:31",
+        "maghrib": "19:45",
+        "isha": "21:14"
+      }
+    ]
+  },
+  {
+    "city": "Mansoura",
+    "city_local": "المنصورة",
+    "country": "Egypt",
+    "latitude": 31.0364,
+    "longitude": 31.3807,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:17",
+        "sunrise": "05:58",
+        "dhuhr": "12:51",
+        "asr": "16:30",
+        "maghrib": "19:44",
+        "isha": "21:13"
+      }
+    ]
+  },
+  {
+    "city": "Zagazig",
+    "city_local": "الزقازيق",
+    "country": "Egypt",
+    "latitude": 30.5877,
+    "longitude": 31.5022,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:19",
+        "sunrise": "05:59",
+        "dhuhr": "12:50",
+        "asr": "16:28",
+        "maghrib": "19:42",
+        "isha": "21:11"
+      }
+    ]
+  },
+  {
+    "city": "Asyut",
+    "city_local": "أسيوط",
+    "country": "Egypt",
+    "latitude": 27.1809,
+    "longitude": 31.1837,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:31",
+        "sunrise": "06:07",
+        "dhuhr": "12:52",
+        "asr": "16:23",
+        "maghrib": "19:37",
+        "isha": "21:02"
+      }
+    ]
+  },
+  {
+    "city": "Sohag",
+    "city_local": "سوهاج",
+    "country": "Egypt",
+    "latitude": 26.5569,
+    "longitude": 31.6948,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:31",
+        "sunrise": "06:06",
+        "dhuhr": "12:50",
+        "asr": "16:19",
+        "maghrib": "19:34",
+        "isha": "20:58"
+      }
+    ]
+  },
+  {
+    "city": "Beni Suef",
+    "city_local": "بنى سويف",
+    "country": "Egypt",
+    "latitude": 29.0661,
+    "longitude": 31.0994,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:25",
+        "sunrise": "06:03",
+        "dhuhr": "12:52",
+        "asr": "16:27",
+        "maghrib": "19:41",
+        "isha": "21:08"
+      }
+    ]
+  },
+  {
+    "city": "Minya",
+    "city_local": "المنيا",
+    "country": "Egypt",
+    "latitude": 28.0871,
+    "longitude": 30.7618,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:30",
+        "sunrise": "06:07",
+        "dhuhr": "12:53",
+        "asr": "16:26",
+        "maghrib": "19:40",
+        "isha": "21:06"
+      }
+    ]
+  },
+  {
+    "city": "Qena",
+    "city_local": "قنا",
+    "country": "Egypt",
+    "latitude": 26.1551,
+    "longitude": 32.716,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:28",
+        "sunrise": "06:02",
+        "dhuhr": "12:46",
+        "asr": "16:14",
+        "maghrib": "19:29",
+        "isha": "20:53"
+      }
+    ]
+  },
+  {
+    "city": "Aswan",
+    "city_local": "أسوان",
+    "country": "Egypt",
+    "latitude": 24.0889,
+    "longitude": 32.8998,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:34",
+        "sunrise": "06:05",
+        "dhuhr": "12:45",
+        "asr": "16:08",
+        "maghrib": "19:24",
+        "isha": "20:46"
+      }
+    ]
+  },
+  {
+    "city": "Marsa Matruh",
+    "city_local": "مطروح",
+    "country": "Egypt",
+    "latitude": 31.3543,
+    "longitude": 27.2373,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:33",
+        "sunrise": "06:14",
+        "dhuhr": "13:07",
+        "asr": "16:47",
+        "maghrib": "20:01",
+        "isha": "21:31"
+      }
+    ]
+  },
+  {
+    "city": "Hurghada",
+    "city_local": "الغردقة",
+    "country": "Egypt",
+    "latitude": 27.2579,
+    "longitude": 33.8116,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:21",
+        "sunrise": "05:56",
+        "dhuhr": "12:41",
+        "asr": "16:12",
+        "maghrib": "19:26",
+        "isha": "20:51"
+      }
+    ]
+  },
+  {
+    "city": "Kharga Oasis",
+    "city_local": "الخارجة",
+    "country": "Egypt",
+    "latitude": 25.4513,
+    "longitude": 30.5429,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:40",
+        "sunrise": "06:13",
+        "dhuhr": "12:55",
+        "asr": "16:22",
+        "maghrib": "19:38",
+        "isha": "21:00"
+      }
+    ]
+  },
+  {
+    "city": "Ismailia",
+    "city_local": "الإسماعيلية",
+    "country": "Egypt",
+    "latitude": 30.5965,
+    "longitude": 32.2715,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:16",
+        "sunrise": "05:56",
+        "dhuhr": "12:47",
+        "asr": "16:25",
+        "maghrib": "19:39",
+        "isha": "21:08"
+      }
+    ]
+  },
+  {
+    "city": "Damietta",
+    "city_local": "دمياط",
+    "country": "Egypt",
+    "latitude": 31.4165,
+    "longitude": 31.8133,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-16T06:07:17.374Z",
+    "dates": [
+      {
+        "date": "2026-05-16",
+        "fajr": "04:14",
+        "sunrise": "05:56",
+        "dhuhr": "12:49",
+        "asr": "16:29",
+        "maghrib": "19:43",
+        "isha": "21:13"
+      }
+    ]
+  }
+]

--- a/fixtures/egypt-esa/daily/2026-05-17.json
+++ b/fixtures/egypt-esa/daily/2026-05-17.json
@@ -1,0 +1,392 @@
+[
+  {
+    "city": "Alexandria",
+    "city_local": "الأسكندرية",
+    "country": "Egypt",
+    "latitude": 31.2001,
+    "longitude": 29.9187,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:22",
+        "sunrise": "06:03",
+        "dhuhr": "12:57",
+        "asr": "16:36",
+        "maghrib": "19:50",
+        "isha": "21:20"
+      }
+    ]
+  },
+  {
+    "city": "Tanta",
+    "city_local": "طنطا",
+    "country": "Egypt",
+    "latitude": 30.7865,
+    "longitude": 31.0004,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:19",
+        "sunrise": "06:00",
+        "dhuhr": "12:52",
+        "asr": "16:31",
+        "maghrib": "19:45",
+        "isha": "21:15"
+      }
+    ]
+  },
+  {
+    "city": "Mansoura",
+    "city_local": "المنصورة",
+    "country": "Egypt",
+    "latitude": 31.0364,
+    "longitude": 31.3807,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:17",
+        "sunrise": "05:58",
+        "dhuhr": "12:51",
+        "asr": "16:30",
+        "maghrib": "19:44",
+        "isha": "21:14"
+      }
+    ]
+  },
+  {
+    "city": "Zagazig",
+    "city_local": "الزقازيق",
+    "country": "Egypt",
+    "latitude": 30.5877,
+    "longitude": 31.5022,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:18",
+        "sunrise": "05:58",
+        "dhuhr": "12:50",
+        "asr": "16:28",
+        "maghrib": "19:43",
+        "isha": "21:12"
+      }
+    ]
+  },
+  {
+    "city": "Asyut",
+    "city_local": "أسيوط",
+    "country": "Egypt",
+    "latitude": 27.1809,
+    "longitude": 31.1837,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:31",
+        "sunrise": "06:06",
+        "dhuhr": "12:52",
+        "asr": "16:22",
+        "maghrib": "19:38",
+        "isha": "21:02"
+      }
+    ]
+  },
+  {
+    "city": "Sohag",
+    "city_local": "سوهاج",
+    "country": "Egypt",
+    "latitude": 26.5569,
+    "longitude": 31.6948,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:31",
+        "sunrise": "06:05",
+        "dhuhr": "12:50",
+        "asr": "16:19",
+        "maghrib": "19:34",
+        "isha": "20:58"
+      }
+    ]
+  },
+  {
+    "city": "Beni Suef",
+    "city_local": "بنى سويف",
+    "country": "Egypt",
+    "latitude": 29.0661,
+    "longitude": 31.0994,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:25",
+        "sunrise": "06:03",
+        "dhuhr": "12:52",
+        "asr": "16:27",
+        "maghrib": "19:42",
+        "isha": "21:09"
+      }
+    ]
+  },
+  {
+    "city": "Minya",
+    "city_local": "المنيا",
+    "country": "Egypt",
+    "latitude": 28.0871,
+    "longitude": 30.7618,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:29",
+        "sunrise": "06:06",
+        "dhuhr": "12:53",
+        "asr": "16:26",
+        "maghrib": "19:41",
+        "isha": "21:07"
+      }
+    ]
+  },
+  {
+    "city": "Qena",
+    "city_local": "قنا",
+    "country": "Egypt",
+    "latitude": 26.1551,
+    "longitude": 32.716,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:28",
+        "sunrise": "06:02",
+        "dhuhr": "12:46",
+        "asr": "16:14",
+        "maghrib": "19:30",
+        "isha": "20:53"
+      }
+    ]
+  },
+  {
+    "city": "Aswan",
+    "city_local": "أسوان",
+    "country": "Egypt",
+    "latitude": 24.0889,
+    "longitude": 32.8998,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:33",
+        "sunrise": "06:05",
+        "dhuhr": "12:45",
+        "asr": "16:08",
+        "maghrib": "19:25",
+        "isha": "20:46"
+      }
+    ]
+  },
+  {
+    "city": "Marsa Matruh",
+    "city_local": "مطروح",
+    "country": "Egypt",
+    "latitude": 31.3543,
+    "longitude": 27.2373,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.663Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:32",
+        "sunrise": "06:14",
+        "dhuhr": "13:07",
+        "asr": "16:47",
+        "maghrib": "20:01",
+        "isha": "21:32"
+      }
+    ]
+  },
+  {
+    "city": "Hurghada",
+    "city_local": "الغردقة",
+    "country": "Egypt",
+    "latitude": 27.2579,
+    "longitude": 33.8116,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.664Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:20",
+        "sunrise": "05:55",
+        "dhuhr": "12:41",
+        "asr": "16:12",
+        "maghrib": "19:27",
+        "isha": "20:52"
+      }
+    ]
+  },
+  {
+    "city": "Kharga Oasis",
+    "city_local": "الخارجة",
+    "country": "Egypt",
+    "latitude": 25.4513,
+    "longitude": 30.5429,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.664Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:40",
+        "sunrise": "06:13",
+        "dhuhr": "12:55",
+        "asr": "16:22",
+        "maghrib": "19:38",
+        "isha": "21:01"
+      }
+    ]
+  },
+  {
+    "city": "Ismailia",
+    "city_local": "الإسماعيلية",
+    "country": "Egypt",
+    "latitude": 30.5965,
+    "longitude": 32.2715,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.664Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:15",
+        "sunrise": "05:55",
+        "dhuhr": "12:47",
+        "asr": "16:25",
+        "maghrib": "19:40",
+        "isha": "21:09"
+      }
+    ]
+  },
+  {
+    "city": "Damietta",
+    "city_local": "دمياط",
+    "country": "Egypt",
+    "latitude": 31.4165,
+    "longitude": 31.8133,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-17T06:30:13.664Z",
+    "dates": [
+      {
+        "date": "2026-05-17",
+        "fajr": "04:13",
+        "sunrise": "05:55",
+        "dhuhr": "12:49",
+        "asr": "16:29",
+        "maghrib": "19:43",
+        "isha": "21:14"
+      }
+    ]
+  }
+]

--- a/fixtures/egypt-esa/daily/2026-05-18.json
+++ b/fixtures/egypt-esa/daily/2026-05-18.json
@@ -1,0 +1,392 @@
+[
+  {
+    "city": "Alexandria",
+    "city_local": "الأسكندرية",
+    "country": "Egypt",
+    "latitude": 31.2001,
+    "longitude": 29.9187,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:21",
+        "sunrise": "06:03",
+        "dhuhr": "12:57",
+        "asr": "16:36",
+        "maghrib": "19:51",
+        "isha": "21:21"
+      }
+    ]
+  },
+  {
+    "city": "Tanta",
+    "city_local": "طنطا",
+    "country": "Egypt",
+    "latitude": 30.7865,
+    "longitude": 31.0004,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:18",
+        "sunrise": "05:59",
+        "dhuhr": "12:52",
+        "asr": "16:31",
+        "maghrib": "19:46",
+        "isha": "21:16"
+      }
+    ]
+  },
+  {
+    "city": "Mansoura",
+    "city_local": "المنصورة",
+    "country": "Egypt",
+    "latitude": 31.0364,
+    "longitude": 31.3807,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:16",
+        "sunrise": "05:57",
+        "dhuhr": "12:51",
+        "asr": "16:30",
+        "maghrib": "19:45",
+        "isha": "21:15"
+      }
+    ]
+  },
+  {
+    "city": "Zagazig",
+    "city_local": "الزقازيق",
+    "country": "Egypt",
+    "latitude": 30.5877,
+    "longitude": 31.5022,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:17",
+        "sunrise": "05:58",
+        "dhuhr": "12:50",
+        "asr": "16:28",
+        "maghrib": "19:43",
+        "isha": "21:13"
+      }
+    ]
+  },
+  {
+    "city": "Asyut",
+    "city_local": "أسيوط",
+    "country": "Egypt",
+    "latitude": 27.1809,
+    "longitude": 31.1837,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:30",
+        "sunrise": "06:06",
+        "dhuhr": "12:52",
+        "asr": "16:22",
+        "maghrib": "19:38",
+        "isha": "21:03"
+      }
+    ]
+  },
+  {
+    "city": "Sohag",
+    "city_local": "سوهاج",
+    "country": "Egypt",
+    "latitude": 26.5569,
+    "longitude": 31.6948,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:30",
+        "sunrise": "06:05",
+        "dhuhr": "12:50",
+        "asr": "16:19",
+        "maghrib": "19:35",
+        "isha": "20:59"
+      }
+    ]
+  },
+  {
+    "city": "Beni Suef",
+    "city_local": "بنى سويف",
+    "country": "Egypt",
+    "latitude": 29.0661,
+    "longitude": 31.0994,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:24",
+        "sunrise": "06:02",
+        "dhuhr": "12:52",
+        "asr": "16:27",
+        "maghrib": "19:42",
+        "isha": "21:10"
+      }
+    ]
+  },
+  {
+    "city": "Minya",
+    "city_local": "المنيا",
+    "country": "Egypt",
+    "latitude": 28.0871,
+    "longitude": 30.7618,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:29",
+        "sunrise": "06:06",
+        "dhuhr": "12:53",
+        "asr": "16:26",
+        "maghrib": "19:42",
+        "isha": "21:08"
+      }
+    ]
+  },
+  {
+    "city": "Qena",
+    "city_local": "قنا",
+    "country": "Egypt",
+    "latitude": 26.1551,
+    "longitude": 32.716,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:27",
+        "sunrise": "06:01",
+        "dhuhr": "12:46",
+        "asr": "16:14",
+        "maghrib": "19:30",
+        "isha": "20:54"
+      }
+    ]
+  },
+  {
+    "city": "Aswan",
+    "city_local": "أسوان",
+    "country": "Egypt",
+    "latitude": 24.0889,
+    "longitude": 32.8998,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:33",
+        "sunrise": "06:05",
+        "dhuhr": "12:45",
+        "asr": "16:08",
+        "maghrib": "19:25",
+        "isha": "20:47"
+      }
+    ]
+  },
+  {
+    "city": "Marsa Matruh",
+    "city_local": "مطروح",
+    "country": "Egypt",
+    "latitude": 31.3543,
+    "longitude": 27.2373,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:31",
+        "sunrise": "06:13",
+        "dhuhr": "13:07",
+        "asr": "16:47",
+        "maghrib": "20:02",
+        "isha": "21:33"
+      }
+    ]
+  },
+  {
+    "city": "Hurghada",
+    "city_local": "الغردقة",
+    "country": "Egypt",
+    "latitude": 27.2579,
+    "longitude": 33.8116,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:19",
+        "sunrise": "05:55",
+        "dhuhr": "12:41",
+        "asr": "16:12",
+        "maghrib": "19:27",
+        "isha": "20:53"
+      }
+    ]
+  },
+  {
+    "city": "Kharga Oasis",
+    "city_local": "الخارجة",
+    "country": "Egypt",
+    "latitude": 25.4513,
+    "longitude": 30.5429,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:39",
+        "sunrise": "06:12",
+        "dhuhr": "12:55",
+        "asr": "16:22",
+        "maghrib": "19:39",
+        "isha": "21:02"
+      }
+    ]
+  },
+  {
+    "city": "Ismailia",
+    "city_local": "الإسماعيلية",
+    "country": "Egypt",
+    "latitude": 30.5965,
+    "longitude": 32.2715,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:14",
+        "sunrise": "05:55",
+        "dhuhr": "12:47",
+        "asr": "16:25",
+        "maghrib": "19:40",
+        "isha": "21:10"
+      }
+    ]
+  },
+  {
+    "city": "Damietta",
+    "city_local": "دمياط",
+    "country": "Egypt",
+    "latitude": 31.4165,
+    "longitude": 31.8133,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-18T07:05:40.892Z",
+    "dates": [
+      {
+        "date": "2026-05-18",
+        "fajr": "04:13",
+        "sunrise": "05:55",
+        "dhuhr": "12:49",
+        "asr": "16:29",
+        "maghrib": "19:44",
+        "isha": "21:15"
+      }
+    ]
+  }
+]

--- a/fixtures/egypt-esa/daily/2026-05-19.json
+++ b/fixtures/egypt-esa/daily/2026-05-19.json
@@ -1,0 +1,392 @@
+[
+  {
+    "city": "Alexandria",
+    "city_local": "الأسكندرية",
+    "country": "Egypt",
+    "latitude": 31.2001,
+    "longitude": 29.9187,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.022Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:20",
+        "sunrise": "06:02",
+        "dhuhr": "12:57",
+        "asr": "16:36",
+        "maghrib": "19:52",
+        "isha": "21:22"
+      }
+    ]
+  },
+  {
+    "city": "Tanta",
+    "city_local": "طنطا",
+    "country": "Egypt",
+    "latitude": 30.7865,
+    "longitude": 31.0004,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:17",
+        "sunrise": "05:59",
+        "dhuhr": "12:53",
+        "asr": "16:31",
+        "maghrib": "19:47",
+        "isha": "21:17"
+      }
+    ]
+  },
+  {
+    "city": "Mansoura",
+    "city_local": "المنصورة",
+    "country": "Egypt",
+    "latitude": 31.0364,
+    "longitude": 31.3807,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:15",
+        "sunrise": "05:57",
+        "dhuhr": "12:51",
+        "asr": "16:30",
+        "maghrib": "19:46",
+        "isha": "21:16"
+      }
+    ]
+  },
+  {
+    "city": "Zagazig",
+    "city_local": "الزقازيق",
+    "country": "Egypt",
+    "latitude": 30.5877,
+    "longitude": 31.5022,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:16",
+        "sunrise": "05:57",
+        "dhuhr": "12:50",
+        "asr": "16:28",
+        "maghrib": "19:44",
+        "isha": "21:14"
+      }
+    ]
+  },
+  {
+    "city": "Asyut",
+    "city_local": "أسيوط",
+    "country": "Egypt",
+    "latitude": 27.1809,
+    "longitude": 31.1837,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:29",
+        "sunrise": "06:05",
+        "dhuhr": "12:52",
+        "asr": "16:22",
+        "maghrib": "19:39",
+        "isha": "21:04"
+      }
+    ]
+  },
+  {
+    "city": "Sohag",
+    "city_local": "سوهاج",
+    "country": "Egypt",
+    "latitude": 26.5569,
+    "longitude": 31.6948,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:29",
+        "sunrise": "06:04",
+        "dhuhr": "12:50",
+        "asr": "16:19",
+        "maghrib": "19:35",
+        "isha": "21:00"
+      }
+    ]
+  },
+  {
+    "city": "Beni Suef",
+    "city_local": "بنى سويف",
+    "country": "Egypt",
+    "latitude": 29.0661,
+    "longitude": 31.0994,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:23",
+        "sunrise": "06:02",
+        "dhuhr": "12:52",
+        "asr": "16:27",
+        "maghrib": "19:43",
+        "isha": "21:10"
+      }
+    ]
+  },
+  {
+    "city": "Minya",
+    "city_local": "المنيا",
+    "country": "Egypt",
+    "latitude": 28.0871,
+    "longitude": 30.7618,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:28",
+        "sunrise": "06:05",
+        "dhuhr": "12:53",
+        "asr": "16:26",
+        "maghrib": "19:42",
+        "isha": "21:08"
+      }
+    ]
+  },
+  {
+    "city": "Qena",
+    "city_local": "قنا",
+    "country": "Egypt",
+    "latitude": 26.1551,
+    "longitude": 32.716,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:26",
+        "sunrise": "06:01",
+        "dhuhr": "12:46",
+        "asr": "16:14",
+        "maghrib": "19:31",
+        "isha": "20:55"
+      }
+    ]
+  },
+  {
+    "city": "Aswan",
+    "city_local": "أسوان",
+    "country": "Egypt",
+    "latitude": 24.0889,
+    "longitude": 32.8998,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:32",
+        "sunrise": "06:04",
+        "dhuhr": "12:45",
+        "asr": "16:08",
+        "maghrib": "19:26",
+        "isha": "20:48"
+      }
+    ]
+  },
+  {
+    "city": "Marsa Matruh",
+    "city_local": "مطروح",
+    "country": "Egypt",
+    "latitude": 31.3543,
+    "longitude": 27.2373,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:30",
+        "sunrise": "06:13",
+        "dhuhr": "13:07",
+        "asr": "16:47",
+        "maghrib": "20:03",
+        "isha": "21:34"
+      }
+    ]
+  },
+  {
+    "city": "Hurghada",
+    "city_local": "الغردقة",
+    "country": "Egypt",
+    "latitude": 27.2579,
+    "longitude": 33.8116,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:19",
+        "sunrise": "05:55",
+        "dhuhr": "12:41",
+        "asr": "16:12",
+        "maghrib": "19:28",
+        "isha": "20:53"
+      }
+    ]
+  },
+  {
+    "city": "Kharga Oasis",
+    "city_local": "الخارجة",
+    "country": "Egypt",
+    "latitude": 25.4513,
+    "longitude": 30.5429,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:38",
+        "sunrise": "06:12",
+        "dhuhr": "12:55",
+        "asr": "16:22",
+        "maghrib": "19:39",
+        "isha": "21:02"
+      }
+    ]
+  },
+  {
+    "city": "Ismailia",
+    "city_local": "الإسماعيلية",
+    "country": "Egypt",
+    "latitude": 30.5965,
+    "longitude": 32.2715,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:13",
+        "sunrise": "05:54",
+        "dhuhr": "12:47",
+        "asr": "16:25",
+        "maghrib": "19:41",
+        "isha": "21:11"
+      }
+    ]
+  },
+  {
+    "city": "Damietta",
+    "city_local": "دمياط",
+    "country": "Egypt",
+    "latitude": 31.4165,
+    "longitude": 31.8133,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-19T06:56:40.023Z",
+    "dates": [
+      {
+        "date": "2026-05-19",
+        "fajr": "04:12",
+        "sunrise": "05:54",
+        "dhuhr": "12:49",
+        "asr": "16:29",
+        "maghrib": "19:45",
+        "isha": "21:16"
+      }
+    ]
+  }
+]

--- a/fixtures/egypt-esa/daily/2026-05-20.json
+++ b/fixtures/egypt-esa/daily/2026-05-20.json
@@ -1,0 +1,392 @@
+[
+  {
+    "city": "Alexandria",
+    "city_local": "الأسكندرية",
+    "country": "Egypt",
+    "latitude": 31.2001,
+    "longitude": 29.9187,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:19",
+        "sunrise": "06:01",
+        "dhuhr": "12:57",
+        "asr": "16:36",
+        "maghrib": "19:52",
+        "isha": "21:23"
+      }
+    ]
+  },
+  {
+    "city": "Tanta",
+    "city_local": "طنطا",
+    "country": "Egypt",
+    "latitude": 30.7865,
+    "longitude": 31.0004,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:16",
+        "sunrise": "05:58",
+        "dhuhr": "12:53",
+        "asr": "16:31",
+        "maghrib": "19:47",
+        "isha": "21:17"
+      }
+    ]
+  },
+  {
+    "city": "Mansoura",
+    "city_local": "المنصورة",
+    "country": "Egypt",
+    "latitude": 31.0364,
+    "longitude": 31.3807,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:14",
+        "sunrise": "05:56",
+        "dhuhr": "12:51",
+        "asr": "16:30",
+        "maghrib": "19:46",
+        "isha": "21:17"
+      }
+    ]
+  },
+  {
+    "city": "Zagazig",
+    "city_local": "الزقازيق",
+    "country": "Egypt",
+    "latitude": 30.5877,
+    "longitude": 31.5022,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:15",
+        "sunrise": "05:57",
+        "dhuhr": "12:51",
+        "asr": "16:28",
+        "maghrib": "19:45",
+        "isha": "21:15"
+      }
+    ]
+  },
+  {
+    "city": "Asyut",
+    "city_local": "أسيوط",
+    "country": "Egypt",
+    "latitude": 27.1809,
+    "longitude": 31.1837,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:28",
+        "sunrise": "06:05",
+        "dhuhr": "12:52",
+        "asr": "16:22",
+        "maghrib": "19:39",
+        "isha": "21:05"
+      }
+    ]
+  },
+  {
+    "city": "Sohag",
+    "city_local": "سوهاج",
+    "country": "Egypt",
+    "latitude": 26.5569,
+    "longitude": 31.6948,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:28",
+        "sunrise": "06:04",
+        "dhuhr": "12:50",
+        "asr": "16:19",
+        "maghrib": "19:36",
+        "isha": "21:01"
+      }
+    ]
+  },
+  {
+    "city": "Beni Suef",
+    "city_local": "بنى سويف",
+    "country": "Egypt",
+    "latitude": 29.0661,
+    "longitude": 31.0994,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:22",
+        "sunrise": "06:01",
+        "dhuhr": "12:52",
+        "asr": "16:27",
+        "maghrib": "19:43",
+        "isha": "21:11"
+      }
+    ]
+  },
+  {
+    "city": "Minya",
+    "city_local": "المنيا",
+    "country": "Egypt",
+    "latitude": 28.0871,
+    "longitude": 30.7618,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:27",
+        "sunrise": "06:05",
+        "dhuhr": "12:54",
+        "asr": "16:26",
+        "maghrib": "19:43",
+        "isha": "21:09"
+      }
+    ]
+  },
+  {
+    "city": "Qena",
+    "city_local": "قنا",
+    "country": "Egypt",
+    "latitude": 26.1551,
+    "longitude": 32.716,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:26",
+        "sunrise": "06:01",
+        "dhuhr": "12:46",
+        "asr": "16:14",
+        "maghrib": "19:31",
+        "isha": "20:55"
+      }
+    ]
+  },
+  {
+    "city": "Aswan",
+    "city_local": "أسوان",
+    "country": "Egypt",
+    "latitude": 24.0889,
+    "longitude": 32.8998,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:31",
+        "sunrise": "06:04",
+        "dhuhr": "12:45",
+        "asr": "16:08",
+        "maghrib": "19:26",
+        "isha": "20:48"
+      }
+    ]
+  },
+  {
+    "city": "Marsa Matruh",
+    "city_local": "مطروح",
+    "country": "Egypt",
+    "latitude": 31.3543,
+    "longitude": 27.2373,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.630Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:29",
+        "sunrise": "06:12",
+        "dhuhr": "13:08",
+        "asr": "16:47",
+        "maghrib": "20:03",
+        "isha": "21:35"
+      }
+    ]
+  },
+  {
+    "city": "Hurghada",
+    "city_local": "الغردقة",
+    "country": "Egypt",
+    "latitude": 27.2579,
+    "longitude": 33.8116,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.631Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:18",
+        "sunrise": "05:54",
+        "dhuhr": "12:41",
+        "asr": "16:12",
+        "maghrib": "19:29",
+        "isha": "20:54"
+      }
+    ]
+  },
+  {
+    "city": "Kharga Oasis",
+    "city_local": "الخارجة",
+    "country": "Egypt",
+    "latitude": 25.4513,
+    "longitude": 30.5429,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.631Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:38",
+        "sunrise": "06:12",
+        "dhuhr": "12:56",
+        "asr": "16:22",
+        "maghrib": "19:40",
+        "isha": "21:03"
+      }
+    ]
+  },
+  {
+    "city": "Ismailia",
+    "city_local": "الإسماعيلية",
+    "country": "Egypt",
+    "latitude": 30.5965,
+    "longitude": 32.2715,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.631Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:12",
+        "sunrise": "05:54",
+        "dhuhr": "12:48",
+        "asr": "16:25",
+        "maghrib": "19:42",
+        "isha": "21:12"
+      }
+    ]
+  },
+  {
+    "city": "Damietta",
+    "city_local": "دمياط",
+    "country": "Egypt",
+    "latitude": 31.4165,
+    "longitude": 31.8133,
+    "elevation": 0,
+    "timezone": "Africa/Cairo",
+    "method": "Egyptian (ESA — General Authority for Survey)",
+    "source": "Egyptian General Authority for Survey (esa.gov.eg/praytimes.aspx)",
+    "source_institution": "Egyptian General Authority for Survey (ESA)",
+    "source_method": "Egyptian (19.5°/17.5°) per ESA",
+    "source_url": "https://www.esa.gov.eg/praytimes.aspx",
+    "source_fetched": "2026-05-20T06:56:50.631Z",
+    "dates": [
+      {
+        "date": "2026-05-20",
+        "fajr": "04:11",
+        "sunrise": "05:54",
+        "dhuhr": "12:49",
+        "asr": "16:29",
+        "maghrib": "19:45",
+        "isha": "21:16"
+      }
+    ]
+  }
+]

--- a/test/egyptEsaSnapshots.test.js
+++ b/test/egyptEsaSnapshots.test.js
@@ -1,0 +1,70 @@
+// بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ
+// Bismillah ir-Rahman ir-Rahim
+/**
+ * Egypt ESA daily source-snapshot archive checks.
+ *
+ * These snapshots are source evidence under fixtures/, not ratchet fixtures
+ * under eval/data/. This test keeps the archive structurally reviewable before
+ * any later curated promotion into the holdout corpus.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const ROOT = path.resolve(import.meta.dirname, '..')
+const SNAPSHOT_DIR = path.join(ROOT, 'fixtures/egypt-esa/daily')
+const FILENAME_RE = /^(\d{4}-\d{2}-\d{2})\.json$/
+const HHMM_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+const PRAYERS = ['fajr', 'sunrise', 'dhuhr', 'asr', 'maghrib', 'isha']
+
+function readSnapshots() {
+  if (!existsSync(SNAPSHOT_DIR)) return []
+
+  return readdirSync(SNAPSHOT_DIR)
+    .filter(file => file.endsWith('.json'))
+    .sort()
+    .map(file => {
+      const match = file.match(FILENAME_RE)
+      if (!match) throw new Error(`Unexpected Egypt ESA snapshot filename: ${file}`)
+
+      return {
+        file,
+        date: match[1],
+        rows: JSON.parse(readFileSync(path.join(SNAPSHOT_DIR, file), 'utf8')),
+      }
+    })
+}
+
+describe('Egypt ESA daily source snapshots', () => {
+  it('keeps archived daily snapshots structurally reviewable', () => {
+    const snapshots = readSnapshots()
+    expect(snapshots.length).toBeGreaterThanOrEqual(1)
+
+    const expectedCities = snapshots[0].rows.map(row => row.city).sort()
+    expect(expectedCities.length, snapshots[0].file).toBeGreaterThanOrEqual(10)
+
+    for (const snapshot of snapshots) {
+      expect(Array.isArray(snapshot.rows), snapshot.file).toBe(true)
+      expect(snapshot.rows.map(row => row.city).sort(), snapshot.file).toEqual(expectedCities)
+
+      for (const fixture of snapshot.rows) {
+        expect(fixture.country, `${snapshot.file} ${fixture.city}`).toBe('Egypt')
+        expect(fixture.timezone, `${snapshot.file} ${fixture.city}`).toBe('Africa/Cairo')
+        expect(fixture.source_institution, `${snapshot.file} ${fixture.city}`)
+          .toBe('Egyptian General Authority for Survey (ESA)')
+        expect(fixture.source_method, `${snapshot.file} ${fixture.city}`)
+          .toMatch(/Egyptian/)
+        expect(fixture.source_url, `${snapshot.file} ${fixture.city}`)
+          .toBe('https://www.esa.gov.eg/praytimes.aspx')
+        expect(fixture.dates, `${snapshot.file} ${fixture.city}`).toHaveLength(1)
+
+        const row = fixture.dates[0]
+        expect(row.date, `${snapshot.file} ${fixture.city}`).toBe(snapshot.date)
+        for (const prayer of PRAYERS) {
+          expect(row[prayer], `${snapshot.file} ${fixture.city} ${prayer}`).toMatch(HHMM_RE)
+        }
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Recovers ESA daily source snapshots from orphaned automation branches for 2026-05-15 through 2026-05-20.
- Adds a structural test for `fixtures/egypt-esa/daily/*.json` so archived ESA snapshots stay reviewable.
- Updates the ESA snapshot workflow to use one persistent review branch because GitHub Actions can push branches here but cannot create pull requests.

## Verification
- jq empty fixtures/egypt-esa/daily/*.json
- npx vitest run test/egyptEsaSnapshots.test.js
- npm test (446/446)
- git diff --check
- node --check scripts/fetch-egypt-esa.js

## Notes
- No runtime prayer calculation behavior changed.
- No `eval/data/` changes are included; these remain source snapshots under `fixtures/` pending future curated promotion.