### PR TITLE
docs: refresh scoreboard after ESA test

### DIFF
--- a/SCOREBOARD.md
+++ b/SCOREBOARD.md
@@ -57,7 +57,7 @@
 
 ### Test corpus
 
-- Tests: **445/445 passing** ✅
+- Tests: **446/446 passing** ✅
 
 ---
 
@@ -75,7 +75,7 @@
 
 ## Trajectory verdict (rolling 30 days)
 
-**Rolling 30-day window (102 runs):**
+**Rolling 30-day window (101 runs):**
 - Train WMAE: 1.1667 → 0.9757 (-16.4%)
 - Direction: 📈 improving
 


### PR DESCRIPTION
## Summary
- Refreshes SCOREBOARD.md after PR #187 added the Egypt ESA snapshot archive test.
- Updates visible test corpus count from 445/445 to 446/446.

## Verification
- node scripts/build-scoreboard.js
- git diff --check
- npm test (446/446)

## Notes
- Docs-only generated scoreboard sync; no runtime or eval/data changes.